### PR TITLE
Hotfix for several server errors

### DIFF
--- a/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralCalculations.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralCalculations.cs
@@ -324,10 +324,17 @@ namespace CareTogether.Engines.PolicyEvaluation
             // unless the arrangement has ended, in which case use the end of the arrangement).
             // This represents the set of gaps between completions in which there could be missing requirement due dates.
             // Prepend this list with an entry representing the start of the arrangement.
-            var completionGaps = completions.Select((completion, i) =>
-                (start: completion, end: i + 1 >= completions.Count
-                    ? (arrangementEndedAtUtc.HasValue ? arrangementEndedAtUtc.Value : DateTime.MaxValue)
-                    : completions[i + 1]))
+            // There is an edge case where the last completion occurs *after* the end of the arrangement;
+            // in this case, exclude that completion from the list of gaps.
+            var completionGaps = completions
+                .Where((completion, i) =>
+                    i + 1 >= completions.Count && arrangementEndedAtUtc.HasValue
+                        ? completion < arrangementEndedAtUtc.Value
+                        : true)
+                .Select((completion, i) =>
+                    (start: completion, end: i + 1 >= completions.Count
+                        ? (arrangementEndedAtUtc.HasValue ? arrangementEndedAtUtc.Value : DateTime.MaxValue)
+                        : completions[i + 1]))
                 .Prepend((start: arrangementStartedAtUtc, end: completions.Count > 0
                     ? completions[0]
                     : (arrangementEndedAtUtc.HasValue ? arrangementEndedAtUtc.Value : DateTime.MaxValue)))

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/Timeline.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/Timeline.cs
@@ -36,6 +36,9 @@ namespace CareTogether.Engines.PolicyEvaluation
             if (terminatingStages.Count == 0)
                 throw new ArgumentException("At least one timeline stage is required.");
 
+            if (terminatingStages.Any(stage => stage.End < stage.Start))
+                throw new ArgumentException("All timeline stages must have start dates before their end dates.");
+
             stages = terminatingStages
                 .Select(stage => new AbsoluteTimeSpan(stage.Start, stage.End))
                 .ToImmutableList();

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/Timeline.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/Timeline.cs
@@ -130,7 +130,11 @@ namespace CareTogether.Engines.PolicyEvaluation
                     End: subsetEnd < stage.End ? subsetEnd : stage.End))
                 .ToImmutableList();
 
-            return new Timeline(subsetStages);
+            // To protect against invalid timelines when the subset is empty,
+            // return a single-instant timeline starting at the requested start date.
+            return subsetStages.Count == 0
+                ? new Timeline(start, start)
+                : new Timeline(subsetStages);
         }
 
         public override bool Equals(object? obj)

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirementInstances.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirementInstances.cs
@@ -190,6 +190,22 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
         }
 
         [TestMethod]
+        public void TestEdgeCaseOneCompletionAfterEnded()
+        {
+            var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(
+                new DurationStagesRecurrencePolicy(ImmutableList<RecurrencePolicyStage>.Empty
+                .Add(new RecurrencePolicyStage(TimeSpan.FromDays(7), null))),
+                filterToFamilyId: null,
+                arrangementStartedAtUtc: new DateTime(2022, 1, 3),
+                arrangementEndedAtUtc: new DateTime(2022, 1, 8),
+                completions: Helpers.Dates((1, 9)),
+                childLocationHistory: Helpers.LocationHistoryEntries(),
+                utcNow: new DateTime(2022, 2, 1));
+
+            AssertEx.SequenceIs(result, Helpers.Dates());
+        }
+
+        [TestMethod]
         public void TestTwoCompletionsInFirstStage()
         {
             var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirementInstances.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirementInstances.cs
@@ -190,6 +190,22 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
         }
 
         [TestMethod]
+        public void TestEdgeCaseOneCompletionBeforeStarted()
+        {
+            var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(
+                new DurationStagesRecurrencePolicy(ImmutableList<RecurrencePolicyStage>.Empty
+                .Add(new RecurrencePolicyStage(TimeSpan.FromDays(7), null))),
+                filterToFamilyId: null,
+                arrangementStartedAtUtc: new DateTime(2022, 1, 7),
+                arrangementEndedAtUtc: new DateTime(2022, 1, 10),
+                completions: Helpers.Dates((1, 5)),
+                childLocationHistory: Helpers.LocationHistoryEntries(),
+                utcNow: new DateTime(2022, 2, 1));
+
+            AssertEx.SequenceIs(result, Helpers.Dates());
+        }
+
+        [TestMethod]
         public void TestEdgeCaseOneCompletionAfterEnded()
         {
             var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/TimelineTest.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/TimelineTest.cs
@@ -63,9 +63,9 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
             Assert.AreEqual(MMaxMax, dut.MapUnbounded(T(11), T(19)));
 
             Assert.AreEqual(TL((1, 1)), dut.Subset(D(1), D(5)));
-            Assert.ThrowsException<ArgumentException>(() => dut.Subset(D(6), D(15)));
+            Assert.AreEqual(TL((6, 6)), dut.Subset(D(6), D(15)));
             Assert.AreEqual(TL((1, 1)), dut.Subset(D(1), D(26)));
-            Assert.ThrowsException<ArgumentException>(() => dut.Subset(D(8), null));
+            Assert.AreEqual(TL((8, 8)), dut.Subset(D(8), null));
 
             Assert.IsNull(dut.TryMapFrom(D(7), T(3)));
             Assert.IsNull(dut.TryMapFrom(D(7), T(5)));


### PR DESCRIPTION
"Invalid" data entry in real-world usage is causing the code to hit some edge cases that generate exceptions. This PR prevents those exceptions from being thrown while preserving correct calculation results.