### PR TITLE
bug: Incorrect case sensitivity in volunteer families (approval & progress) search logic

### DIFF
--- a/src/caretogether-pwa/src/Components/Volunteers/VolunteerApproval.tsx
+++ b/src/caretogether-pwa/src/Components/Volunteers/VolunteerApproval.tsx
@@ -207,8 +207,8 @@ function VolunteerApproval(props: { onOpen: () => void }) {
   // Filter volunteer families by name and by applicable roles.
   const filteredVolunteerFamilies = volunteerFamilies.filter(family => (
       filterText.length === 0 ||
-      family.family?.adults?.some(adult => simplify(`${adult.item1?.firstName} ${adult.item1?.lastName}`).includes(filterText)) ||
-      family.family?.children?.some(child => simplify(`${child?.firstName} ${child?.lastName}`).includes(filterText))) && (
+      family.family?.adults?.some(adult => simplify(`${adult.item1?.firstName} ${adult.item1?.lastName}`).includes(filterText.toLowerCase())) ||
+      family.family?.children?.some(child => simplify(`${child?.firstName} ${child?.lastName}`).includes(filterText.toLowerCase()))) && (
       volunteerFamilyRoleFilters.every(roleFilter =>
         family.volunteerFamilyInfo?.familyRoleApprovals?.[roleFilter.roleName]?.some(approval =>
           roleFilter.selected.indexOf(approval.approvalStatus!) > -1) || roleFilter.selected.indexOf(null) > -1) &&

--- a/src/caretogether-pwa/src/Components/Volunteers/VolunteerProgress.tsx
+++ b/src/caretogether-pwa/src/Components/Volunteers/VolunteerProgress.tsx
@@ -59,8 +59,8 @@ function VolunteerProgress(props: { onOpen: () => void }) {
 
   const [filterText, setFilterText] = useState("");
   const filteredVolunteerFamilies = volunteerFamilies.filter(family => filterText.length === 0 ||
-    family.family?.adults?.some(adult => simplify(`${adult.item1?.firstName} ${adult.item1?.lastName}`).includes(filterText)) ||
-    family.family?.children?.some(child => simplify(`${child?.firstName} ${child?.lastName}`).includes(filterText)));
+    family.family?.adults?.some(adult => simplify(`${adult.item1?.firstName} ${adult.item1?.lastName}`).includes(filterText.toLowerCase())) ||
+    family.family?.children?.some(child => simplify(`${child?.firstName} ${child?.lastName}`).includes(filterText.toLowerCase())));
 
   useScrollMemory();
 


### PR DESCRIPTION
gh #449 - There were 4 instances wherein the search logic on both the volunteer family Approval and Progress screens is incorrectly sensitive to the case of the search text.
Hence, following changes were made in this PR - `filterText` -> `filterText.toLowerCase()`

Result: This makes searching, `case-insensitive` and hence `reduces bugs`