### PR TITLE
Fix #660

### DIFF
--- a/src/caretogether-pwa/src/Hooks/useGlobalSnackBar.ts
+++ b/src/caretogether-pwa/src/Hooks/useGlobalSnackBar.ts
@@ -1,0 +1,20 @@
+import { atom, useRecoilState } from 'recoil';
+
+export const showGlobalSnackBar = atom<string | null>({
+  key: 'showGlobalSnackBar',
+  default: null,
+});
+
+export function useGlobalSnackBar() {
+  const [message, set] = useRecoilState(showGlobalSnackBar);
+
+  return {
+    message,
+    setAndShowGlobalSnackBar: (value: string) => {
+      set(value);
+    },
+    resetSnackBar: () => {
+      set(null);
+    },
+  };
+}

--- a/src/caretogether-pwa/src/Hooks/useGlobalSnackBar.ts
+++ b/src/caretogether-pwa/src/Hooks/useGlobalSnackBar.ts
@@ -6,15 +6,38 @@ export const showGlobalSnackBar = atom<string | null>({
 });
 
 export function useGlobalSnackBar() {
-  const [message, set] = useRecoilState(showGlobalSnackBar);
+  const [message, setMessage] = useRecoilState(showGlobalSnackBar);
 
   return {
     message,
-    setAndShowGlobalSnackBar: (value: string) => {
-      set(value);
+    setAndShowGlobalSnackBar: (newMessage: string) => {
+      setMessage((currentMessage) => {
+        if (currentMessage === null) {
+          return newMessage;
+        }
+
+        // If newMessage is equal to the currentMessage, add a " (x)" at the end
+        // to indicate how many times that notification was shown.
+        const match = currentMessage
+          ?.replace(newMessage, '')
+          .match(/^\s\((\d)\)$/);
+
+        const currentMessageIncludesCounter = match !== null;
+
+        const isADuplicatedMessage =
+          currentMessageIncludesCounter || currentMessage === newMessage;
+
+        const currentMessageNumber = match ? parseInt(match[1]) : 0;
+
+        if (isADuplicatedMessage) {
+          return `${newMessage} (${currentMessageNumber + 1})`;
+        }
+
+        return newMessage;
+      });
     },
     resetSnackBar: () => {
-      set(null);
+      setMessage(null);
     },
   };
 }

--- a/src/caretogether-pwa/src/Shell/ShellRootLayout.tsx
+++ b/src/caretogether-pwa/src/Shell/ShellRootLayout.tsx
@@ -1,10 +1,17 @@
-import { Box, Container, useMediaQuery, useTheme } from '@mui/material';
+import {
+  Box,
+  Container,
+  Snackbar,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { ShellBottomNavigation } from './ShellBottomNavigation';
 import { ShellAppBar } from './ShellAppBar';
 import { ShellSideNavigation } from './ShellSideNavigation';
 import { useLocalStorage } from '../Hooks/useLocalStorage';
 import React from 'react';
 import { ProgressBackdrop } from './ProgressBackdrop';
+import { useGlobalSnackBar } from '../Hooks/useGlobalSnackBar';
 
 function ShellRootLayout({ children }: React.PropsWithChildren) {
   const theme = useTheme();
@@ -16,6 +23,8 @@ function ShellRootLayout({ children }: React.PropsWithChildren) {
   );
 
   const drawerWidth = menuDrawerOpen ? 190 : 48;
+
+  const { message, resetSnackBar } = useGlobalSnackBar();
 
   return (
     <Box sx={{ flexGrow: 1 }}>
@@ -51,6 +60,14 @@ function ShellRootLayout({ children }: React.PropsWithChildren) {
         </Container>
       </Box>
       {!isDesktop && <ShellBottomNavigation />}
+
+      <Snackbar
+        open={Boolean(message)}
+        autoHideDuration={5000}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        message={message}
+        onClose={resetSnackBar}
+      />
     </Box>
   );
 }

--- a/src/caretogether-pwa/src/Shell/ShellRootLayout.tsx
+++ b/src/caretogether-pwa/src/Shell/ShellRootLayout.tsx
@@ -62,6 +62,7 @@ function ShellRootLayout({ children }: React.PropsWithChildren) {
       {!isDesktop && <ShellBottomNavigation />}
 
       <Snackbar
+        key={message}
         open={Boolean(message)}
         autoHideDuration={5000}
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}

--- a/src/caretogether-pwa/src/Volunteers/VolunteerApproval.tsx
+++ b/src/caretogether-pwa/src/Volunteers/VolunteerApproval.tsx
@@ -19,7 +19,6 @@ import {
   InputBase,
   SelectChangeEvent,
   IconButton,
-  Snackbar,
   Stack,
   ToggleButton,
   ToggleButtonGroup,
@@ -60,6 +59,7 @@ import { ProgressBackdrop } from '../Shell/ProgressBackdrop';
 import { selectedLocationContextState } from '../Model/Data';
 import { useAppNavigate } from '../Hooks/useAppNavigate';
 import { VolunteerRoleApprovalStatusChip } from './VolunteerRoleApprovalStatusChip';
+import { useGlobalSnackBar } from '../Hooks/useGlobalSnackBar';
 
 //#region Role/Status Selection code
 enum filterType {
@@ -605,14 +605,17 @@ function VolunteerApproval(props: { onOpen: () => void }) {
       .filter((email) => typeof email !== 'undefined') as EmailAddress[];
   }
 
+  const { setAndShowGlobalSnackBar } = useGlobalSnackBar();
+
   function copyEmailAddresses() {
     const emailAddresses = getSelectedFamiliesContactEmails();
     navigator.clipboard.writeText(
       emailAddresses.map((email) => email.address).join('; ')
     );
-    setNoticeOpen(true);
+    setAndShowGlobalSnackBar(
+      `Found and copied ${getSelectedFamiliesContactEmails().length} email addresses for ${selectedFamilies.length} selected families to clipboard`
+    );
   }
-  const [noticeOpen, setNoticeOpen] = useState(false);
 
   const windowSize = useWindowSize();
 
@@ -680,13 +683,7 @@ function VolunteerApproval(props: { onOpen: () => void }) {
                   <SmsIcon sx={{ position: 'relative', top: 1 }} />
                 </IconButton>
               )}
-            <Snackbar
-              open={noticeOpen}
-              autoHideDuration={5000}
-              anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-              onClose={() => setNoticeOpen(false)}
-              message={`Found and copied ${getSelectedFamiliesContactEmails().length} email addresses for ${selectedFamilies.length} selected families to clipboard`}
-            />
+
             <Box
               sx={{
                 display: 'flex',


### PR DESCRIPTION
Solution for the clipboard restriction in safari (can only use clipboard in a direct response to a user gesture, no fetching in-between).

Instead of fetching/generating the invite link and then trying to write to clipboard, we render a textinput showing the link with a copy button. Tested in Safari.

## Other changes

### Implemented a global snackbar component

Needed because rendering inside the Drawer component made so that the snackbar was rendering under the ShellAppBar, despite its z-index being higher. So instead of rendering just one level above the Drawer I decided to implement it at Layout level, in ShellRootLayout, and provide a hook so any component can trigger a  snackbar 'notification'.

Also, whenever a component triggers a notification with the same message, a counter is added so the user has a feedback that this notification was shown again (example in the video).

### Updated 'copy email addresses' button in Volunteers screen to use the new global snackbar

To start using the new global snackbar.

## Preview

[preview.webm](https://github.com/user-attachments/assets/050d3b7a-16e9-4267-a486-aa4297233cae)
