### PR TITLE
Handling the case where a note's author user ID doesn't match a person

### DIFF
--- a/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
@@ -461,7 +461,7 @@ namespace CareTogether.Engines.Authorization
             Guid familyId, Note note, Guid organizationId, Guid locationId)
         {
             var author = await directoryResource.FindUserAsync(organizationId, locationId, note.AuthorId);
-            return author.Id == user.PersonId(organizationId, locationId) ||
+            return author?.Id == user.PersonId(organizationId, locationId) ||
                 user.HasPermission(organizationId, locationId, Permission.ViewAllNotes);
         }
     }

--- a/src/CareTogether.Core/Resources/Directory/DirectoryResource.cs
+++ b/src/CareTogether.Core/Resources/Directory/DirectoryResource.cs
@@ -54,12 +54,12 @@ namespace CareTogether.Resources.Directory
             }
         }
 
-        public async Task<Person> FindUserAsync(Guid organizationId, Guid locationId, Guid userId)
+        public async Task<Person?> FindUserAsync(Guid organizationId, Guid locationId, Guid userId)
         {
             using (var lockedModel = await tenantModels.ReadLockItemAsync((organizationId, locationId)))
             {
                 var result = lockedModel.Value.FindPeople(p => p.UserId == userId);
-                return result.Single();
+                return result.SingleOrDefault();
                 //TODO: Handle the exception case where multiple people have the same user ID assigned, or
                 //      protect against that scenario in the domain model.
             }

--- a/src/CareTogether.Core/Resources/Directory/IDirectoryResource.cs
+++ b/src/CareTogether.Core/Resources/Directory/IDirectoryResource.cs
@@ -118,7 +118,7 @@ namespace CareTogether.Resources.Directory
     /// </summary>
     public interface IDirectoryResource
     {
-        Task<Person> FindUserAsync(Guid organizationId, Guid locationId, Guid userId);
+        Task<Person?> FindUserAsync(Guid organizationId, Guid locationId, Guid userId);
 
         Task<ImmutableList<Person>> ListPeopleAsync(Guid organizationId, Guid locationId);
 

--- a/test/CareTogether.Core.Test/DirectoryResourceTest.cs
+++ b/test/CareTogether.Core.Test/DirectoryResourceTest.cs
@@ -20,6 +20,7 @@ namespace CareTogether.Core.Test
         static readonly Guid guid4 = Id('4');
         static readonly Guid guid5 = Id('5');
         static readonly Guid guid6 = Id('6');
+        static readonly Guid guid7 = Id('7');
 
 #nullable disable
         MemoryEventLog<DirectoryEvent> events;
@@ -79,9 +80,11 @@ namespace CareTogether.Core.Test
 
             var user2 = await dut.FindUserAsync(guid1, guid2, guid3);
             var user1 = await dut.FindUserAsync(guid1, guid2, guid4);
+            var nonexistentUser = await dut.FindUserAsync(guid1, guid2, guid7);
 
-            Assert.AreEqual(guid2, user2.Id);
-            Assert.AreEqual(guid1, user1.Id);
+            Assert.AreEqual(guid2, user2!.Id);
+            Assert.AreEqual(guid1, user1!.Id);
+            Assert.IsNull(nonexistentUser);
         }
 
         [TestMethod]


### PR DESCRIPTION
Example: new administrator (defined via policy), who doesn't yet match a person created in the directory, is authoring notes.