### PR TITLE
Change calculation for one time recurrence to consider the delay as 'full days'

### DIFF
--- a/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationEngine.cs
@@ -42,9 +42,13 @@ namespace CareTogether.Engines.PolicyEvaluation
             ReferralEntry referralEntry)
         {
             var policy = await policiesResource.GetCurrentPolicy(organizationId, locationId);
+            var config = await policiesResource.GetConfigurationAsync(organizationId);
+
+            var location = config.Locations.Find(item => item.Id == locationId);
+            TimeZoneInfo locationTimeZone = location?.timeZone ?? TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
 
             return ReferralCalculations.CalculateReferralStatus(
-                policy.ReferralPolicy, referralEntry, DateTime.UtcNow);
+                policy.ReferralPolicy, referralEntry, DateTime.UtcNow, locationTimeZone);
         }
     }
 }

--- a/src/CareTogether.Core/Resources/Policies/IPoliciesResource.cs
+++ b/src/CareTogether.Core/Resources/Policies/IPoliciesResource.cs
@@ -13,7 +13,7 @@ namespace CareTogether.Resources.Policies
     public sealed record LocationConfiguration(Guid Id, string Name,
         ImmutableList<string> Ethnicities, ImmutableList<string> AdultFamilyRelationships,
         ImmutableList<string>? ArrangementReasons,
-        ImmutableList<SourcePhoneNumberConfiguration> SmsSourcePhoneNumbers);
+        ImmutableList<SourcePhoneNumberConfiguration> SmsSourcePhoneNumbers, TimeZoneInfo? timeZone = null); 
 
     public sealed record SourcePhoneNumberConfiguration(string SourcePhoneNumber, string Description);
 

--- a/src/caretogether-pwa/src/GeneratedClient.ts
+++ b/src/caretogether-pwa/src/GeneratedClient.ts
@@ -906,10 +906,6 @@ export class MetadataClient {
         this.baseUrl = baseUrl ?? "";
     }
 
-    /**
-     * Generates the OData $metadata document.
-     * @return The IEdmModel representing $metadata.
-     */
     getMetadata(): Promise<IEdmModel> {
         let url_ = this.baseUrl + "/api/odata/live/$metadata";
         url_ = url_.replace(/[?&]$/, "");
@@ -944,10 +940,6 @@ export class MetadataClient {
         return Promise.resolve<IEdmModel>(null as any);
     }
 
-    /**
-     * Generates the OData service document.
-     * @return The service document for the service.
-     */
     getServiceDocument(): Promise<ODataServiceDocument> {
         let url_ = this.baseUrl + "/api/odata/live";
         url_ = url_.replace(/[?&]$/, "");
@@ -1201,6 +1193,7 @@ export class LocationConfiguration implements ILocationConfiguration {
     adultFamilyRelationships?: string[];
     arrangementReasons?: string[] | undefined;
     smsSourcePhoneNumbers?: SourcePhoneNumberConfiguration[];
+    timeZone?: TimeZoneInfo | undefined;
 
     constructor(data?: ILocationConfiguration) {
         if (data) {
@@ -1235,6 +1228,7 @@ export class LocationConfiguration implements ILocationConfiguration {
                 for (let item of _data["smsSourcePhoneNumbers"])
                     this.smsSourcePhoneNumbers!.push(SourcePhoneNumberConfiguration.fromJS(item));
             }
+            this.timeZone = _data["timeZone"] ? TimeZoneInfo.fromJS(_data["timeZone"]) : <any>undefined;
         }
     }
 
@@ -1269,6 +1263,7 @@ export class LocationConfiguration implements ILocationConfiguration {
             for (let item of this.smsSourcePhoneNumbers)
                 data["smsSourcePhoneNumbers"].push(item.toJSON());
         }
+        data["timeZone"] = this.timeZone ? this.timeZone.toJSON() : <any>undefined;
         return data;
     }
 }
@@ -1280,6 +1275,7 @@ export interface ILocationConfiguration {
     adultFamilyRelationships?: string[];
     arrangementReasons?: string[] | undefined;
     smsSourcePhoneNumbers?: SourcePhoneNumberConfiguration[];
+    timeZone?: TimeZoneInfo | undefined;
 }
 
 export class SourcePhoneNumberConfiguration implements ISourcePhoneNumberConfiguration {
@@ -1320,6 +1316,66 @@ export class SourcePhoneNumberConfiguration implements ISourcePhoneNumberConfigu
 export interface ISourcePhoneNumberConfiguration {
     sourcePhoneNumber?: string;
     description?: string;
+}
+
+export class TimeZoneInfo implements ITimeZoneInfo {
+    id?: string;
+    hasIanaId?: boolean;
+    displayName?: string;
+    standardName?: string;
+    daylightName?: string;
+    baseUtcOffset?: string;
+    supportsDaylightSavingTime?: boolean;
+
+    constructor(data?: ITimeZoneInfo) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["Id"];
+            this.hasIanaId = _data["HasIanaId"];
+            this.displayName = _data["DisplayName"];
+            this.standardName = _data["StandardName"];
+            this.daylightName = _data["DaylightName"];
+            this.baseUtcOffset = _data["BaseUtcOffset"];
+            this.supportsDaylightSavingTime = _data["SupportsDaylightSavingTime"];
+        }
+    }
+
+    static fromJS(data: any): TimeZoneInfo {
+        data = typeof data === 'object' ? data : {};
+        let result = new TimeZoneInfo();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["Id"] = this.id;
+        data["HasIanaId"] = this.hasIanaId;
+        data["DisplayName"] = this.displayName;
+        data["StandardName"] = this.standardName;
+        data["DaylightName"] = this.daylightName;
+        data["BaseUtcOffset"] = this.baseUtcOffset;
+        data["SupportsDaylightSavingTime"] = this.supportsDaylightSavingTime;
+        return data;
+    }
+}
+
+export interface ITimeZoneInfo {
+    id?: string;
+    hasIanaId?: boolean;
+    displayName?: string;
+    standardName?: string;
+    daylightName?: string;
+    baseUtcOffset?: string;
+    supportsDaylightSavingTime?: boolean;
 }
 
 export class RoleDefinition implements IRoleDefinition {
@@ -12409,19 +12465,12 @@ export interface IAccountLocationAccess {
     roles?: string[];
 }
 
-/** Semantic representation of an EDM model. */
 export abstract class IEdmModel implements IIEdmModel {
-    /** Gets the collection of schema elements that are contained in this model. */
     schemaElements?: IEdmSchemaElement[] | undefined;
-    /** Gets the collection of vocabulary annotations that are contained in this model. */
     vocabularyAnnotations?: IEdmVocabularyAnnotation[] | undefined;
-    /** Gets the collection of models referred to by this model (mainly by the this.References). */
     referencedModels?: IEdmModel[] | undefined;
-    /** Gets the collection of namespaces that schema elements use contained in this model. */
     declaredNamespaces?: string[] | undefined;
-    /** Gets the model's annotations manager. */
     directValueAnnotationsManager?: IEdmDirectValueAnnotationsManager | undefined;
-    /** Gets the only one entity container of the model. */
     entityContainer?: IEdmEntityContainer | undefined;
 
     constructor(data?: IIEdmModel) {
@@ -12493,27 +12542,17 @@ export abstract class IEdmModel implements IIEdmModel {
     }
 }
 
-/** Semantic representation of an EDM model. */
 export interface IIEdmModel {
-    /** Gets the collection of schema elements that are contained in this model. */
     schemaElements?: IEdmSchemaElement[] | undefined;
-    /** Gets the collection of vocabulary annotations that are contained in this model. */
     vocabularyAnnotations?: IEdmVocabularyAnnotation[] | undefined;
-    /** Gets the collection of models referred to by this model (mainly by the this.References). */
     referencedModels?: IEdmModel[] | undefined;
-    /** Gets the collection of namespaces that schema elements use contained in this model. */
     declaredNamespaces?: string[] | undefined;
-    /** Gets the model's annotations manager. */
     directValueAnnotationsManager?: IEdmDirectValueAnnotationsManager | undefined;
-    /** Gets the only one entity container of the model. */
     entityContainer?: IEdmEntityContainer | undefined;
 }
 
-/** Common base interface for all named children of EDM schema. */
 export abstract class IEdmSchemaElement implements IIEdmSchemaElement {
-    /** Gets the kind of this schema element. */
     schemaElementKind?: EdmSchemaElementKind;
-    /** Gets the namespace this schema element belongs to. */
     namespace?: string | undefined;
 
     constructor(data?: IIEdmSchemaElement) {
@@ -12545,15 +12584,11 @@ export abstract class IEdmSchemaElement implements IIEdmSchemaElement {
     }
 }
 
-/** Common base interface for all named children of EDM schema. */
 export interface IIEdmSchemaElement {
-    /** Gets the kind of this schema element. */
     schemaElementKind?: EdmSchemaElementKind;
-    /** Gets the namespace this schema element belongs to. */
     namespace?: string | undefined;
 }
 
-/** Defines EDM schema element types. */
 export enum EdmSchemaElementKind {
     None = 0,
     TypeDefinition = 1,
@@ -12563,15 +12598,10 @@ export enum EdmSchemaElementKind {
     Function = 5,
 }
 
-/** Represents an EDM vocabulary annotation. */
 export abstract class IEdmVocabularyAnnotation implements IIEdmVocabularyAnnotation {
-    /** Gets the qualifier used to discriminate between multiple bindings of the same property or type. */
     qualifier?: string | undefined;
-    /** Gets the term bound by the annotation. */
     term?: IEdmTerm | undefined;
-    /** Gets the element the annotation applies to. */
     target?: IEdmVocabularyAnnotatable | undefined;
-    /** Gets the expression producing the value of the annotation. */
     value?: IEdmExpression | undefined;
 
     constructor(data?: IIEdmVocabularyAnnotation) {
@@ -12607,25 +12637,16 @@ export abstract class IEdmVocabularyAnnotation implements IIEdmVocabularyAnnotat
     }
 }
 
-/** Represents an EDM vocabulary annotation. */
 export interface IIEdmVocabularyAnnotation {
-    /** Gets the qualifier used to discriminate between multiple bindings of the same property or type. */
     qualifier?: string | undefined;
-    /** Gets the term bound by the annotation. */
     term?: IEdmTerm | undefined;
-    /** Gets the element the annotation applies to. */
     target?: IEdmVocabularyAnnotatable | undefined;
-    /** Gets the expression producing the value of the annotation. */
     value?: IEdmExpression | undefined;
 }
 
-/** Represents an EDM term. */
 export abstract class IEdmTerm implements IIEdmTerm {
-    /** Gets the type of this term. */
     type?: IEdmTypeReference | undefined;
-    /** Gets the AppliesTo of this term. */
     appliesTo?: string | undefined;
-    /** Gets the DefaultValue of this term. */
     defaultValue?: string | undefined;
 
     constructor(data?: IIEdmTerm) {
@@ -12659,21 +12680,14 @@ export abstract class IEdmTerm implements IIEdmTerm {
     }
 }
 
-/** Represents an EDM term. */
 export interface IIEdmTerm {
-    /** Gets the type of this term. */
     type?: IEdmTypeReference | undefined;
-    /** Gets the AppliesTo of this term. */
     appliesTo?: string | undefined;
-    /** Gets the DefaultValue of this term. */
     defaultValue?: string | undefined;
 }
 
-/** Represents a references to a type. */
 export abstract class IEdmTypeReference implements IIEdmTypeReference {
-    /** Gets a value indicating whether this type is nullable. */
     isNullable?: boolean;
-    /** Gets the definition to which this type refers. */
     definition?: IEdmType | undefined;
 
     constructor(data?: IIEdmTypeReference) {
@@ -12705,17 +12719,12 @@ export abstract class IEdmTypeReference implements IIEdmTypeReference {
     }
 }
 
-/** Represents a references to a type. */
 export interface IIEdmTypeReference {
-    /** Gets a value indicating whether this type is nullable. */
     isNullable?: boolean;
-    /** Gets the definition to which this type refers. */
     definition?: IEdmType | undefined;
 }
 
-/** Represents the definition of an EDM type. */
 export abstract class IEdmType implements IIEdmType {
-    /** Gets the kind of this type. */
     typeKind?: EdmTypeKind;
 
     constructor(data?: IIEdmType) {
@@ -12745,13 +12754,10 @@ export abstract class IEdmType implements IIEdmType {
     }
 }
 
-/** Represents the definition of an EDM type. */
 export interface IIEdmType {
-    /** Gets the kind of this type. */
     typeKind?: EdmTypeKind;
 }
 
-/** Defines EDM metatypes. */
 export enum EdmTypeKind {
     None = 0,
     Primitive = 1,
@@ -12765,7 +12771,6 @@ export enum EdmTypeKind {
     Path = 9,
 }
 
-/** Represents an element that can be targeted by Vocabulary Annotations */
 export abstract class IEdmVocabularyAnnotatable implements IIEdmVocabularyAnnotatable {
 
     constructor(data?: IIEdmVocabularyAnnotatable) {
@@ -12791,13 +12796,10 @@ export abstract class IEdmVocabularyAnnotatable implements IIEdmVocabularyAnnota
     }
 }
 
-/** Represents an element that can be targeted by Vocabulary Annotations */
 export interface IIEdmVocabularyAnnotatable {
 }
 
-/** Represents an EDM expression. */
 export abstract class IEdmExpression implements IIEdmExpression {
-    /** Gets the kind of this expression. */
     expressionKind?: EdmExpressionKind;
 
     constructor(data?: IIEdmExpression) {
@@ -12827,13 +12829,10 @@ export abstract class IEdmExpression implements IIEdmExpression {
     }
 }
 
-/** Represents an EDM expression. */
 export interface IIEdmExpression {
-    /** Gets the kind of this expression. */
     expressionKind?: EdmExpressionKind;
 }
 
-/** Defines EDM expression kinds. */
 export enum EdmExpressionKind {
     None = 0,
     BinaryConstant = 1,
@@ -12863,7 +12862,6 @@ export enum EdmExpressionKind {
     AnnotationPath = 25,
 }
 
-/** Manages getting and setting direct annotations on EDM elements. */
 export abstract class IEdmDirectValueAnnotationsManager implements IIEdmDirectValueAnnotationsManager {
 
     constructor(data?: IIEdmDirectValueAnnotationsManager) {
@@ -12889,13 +12887,10 @@ export abstract class IEdmDirectValueAnnotationsManager implements IIEdmDirectVa
     }
 }
 
-/** Manages getting and setting direct annotations on EDM elements. */
 export interface IIEdmDirectValueAnnotationsManager {
 }
 
-/** Represents an EDM entity container. */
 export abstract class IEdmEntityContainer implements IIEdmEntityContainer {
-    /** Gets a collection of the elements of this entity container. */
     elements?: IEdmEntityContainerElement[] | undefined;
 
     constructor(data?: IIEdmEntityContainer) {
@@ -12933,17 +12928,12 @@ export abstract class IEdmEntityContainer implements IIEdmEntityContainer {
     }
 }
 
-/** Represents an EDM entity container. */
 export interface IIEdmEntityContainer {
-    /** Gets a collection of the elements of this entity container. */
     elements?: IEdmEntityContainerElement[] | undefined;
 }
 
-/** Represents the common elements of all EDM entity container elements. */
 export abstract class IEdmEntityContainerElement implements IIEdmEntityContainerElement {
-    /** Gets the kind of element of this container element. */
     containerElementKind?: EdmContainerElementKind;
-    /** Gets the container that contains this element. */
     container?: IEdmEntityContainer | undefined;
 
     constructor(data?: IIEdmEntityContainerElement) {
@@ -12975,15 +12965,11 @@ export abstract class IEdmEntityContainerElement implements IIEdmEntityContainer
     }
 }
 
-/** Represents the common elements of all EDM entity container elements. */
 export interface IIEdmEntityContainerElement {
-    /** Gets the kind of element of this container element. */
     containerElementKind?: EdmContainerElementKind;
-    /** Gets the container that contains this element. */
     container?: IEdmEntityContainer | undefined;
 }
 
-/** Defines EDM container element types. */
 export enum EdmContainerElementKind {
     None = 0,
     EntitySet = 1,
@@ -12992,9 +12978,7 @@ export enum EdmContainerElementKind {
     Singleton = 4,
 }
 
-/** Base class for all annotatable types in OData library. */
 export abstract class ODataAnnotatable implements IODataAnnotatable {
-    /** The annotation for storing @odata.type. */
     typeAnnotation?: ODataTypeAnnotation | undefined;
 
     constructor(data?: IODataAnnotatable) {
@@ -13024,19 +13008,13 @@ export abstract class ODataAnnotatable implements IODataAnnotatable {
     }
 }
 
-/** Base class for all annotatable types in OData library. */
 export interface IODataAnnotatable {
-    /** The annotation for storing @odata.type. */
     typeAnnotation?: ODataTypeAnnotation | undefined;
 }
 
-/** Class representing the a service document. */
 export class ODataServiceDocument extends ODataAnnotatable implements IODataServiceDocument {
-    /** Gets or sets the set of entity sets in the service document. */
     entitySets?: ODataEntitySetInfo[] | undefined;
-    /** Gets or sets the set of singletons in the service document. */
     singletons?: ODataSingletonInfo[] | undefined;
-    /** Gets or sets the set of function imports in the service document. */
     functionImports?: ODataFunctionImportInfo[] | undefined;
 
     constructor(data?: IODataServiceDocument) {
@@ -13093,23 +13071,15 @@ export class ODataServiceDocument extends ODataAnnotatable implements IODataServ
     }
 }
 
-/** Class representing the a service document. */
 export interface IODataServiceDocument extends IODataAnnotatable {
-    /** Gets or sets the set of entity sets in the service document. */
     entitySets?: ODataEntitySetInfo[] | undefined;
-    /** Gets or sets the set of singletons in the service document. */
     singletons?: ODataSingletonInfo[] | undefined;
-    /** Gets or sets the set of function imports in the service document. */
     functionImports?: ODataFunctionImportInfo[] | undefined;
 }
 
-/** Abstract class representing an element (EntitySet, Singleton) in a service document. */
 export abstract class ODataServiceDocumentElement extends ODataAnnotatable implements IODataServiceDocumentElement {
-    /** Gets or sets the URI representing the Unified Resource Locator (URL) to the element. */
     url?: string | undefined;
-    /** Gets or sets the name of the element; this is the entity set or singleton name in JSON and the HREF in Atom. */
     name?: string | undefined;
-    /** Gets or sets the title of the element; this is the title in JSON. */
     title?: string | undefined;
 
     constructor(data?: IODataServiceDocumentElement) {
@@ -13140,17 +13110,12 @@ export abstract class ODataServiceDocumentElement extends ODataAnnotatable imple
     }
 }
 
-/** Abstract class representing an element (EntitySet, Singleton) in a service document. */
 export interface IODataServiceDocumentElement extends IODataAnnotatable {
-    /** Gets or sets the URI representing the Unified Resource Locator (URL) to the element. */
     url?: string | undefined;
-    /** Gets or sets the name of the element; this is the entity set or singleton name in JSON and the HREF in Atom. */
     name?: string | undefined;
-    /** Gets or sets the title of the element; this is the title in JSON. */
     title?: string | undefined;
 }
 
-/** Class representing a entity set in a service document. */
 export class ODataEntitySetInfo extends ODataServiceDocumentElement implements IODataEntitySetInfo {
 
     constructor(data?: IODataEntitySetInfo) {
@@ -13175,13 +13140,10 @@ export class ODataEntitySetInfo extends ODataServiceDocumentElement implements I
     }
 }
 
-/** Class representing a entity set in a service document. */
 export interface IODataEntitySetInfo extends IODataServiceDocumentElement {
 }
 
-/** Annotation which stores the EDM type information of a value. */
 export class ODataTypeAnnotation implements IODataTypeAnnotation {
-    /** Gets the type name to serialize, for the annotated item.  */
     typeName?: string | undefined;
 
     constructor(data?: IODataTypeAnnotation) {
@@ -13213,13 +13175,10 @@ export class ODataTypeAnnotation implements IODataTypeAnnotation {
     }
 }
 
-/** Annotation which stores the EDM type information of a value. */
 export interface IODataTypeAnnotation {
-    /** Gets the type name to serialize, for the annotated item.  */
     typeName?: string | undefined;
 }
 
-/** Class representing a singleton in a service document. */
 export class ODataSingletonInfo extends ODataServiceDocumentElement implements IODataSingletonInfo {
 
     constructor(data?: IODataSingletonInfo) {
@@ -13244,11 +13203,9 @@ export class ODataSingletonInfo extends ODataServiceDocumentElement implements I
     }
 }
 
-/** Class representing a singleton in a service document. */
 export interface IODataSingletonInfo extends IODataServiceDocumentElement {
 }
 
-/** Class representing a function Import in a service document. */
 export class ODataFunctionImportInfo extends ODataServiceDocumentElement implements IODataFunctionImportInfo {
 
     constructor(data?: IODataFunctionImportInfo) {
@@ -13273,7 +13230,6 @@ export class ODataFunctionImportInfo extends ODataServiceDocumentElement impleme
     }
 }
 
-/** Class representing a function Import in a service document. */
 export interface IODataFunctionImportInfo extends IODataServiceDocumentElement {
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -943,11 +943,10 @@
         "tags": [
           "Metadata"
         ],
-        "summary": "Generates the OData $metadata document.",
         "operationId": "Metadata_GetMetadata",
         "responses": {
           "200": {
-            "description": "The IEdmModel representing $metadata.",
+            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -964,11 +963,10 @@
         "tags": [
           "Metadata"
         ],
-        "summary": "Generates the OData service document.",
         "operationId": "Metadata_GetServiceDocument",
         "responses": {
           "200": {
-            "description": "The service document for the service.",
+            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -1105,6 +1103,14 @@
             "items": {
               "$ref": "#/components/schemas/SourcePhoneNumberConfiguration"
             }
+          },
+          "timeZone": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TimeZoneInfo"
+              }
+            ]
           }
         }
       },
@@ -1117,6 +1123,34 @@
           },
           "description": {
             "type": "string"
+          }
+        }
+      },
+      "TimeZoneInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "string"
+          },
+          "HasIanaId": {
+            "type": "boolean"
+          },
+          "DisplayName": {
+            "type": "string"
+          },
+          "StandardName": {
+            "type": "string"
+          },
+          "DaylightName": {
+            "type": "string"
+          },
+          "BaseUtcOffset": {
+            "type": "string",
+            "format": "duration"
+          },
+          "SupportsDaylightSavingTime": {
+            "type": "boolean"
           }
         }
       },
@@ -6946,13 +6980,11 @@
       },
       "IEdmModel": {
         "type": "object",
-        "description": "Semantic representation of an EDM model.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "schemaElements": {
             "type": "array",
-            "description": "Gets the collection of schema elements that are contained in this model.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/IEdmSchemaElement"
@@ -6960,7 +6992,6 @@
           },
           "vocabularyAnnotations": {
             "type": "array",
-            "description": "Gets the collection of vocabulary annotations that are contained in this model.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/IEdmVocabularyAnnotation"
@@ -6968,7 +6999,6 @@
           },
           "referencedModels": {
             "type": "array",
-            "description": "Gets the collection of models referred to by this model (mainly by the this.References).",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/IEdmModel"
@@ -6976,14 +7006,12 @@
           },
           "declaredNamespaces": {
             "type": "array",
-            "description": "Gets the collection of namespaces that schema elements use contained in this model.",
             "nullable": true,
             "items": {
               "type": "string"
             }
           },
           "directValueAnnotationsManager": {
-            "description": "Gets the model's annotations manager.",
             "nullable": true,
             "oneOf": [
               {
@@ -6992,7 +7020,6 @@
             ]
           },
           "entityContainer": {
-            "description": "Gets the only one entity container of the model.",
             "nullable": true,
             "oneOf": [
               {
@@ -7004,28 +7031,21 @@
       },
       "IEdmSchemaElement": {
         "type": "object",
-        "description": "Common base interface for all named children of EDM schema.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "schemaElementKind": {
-            "description": "Gets the kind of this schema element.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EdmSchemaElementKind"
-              }
-            ]
+            "$ref": "#/components/schemas/EdmSchemaElementKind"
           },
           "namespace": {
             "type": "string",
-            "description": "Gets the namespace this schema element belongs to.",
             "nullable": true
           }
         }
       },
       "EdmSchemaElementKind": {
         "type": "integer",
-        "description": "Defines EDM schema element types.",
+        "description": "",
         "x-enumNames": [
           "None",
           "TypeDefinition",
@@ -7045,17 +7065,14 @@
       },
       "IEdmVocabularyAnnotation": {
         "type": "object",
-        "description": "Represents an EDM vocabulary annotation.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "qualifier": {
             "type": "string",
-            "description": "Gets the qualifier used to discriminate between multiple bindings of the same property or type.",
             "nullable": true
           },
           "term": {
-            "description": "Gets the term bound by the annotation.",
             "nullable": true,
             "oneOf": [
               {
@@ -7064,7 +7081,6 @@
             ]
           },
           "target": {
-            "description": "Gets the element the annotation applies to.",
             "nullable": true,
             "oneOf": [
               {
@@ -7073,7 +7089,6 @@
             ]
           },
           "value": {
-            "description": "Gets the expression producing the value of the annotation.",
             "nullable": true,
             "oneOf": [
               {
@@ -7085,12 +7100,10 @@
       },
       "IEdmTerm": {
         "type": "object",
-        "description": "Represents an EDM term.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "type": {
-            "description": "Gets the type of this term.",
             "nullable": true,
             "oneOf": [
               {
@@ -7100,28 +7113,23 @@
           },
           "appliesTo": {
             "type": "string",
-            "description": "Gets the AppliesTo of this term.",
             "nullable": true
           },
           "defaultValue": {
             "type": "string",
-            "description": "Gets the DefaultValue of this term.",
             "nullable": true
           }
         }
       },
       "IEdmTypeReference": {
         "type": "object",
-        "description": "Represents a references to a type.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "isNullable": {
-            "type": "boolean",
-            "description": "Gets a value indicating whether this type is nullable."
+            "type": "boolean"
           },
           "definition": {
-            "description": "Gets the definition to which this type refers.",
             "nullable": true,
             "oneOf": [
               {
@@ -7133,23 +7141,17 @@
       },
       "IEdmType": {
         "type": "object",
-        "description": "Represents the definition of an EDM type.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "typeKind": {
-            "description": "Gets the kind of this type.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EdmTypeKind"
-              }
-            ]
+            "$ref": "#/components/schemas/EdmTypeKind"
           }
         }
       },
       "EdmTypeKind": {
         "type": "integer",
-        "description": "Defines EDM metatypes.",
+        "description": "",
         "x-enumNames": [
           "None",
           "Primitive",
@@ -7177,29 +7179,22 @@
       },
       "IEdmVocabularyAnnotatable": {
         "type": "object",
-        "description": "Represents an element that can be targeted by Vocabulary Annotations",
         "x-abstract": true,
         "additionalProperties": false
       },
       "IEdmExpression": {
         "type": "object",
-        "description": "Represents an EDM expression.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "expressionKind": {
-            "description": "Gets the kind of this expression.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EdmExpressionKind"
-              }
-            ]
+            "$ref": "#/components/schemas/EdmExpressionKind"
           }
         }
       },
       "EdmExpressionKind": {
         "type": "integer",
-        "description": "Defines EDM expression kinds.",
+        "description": "",
         "x-enumNames": [
           "None",
           "BinaryConstant",
@@ -7259,19 +7254,16 @@
       },
       "IEdmDirectValueAnnotationsManager": {
         "type": "object",
-        "description": "Manages getting and setting direct annotations on EDM elements.",
         "x-abstract": true,
         "additionalProperties": false
       },
       "IEdmEntityContainer": {
         "type": "object",
-        "description": "Represents an EDM entity container.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "elements": {
             "type": "array",
-            "description": "Gets a collection of the elements of this entity container.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/IEdmEntityContainerElement"
@@ -7281,20 +7273,13 @@
       },
       "IEdmEntityContainerElement": {
         "type": "object",
-        "description": "Represents the common elements of all EDM entity container elements.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "containerElementKind": {
-            "description": "Gets the kind of element of this container element.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EdmContainerElementKind"
-              }
-            ]
+            "$ref": "#/components/schemas/EdmContainerElementKind"
           },
           "container": {
-            "description": "Gets the container that contains this element.",
             "nullable": true,
             "oneOf": [
               {
@@ -7306,7 +7291,7 @@
       },
       "EdmContainerElementKind": {
         "type": "integer",
-        "description": "Defines EDM container element types.",
+        "description": "",
         "x-enumNames": [
           "None",
           "EntitySet",
@@ -7329,12 +7314,10 @@
           },
           {
             "type": "object",
-            "description": "Class representing the a service document.",
             "additionalProperties": false,
             "properties": {
               "entitySets": {
                 "type": "array",
-                "description": "Gets or sets the set of entity sets in the service document.",
                 "nullable": true,
                 "items": {
                   "$ref": "#/components/schemas/ODataEntitySetInfo"
@@ -7342,7 +7325,6 @@
               },
               "singletons": {
                 "type": "array",
-                "description": "Gets or sets the set of singletons in the service document.",
                 "nullable": true,
                 "items": {
                   "$ref": "#/components/schemas/ODataSingletonInfo"
@@ -7350,7 +7332,6 @@
               },
               "functionImports": {
                 "type": "array",
-                "description": "Gets or sets the set of function imports in the service document.",
                 "nullable": true,
                 "items": {
                   "$ref": "#/components/schemas/ODataFunctionImportInfo"
@@ -7367,7 +7348,6 @@
           },
           {
             "type": "object",
-            "description": "Class representing a entity set in a service document.",
             "additionalProperties": false
           }
         ]
@@ -7379,24 +7359,20 @@
           },
           {
             "type": "object",
-            "description": "Abstract class representing an element (EntitySet, Singleton) in a service document.",
             "x-abstract": true,
             "additionalProperties": false,
             "properties": {
               "url": {
                 "type": "string",
-                "description": "Gets or sets the URI representing the Unified Resource Locator (URL) to the element.",
                 "format": "uri",
                 "nullable": true
               },
               "name": {
                 "type": "string",
-                "description": "Gets or sets the name of the element; this is the entity set or singleton name in JSON and the HREF in Atom.",
                 "nullable": true
               },
               "title": {
                 "type": "string",
-                "description": "Gets or sets the title of the element; this is the title in JSON.",
                 "nullable": true
               }
             }
@@ -7405,12 +7381,10 @@
       },
       "ODataAnnotatable": {
         "type": "object",
-        "description": "Base class for all annotatable types in OData library.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "typeAnnotation": {
-            "description": "The annotation for storing @odata.type.",
             "nullable": true,
             "oneOf": [
               {
@@ -7422,12 +7396,10 @@
       },
       "ODataTypeAnnotation": {
         "type": "object",
-        "description": "Annotation which stores the EDM type information of a value.",
         "additionalProperties": false,
         "properties": {
           "typeName": {
             "type": "string",
-            "description": "Gets the type name to serialize, for the annotated item. ",
             "nullable": true
           }
         }
@@ -7439,7 +7411,6 @@
           },
           {
             "type": "object",
-            "description": "Class representing a singleton in a service document.",
             "additionalProperties": false
           }
         ]
@@ -7451,7 +7422,6 @@
           },
           {
             "type": "object",
-            "description": "Class representing a function Import in a service document.",
             "additionalProperties": false
           }
         ]

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirementInstances.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirementInstances.cs
@@ -62,7 +62,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 utcNow: new DateTime(H.YEAR, 2, 14),
                 H.US_EASTERN_TIME_ZONE);
 
-            AssertEx.SequenceIs(result, Helpers.DatesAtLastSecond(H.US_EASTERN_TIME_ZONE, (1, 3)));
+            AssertEx.SequenceIs(result, Helpers.DatesFromTimeZone(H.US_EASTERN_TIME_ZONE, (1, 3)));
         }
 
         [TestMethod]
@@ -78,7 +78,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 utcNow: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 2),
                 H.US_EASTERN_TIME_ZONE);
 
-            AssertEx.SequenceIs(result, Helpers.DatesAtLastSecond(H.US_EASTERN_TIME_ZONE, (1, 3)));
+            AssertEx.SequenceIs(result, Helpers.DatesFromTimeZone(H.US_EASTERN_TIME_ZONE, (1, 3)));
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 utcNow: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 2),
                 H.US_EASTERN_TIME_ZONE);
 
-            AssertEx.SequenceIs(result, Helpers.DatesAtLastSecond(H.US_EASTERN_TIME_ZONE, (1, 3)));
+            AssertEx.SequenceIs(result, Helpers.DatesFromTimeZone(H.US_EASTERN_TIME_ZONE, (1, 3)));
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
             var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(
                 new OneTimeRecurrencePolicy(null),
                 filterToFamilyId: null,
-                arrangementStartedAtUtc: new DateTime(H.YEAR, 1, 1),
+                arrangementStartedAtUtc: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 1),
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
@@ -127,7 +127,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 H.US_EASTERN_TIME_ZONE);
 
             //TODO: This could instead be "max date" -- need to decide what's more intuitive for users.
-            AssertEx.SequenceIs(result, Helpers.Dates((1, 1)));
+            AssertEx.SequenceIs(result, Helpers.DatesFromTimeZone(H.US_EASTERN_TIME_ZONE, (1, 1)));
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 utcNow: new DateTime(H.YEAR, 2, 14),
                 H.US_EASTERN_TIME_ZONE);
 
-            AssertEx.SequenceIs(result, Helpers.DatesAtLastSecond(H.US_EASTERN_TIME_ZONE, (1, 1)));
+            AssertEx.SequenceIs(result, Helpers.DatesFromTimeZone(H.US_EASTERN_TIME_ZONE, (1, 1)));
         }
 
         [TestMethod]

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirementInstances.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirementInstances.cs
@@ -25,7 +25,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3), (1, 10), (1, 17), (1, 24), (1, 31), (2, 14), (2, 28)));
         }
@@ -42,7 +43,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3)));
         }
@@ -53,13 +55,14 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
             var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(
                 new OneTimeRecurrencePolicy(TimeSpan.FromDays(2)),
                 filterToFamilyId: null,
-                arrangementStartedAtUtc: new DateTime(H.YEAR, 1, 1),
+                arrangementStartedAtUtc: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 1),
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
-            AssertEx.SequenceIs(result, Helpers.Dates((1, 3)));
+            AssertEx.SequenceIs(result, Helpers.DatesAtLastSecond(H.US_EASTERN_TIME_ZONE, (1, 3)));
         }
 
         [TestMethod]
@@ -68,13 +71,14 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
             var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(
                 new OneTimeRecurrencePolicy(TimeSpan.FromDays(2)),
                 filterToFamilyId: null,
-                arrangementStartedAtUtc: new DateTime(H.YEAR, 1, 1),
+                arrangementStartedAtUtc: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 1),
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 1, 2));
+                utcNow: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 2),
+                H.US_EASTERN_TIME_ZONE);
 
-            AssertEx.SequenceIs(result, Helpers.Dates((1, 3)));
+            AssertEx.SequenceIs(result, Helpers.DatesAtLastSecond(H.US_EASTERN_TIME_ZONE, (1, 3)));
         }
 
         [TestMethod]
@@ -87,7 +91,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates((1, 2)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 1, 2));
+                utcNow: new DateTime(H.YEAR, 1, 2),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, []);
         }
@@ -98,13 +103,14 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
             var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(
                 new OneTimeRecurrencePolicy(TimeSpan.FromDays(2)),
                 filterToFamilyId: null,
-                arrangementStartedAtUtc: new DateTime(H.YEAR, 1, 1),
+                arrangementStartedAtUtc: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 1),
                 arrangementEndedAtUtc: null,
-                completions: Helpers.Dates((1, 4)),
+                completions: Helpers.DatesFromTimeZone(H.US_EASTERN_TIME_ZONE, (1, 4)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 1, 2));
+                utcNow: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 2),
+                H.US_EASTERN_TIME_ZONE);
 
-            AssertEx.SequenceIs(result, Helpers.Dates((1, 3)));
+            AssertEx.SequenceIs(result, Helpers.DatesAtLastSecond(H.US_EASTERN_TIME_ZONE, (1, 3)));
         }
 
         [TestMethod]
@@ -117,7 +123,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             //TODO: This could instead be "max date" -- need to decide what's more intuitive for users.
             AssertEx.SequenceIs(result, Helpers.Dates((1, 1)));
@@ -130,13 +137,14 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
             var result = ReferralCalculations.CalculateMissingMonitoringRequirementInstances(
                 new OneTimeRecurrencePolicy(TimeSpan.Zero),
                 filterToFamilyId: null,
-                arrangementStartedAtUtc: new DateTime(H.YEAR, 1, 1),
+                arrangementStartedAtUtc: H.DateFromTimeZone(H.US_EASTERN_TIME_ZONE, 1, 1),
                 arrangementEndedAtUtc: null,
-                completions: Helpers.Dates((1, 5)),
+                completions: Helpers.DatesFromTimeZone(H.US_EASTERN_TIME_ZONE, (1, 5)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
-            AssertEx.SequenceIs(result, Helpers.Dates((1, 1)));
+            AssertEx.SequenceIs(result, Helpers.DatesAtLastSecond(H.US_EASTERN_TIME_ZONE, (1, 1)));
         }
 
         [TestMethod]
@@ -152,7 +160,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: new DateTime(H.YEAR, 2, 1),
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3), (1, 10), (1, 17), (1, 24), (1, 31)));
         }
@@ -183,7 +192,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     (ChildLocationPlan.WithParent, 2, 18),
                     (ChildLocationPlan.DaytimeChildCare, 2, 22),
                     (ChildLocationPlan.WithParent, 2, 25)),
-                utcNow: new DateTime(H.YEAR, 2, 28));
+                utcNow: new DateTime(H.YEAR, 2, 28),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3), (1, 24), (2, 17)));
         }
@@ -214,7 +224,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     (ChildLocationPlan.WithParent, 2, 18),
                     (ChildLocationPlan.DaytimeChildCare, 2, 22),
                     (ChildLocationPlan.WithParent, 2, 25)),
-                utcNow: new DateTime(H.YEAR, 2, 28));
+                utcNow: new DateTime(H.YEAR, 2, 28),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 17), (2, 10)));
         }
@@ -236,7 +247,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     (ChildLocationPlan.DaytimeChildCare, 1, 15),
                     (ChildLocationPlan.WithParent, 1, 18),
                     (ChildLocationPlan.DaytimeChildCare, 1, 22)),
-                utcNow: new DateTime(H.YEAR, 2, 28));
+                utcNow: new DateTime(H.YEAR, 2, 28),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3), (1, 24)));
         }
@@ -258,7 +270,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     (ChildLocationPlan.DaytimeChildCare, 1, 15),
                     (ChildLocationPlan.WithParent, 1, 18),
                     (ChildLocationPlan.DaytimeChildCare, 1, 22)),
-                utcNow: new DateTime(H.YEAR, 2, 23));
+                utcNow: new DateTime(H.YEAR, 2, 23),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3), (1, 24)));
         }
@@ -276,7 +289,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates((1, 2)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 9), (1, 16), (1, 23), (1, 30), (2, 13), (2, 27)));
         }
@@ -294,7 +308,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: new DateTime(H.YEAR, 2, 1),
                 completions: Helpers.Dates((1, 2)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 9), (1, 16), (1, 23), (1, 30)));
         }
@@ -310,7 +325,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: new DateTime(H.YEAR, 1, 10),
                 completions: Helpers.Dates((1, 5)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 1));
+                utcNow: new DateTime(H.YEAR, 2, 1),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates());
         }
@@ -326,7 +342,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: new DateTime(H.YEAR, 1, 8),
                 completions: Helpers.Dates((1, 9)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 1));
+                utcNow: new DateTime(H.YEAR, 2, 1),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates());
         }
@@ -344,7 +361,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates((1, 2), (1, 2)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 9), (1, 16), (1, 23), (1, 30), (2, 13), (2, 27)));
         }
@@ -362,7 +380,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates((1, 1), (1, 2)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 9), (1, 16), (1, 23), (1, 30), (2, 13), (2, 27)));
         }
@@ -380,7 +399,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates((1, 2), (1, 9)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 16), (1, 23), (1, 30), (2, 13), (2, 27)));
         }
@@ -398,7 +418,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates((1, 2), (1, 10)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 9), (1, 17), (1, 24), (1, 31), (2, 14), (2, 28)));
         }
@@ -416,7 +437,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates((1, 2), (1, 20)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 9), (1, 16), (1, 27), (2, 10), (2, 24)));
         }
@@ -434,7 +456,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates((1, 2), (1, 20), (2, 9)),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 9), (1, 16), (1, 27), (2, 23)));
         }
@@ -452,7 +475,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates());
         }
@@ -471,7 +495,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(
                     (ChildLocationPlan.DaytimeChildCare, 1, 1)),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3), (1, 10), (1, 17), (1, 24), (1, 31), (2, 14), (2, 28)));
         }
@@ -492,7 +517,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     (ChildLocationPlan.DaytimeChildCare, 1, 1),
                     (ChildLocationPlan.WithParent, 1, 12),
                     (ChildLocationPlan.DaytimeChildCare, 1, 15)),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3), (1, 10), (1, 20), (1, 27), (2, 3), (2, 17)));
         }
@@ -512,7 +538,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 childLocationHistory: Helpers.LocationHistoryEntries(
                     (ChildLocationPlan.DaytimeChildCare, 1, 1),
                     (ChildLocationPlan.WithParent, 2, 7)),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result, Helpers.Dates((1, 3), (1, 10), (1, 17), (1, 24), (1, 31)));
         }
@@ -530,7 +557,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 arrangementEndedAtUtc: null,
                 completions: Helpers.Dates(),
                 childLocationHistory: Helpers.LocationHistoryEntries(),
-                utcNow: new DateTime(H.YEAR, 2, 14));
+                utcNow: new DateTime(H.YEAR, 2, 14),
+                H.US_EASTERN_TIME_ZONE);
 
             Assert.Inconclusive("Test not updated for multiple locations");
             AssertEx.SequenceIs(result, Helpers.Dates(/*(1, 3), (1, 10), (1, 17), (1, 24), (1, 31), (2, 14), (2, 28)*/));

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirements.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateMissingMonitoringRequirements.cs
@@ -39,7 +39,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     Helpers.LocationHistoryEntries(),
                     Helpers.LocationHistoryEntries(),
                     Comments: null, Reason: null),
-                utcNow: new DateTime(H.YEAR, 1, 31));
+                utcNow: new DateTime(H.YEAR, 1, 31),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result);
         }
@@ -65,7 +66,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     Helpers.LocationHistoryEntries(),
                     Helpers.LocationHistoryEntries(),
                     Comments: null, Reason: null),
-                utcNow: new DateTime(H.YEAR, 1, 31));
+                utcNow: new DateTime(H.YEAR, 1, 31),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result,
                 new MissingArrangementRequirement(null, null, null, null, "A", DueBy: null, PastDueSince: new DateTime(H.YEAR, 1, 3)),
@@ -102,7 +104,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     Helpers.LocationHistoryEntries(),
                     Helpers.LocationHistoryEntries(),
                     Comments: null, Reason: null),
-                utcNow: new DateTime(H.YEAR, 1, 31));
+                utcNow: new DateTime(H.YEAR, 1, 31),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result,
                 new MissingArrangementRequirement(null, null, null, null, "A", DueBy: null, PastDueSince: new DateTime(H.YEAR, 1, 10)),
@@ -137,7 +140,8 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     Helpers.LocationHistoryEntries(),
                     Helpers.LocationHistoryEntries(),
                     Comments: null, Reason: null),
-                utcNow: new DateTime(H.YEAR, 1, 8));
+                utcNow: new DateTime(H.YEAR, 1, 8),
+                H.US_EASTERN_TIME_ZONE);
 
             AssertEx.SequenceIs(result,
                 new MissingArrangementRequirement(null, null, null, null, "A", DueBy: new DateTime(H.YEAR, 1, 10), PastDueSince: null),

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/Helpers.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/Helpers.cs
@@ -10,6 +10,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
     internal class Helpers
     {
         public const int YEAR = 2024;
+        public static TimeZoneInfo US_EASTERN_TIME_ZONE = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
 
         public static ImmutableList<CompletedRequirementInfo> Completed(params (string, int)[] completionsWithDates) =>
             completionsWithDates.Select(completion =>
@@ -35,6 +36,15 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
 
         public static ImmutableList<DateTime> Dates(params (int month, int day)[] values) =>
             values.Select(value => new DateTime(YEAR, value.month, value.day)).ToImmutableList();
+
+        public static ImmutableList<DateTime> DatesFromTimeZone(TimeZoneInfo tz, params (int month, int day)[] values) =>
+            values.Select(value => TimeZoneInfo.ConvertTimeToUtc(new DateTime(YEAR, value.month, value.day), tz)).ToImmutableList();
+
+        public static DateTime DateFromTimeZone(TimeZoneInfo tz, int month, int day) =>
+            TimeZoneInfo.ConvertTimeToUtc(new DateTime(YEAR, month, day), tz);
+
+        public static ImmutableList<DateTime> DatesAtLastSecond(TimeZoneInfo tz, params (int month, int day)[] values) =>
+            values.Select(value => TimeZoneInfo.ConvertTimeToUtc(new DateTime(YEAR, value.month, value.day, 23, 59, 59), tz)).ToImmutableList();
 
         public static ImmutableSortedSet<ChildLocationHistoryEntry> LocationHistoryEntries(
             params (ChildLocationPlan plan, int month, int day)[] values) =>


### PR DESCRIPTION
This is the initial solution proposal for #558, but focusing only on the one time recurrence policy for simplicity.

The idea is that the delay defined in the policies should be considered as "full days" delay. So a delay of, say, 2 days, means the requirement can be met at any time in the following 2 days after the startedAt date. So, tecnically it can be more than 48h hours in total.

To calculate, we start counting the 48h (in our 2 days example) from the next day midnight after the start date.

To be able to calculate properly, we convert datetimes to the Location's time zone. That way we avoid a date falling in a different day (e.g. a completion date registered as 7/3 11PM in NY timezone is recorded as 7/4 3AM UTC).