### PR TITLE
New requirement scope for all participating adults

### DIFF
--- a/src/CareTogether.Contracts/Resources/IPoliciesResource.cs
+++ b/src/CareTogether.Contracts/Resources/IPoliciesResource.cs
@@ -77,7 +77,7 @@ namespace CareTogether.Resources
     public sealed record VolunteerFamilyApprovalRequirement(
         RequirementStage Stage, string ActionName, VolunteerFamilyRequirementScope Scope);
 
-    public enum VolunteerFamilyRequirementScope { OncePerFamily, AllAdultsInTheFamily };
+    public enum VolunteerFamilyRequirementScope { OncePerFamily, AllAdultsInTheFamily, AllParticipatingAdultsInTheFamily };
 
 
     /// <summary>

--- a/src/CareTogether.Core/Engines/PolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluationEngine.cs
@@ -1,7 +1,5 @@
 using CareTogether.Managers;
 using CareTogether.Resources;
-using OneOf;
-using OneOf.Types;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -160,6 +158,13 @@ namespace CareTogether.Engines
                             VolunteerFamilyRequirementScope.AllAdultsInTheFamily => family.Adults.All(a =>
                             {
                                 var (person, familyRelationship) = a;
+                                return completedIndividualRequirements.TryGetValue(person.Id, out var completedRequirements)
+                                    && completedRequirements.Any(x => x.RequirementName == requirement.ActionName &&
+                                    (supersededAtUtc == null || x.CompletedAtUtc < supersededAtUtc));
+                            }),
+                            VolunteerFamilyRequirementScope.AllParticipatingAdultsInTheFamily => family.Adults.All(a =>
+                            {
+                                var (person, familyRelationship) = a;
                                 return (removedIndividualRoles.TryGetValue(person.Id, out var removedRoles)
                                         && removedRoles.Any(x => x.RoleName == roleName)) ||
                                     (completedIndividualRequirements.TryGetValue(person.Id, out var completedRequirements)
@@ -174,6 +179,13 @@ namespace CareTogether.Engines
                         }, RequirementMissingForIndividuals: requirement.Scope switch
                         {
                             VolunteerFamilyRequirementScope.AllAdultsInTheFamily => family.Adults.Where(a =>
+                            {
+                                var (person, familyRelationship) = a;
+                                return !completedIndividualRequirements.TryGetValue(person.Id, out var completedRequirements)
+                                    || !completedRequirements.Any(x => x.RequirementName == requirement.ActionName &&
+                                    (supersededAtUtc == null || x.CompletedAtUtc < supersededAtUtc));
+                            }).Select(a => a.Item1.Id).ToList(),
+                            VolunteerFamilyRequirementScope.AllParticipatingAdultsInTheFamily => family.Adults.Where(a =>
                             {
                                 var (person, familyRelationship) = a;
                                 return !(removedIndividualRoles.TryGetValue(person.Id, out var removedRoles)

--- a/src/caretogether-pwa/src/GeneratedClient.ts
+++ b/src/caretogether-pwa/src/GeneratedClient.ts
@@ -1725,6 +1725,7 @@ export interface IVolunteerFamilyApprovalRequirement {
 export enum VolunteerFamilyRequirementScope {
     OncePerFamily = 0,
     AllAdultsInTheFamily = 1,
+    AllParticipatingAdultsInTheFamily = 2,
 }
 
 export class CurrentFeatureFlags implements ICurrentFeatureFlags {

--- a/swagger.json
+++ b/swagger.json
@@ -1129,11 +1129,13 @@
         "description": "",
         "x-enumNames": [
           "OncePerFamily",
-          "AllAdultsInTheFamily"
+          "AllAdultsInTheFamily",
+          "AllParticipatingAdultsInTheFamily"
         ],
         "enum": [
           0,
-          1
+          1,
+          2
         ]
       },
       "CurrentFeatureFlags": {

--- a/test/CareTogether.TestData/TestDataProvider.cs
+++ b/test/CareTogether.TestData/TestDataProvider.cs
@@ -304,6 +304,8 @@ namespace CareTogether.TestData
                     ["Interview with Family Coach Supervisor"] = new ActionRequirement(DocumentLinkRequirement.Allowed, null, null),
                     ["Host Family Application"] = new ActionRequirement(DocumentLinkRequirement.Required,
                         null, new Uri("http://example.com/forms/app-hf")),
+                    ["Host Family Training"] = new ActionRequirement(DocumentLinkRequirement.None,
+                        null, new Uri("http://example.com/training/hf")),
                     ["Home Screening Checklist"] = new ActionRequirement(DocumentLinkRequirement.Required,
                         "Must be filled out by an approved home screener", new Uri("http://example.com/forms/hscheck")),
                     ["Host Family Interview"] = new ActionRequirement(DocumentLinkRequirement.Allowed, null, null),
@@ -468,6 +470,7 @@ namespace CareTogether.TestData
                             {
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Application, "Host Family Application", VolunteerFamilyRequirementScope.OncePerFamily),
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Approval, "Background Check", VolunteerFamilyRequirementScope.AllAdultsInTheFamily),
+                                new VolunteerFamilyApprovalRequirement(RequirementStage.Approval, "Host Family Training", VolunteerFamilyRequirementScope.AllParticipatingAdultsInTheFamily),
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Approval, "Home Screening Checklist", VolunteerFamilyRequirementScope.OncePerFamily),
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Approval, "Host Family Interview", VolunteerFamilyRequirementScope.OncePerFamily),
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Onboarding, "Meet & Greet", VolunteerFamilyRequirementScope.OncePerFamily)
@@ -476,6 +479,7 @@ namespace CareTogether.TestData
                             {
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Application, "Host Family Application", VolunteerFamilyRequirementScope.OncePerFamily),
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Approval, "Comprehensive Background Check", VolunteerFamilyRequirementScope.AllAdultsInTheFamily),
+                                new VolunteerFamilyApprovalRequirement(RequirementStage.Approval, "Host Family Training", VolunteerFamilyRequirementScope.AllParticipatingAdultsInTheFamily),
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Approval, "Home Screening Checklist", VolunteerFamilyRequirementScope.OncePerFamily),
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Approval, "Host Family Interview", VolunteerFamilyRequirementScope.OncePerFamily),
                                 new VolunteerFamilyApprovalRequirement(RequirementStage.Onboarding, "Meet & Greet", VolunteerFamilyRequirementScope.OncePerFamily)


### PR DESCRIPTION
This allows e.g. background checks to apply to all adults in a family but training to only apply to participating adults.