### PR TITLE
Fix a case when multiple location changes doesn't result in the right due dates

### DIFF
--- a/src/CareTogether.Core/Engines/PolicyEvaluation/ChildLocation.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/ChildLocation.cs
@@ -6,16 +6,4 @@ public sealed record ChildLocation(
     Guid ChildLocationFamilyId,
     DateOnly Date,
     bool Paused // means "from now on, we stop checking for completion until resuming"
-)
-    : IComparable<ChildLocation>
-{
-    public int CompareTo(ChildLocation? other)
-    {
-        return other == null
-            ? 1
-            : DateTime.Compare(
-                new DateTime(Date, new TimeOnly()),
-                new DateTime(other.Date, new TimeOnly())
-            );
-    }
-}
+);

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationEngine.cs
@@ -28,7 +28,10 @@ namespace CareTogether.Engines.PolicyEvaluation
             ImmutableList<Resources.CompletedRequirementInfo> completedFamilyRequirements,
             ImmutableList<Resources.ExemptedRequirementInfo> exemptedFamilyRequirements,
             ImmutableList<RoleRemoval> familyRoleRemovals,
-            ImmutableDictionary<Guid, ImmutableList<Resources.CompletedRequirementInfo>> completedIndividualRequirements,
+            ImmutableDictionary<
+                Guid,
+                ImmutableList<Resources.CompletedRequirementInfo>
+            > completedIndividualRequirements,
             ImmutableDictionary<Guid, ImmutableList<Resources.ExemptedRequirementInfo>> exemptedIndividualRequirements,
             ImmutableDictionary<Guid, ImmutableList<RoleRemoval>> individualRoleRemovals
         )
@@ -140,7 +143,7 @@ namespace CareTogether.Engines.PolicyEvaluation
 
             var ChildLocationHistory = entry
                 .ChildLocationHistory.Select(item => ToChildLocation(item, locationTimeZone))
-                .ToImmutableSortedSet();
+                .ToImmutableList();
 
             var individualVolunteerAssignments = entry
                 .IndividualVolunteerAssignments.Select(item =>

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralCalculations.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralCalculations.cs
@@ -501,7 +501,7 @@ namespace CareTogether.Engines.PolicyEvaluation
             Guid? filterToFamilyId = null
         )
         {
-            var dateRanges = GenerateDateRanges(childLocations, filterToFamilyId).ToImmutableList();
+            var dateRanges = GenerateDateRanges(childLocations).ToImmutableList();
 
             var filteredDateRanges = (
                 filterToFamilyId != null ? dateRanges.Where(item => item.Tag == filterToFamilyId) : dateRanges
@@ -517,10 +517,7 @@ namespace CareTogether.Engines.PolicyEvaluation
             return DateOnlyTimeline.FromOverlappingDateRanges(filteredDateRanges);
         }
 
-        private static IEnumerable<DateRange<Guid>> GenerateDateRanges(
-            ImmutableList<ChildLocation> childLocations,
-            Guid? filterToFamilyId
-        )
+        private static IEnumerable<DateRange<Guid>> GenerateDateRanges(ImmutableList<ChildLocation> childLocations)
         {
             (DateOnly Date, Guid ChildLocationFamilyId)? previousChildLocation = null;
 

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralCalculations.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralCalculations.cs
@@ -514,24 +514,7 @@ namespace CareTogether.Engines.PolicyEvaluation
                 return null;
             }
 
-            // DateOnlyTimeline.FromOverlappingDateRanges();
-
-            var nonOverlapping = filteredDateRanges.Aggregate(
-                ImmutableList<DateRange>.Empty,
-                (final, item) =>
-                {
-                    var last = final.LastOrDefault();
-
-                    if (last.End >= item.Start)
-                    {
-                        return final.Replace(last, new DateRange(last.Start, item.End));
-                    }
-
-                    return final.Add(item);
-                }
-            );
-
-            return new DateOnlyTimeline(nonOverlapping);
+            return DateOnlyTimeline.FromOverlappingDateRanges(filteredDateRanges);
         }
 
         private static IEnumerable<DateRange<Guid>> GenerateDateRanges(

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralEntryForCalculation.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralEntryForCalculation.cs
@@ -11,11 +11,7 @@ namespace CareTogether.Engines.PolicyEvaluation
         ImmutableDictionary<Guid, ArrangementEntry> Arrangements
     );
 
-    public sealed record CompletedRequirementInfo(
-        string RequirementName,
-        DateOnly CompletedAt,
-        DateOnly? ExpiresAt
-    );
+    public sealed record CompletedRequirementInfo(string RequirementName, DateOnly CompletedAt, DateOnly? ExpiresAt);
 
     public sealed record ExemptedRequirementInfo(
         string RequirementName,
@@ -33,7 +29,7 @@ namespace CareTogether.Engines.PolicyEvaluation
         ImmutableList<ExemptedRequirementInfo> ExemptedRequirements,
         ImmutableList<IndividualVolunteerAssignment> IndividualVolunteerAssignments,
         ImmutableList<FamilyVolunteerAssignment> FamilyVolunteerAssignments,
-        ImmutableSortedSet<ChildLocation> ChildLocationHistory
+        ImmutableList<ChildLocation> ChildLocationHistory
     );
 
     public sealed record IndividualVolunteerAssignment(

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CreateChildLocationBasedTimeline.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CreateChildLocationBasedTimeline.cs
@@ -153,5 +153,68 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 new DateOnlyTimeline([new DateRange(DateOnly.FromDateTime(H.DateTime(1, 20)))])
             );
         }
+
+        [TestMethod]
+        public void CreateTimelineFilteredByFamilyIdMultipleChangesInSameDay()
+        {
+            var hist = H.ChildLocationHistory(
+                (H.Id('0'), ChildLocationPlan.WithParent, 1, 1),
+                (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('2'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('0'), ChildLocationPlan.WithParent, 1, 15)
+            );
+
+            var result = ReferralCalculations.CreateChildLocationBasedTimeline(hist.ToImmutableList(), H.Id('1'));
+
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline(
+                    [new DateRange(DateOnly.FromDateTime(H.DateTime(1, 10)), DateOnly.FromDateTime(H.DateTime(1, 15)))]
+                )
+            );
+        }
+
+        [TestMethod]
+        public void CreateTimelineFilteredByFamilyIdMultipleChangesInSameDay2()
+        {
+            var hist = H.ChildLocationHistory(
+                (H.Id('0'), ChildLocationPlan.WithParent, 1, 1),
+                (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('2'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('0'), ChildLocationPlan.WithParent, 1, 15)
+            );
+
+            var result = ReferralCalculations.CreateChildLocationBasedTimeline(hist.ToImmutableList(), H.Id('2'));
+
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline(
+                    [new DateRange(DateOnly.FromDateTime(H.DateTime(1, 10)), DateOnly.FromDateTime(H.DateTime(1, 10)))]
+                )
+            );
+        }
+
+        [TestMethod]
+        public void CreateTimelineMultipleChangesInSameDay()
+        {
+            var hist = H.ChildLocationHistory(
+                (H.Id('0'), ChildLocationPlan.WithParent, 1, 1),
+                (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('2'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                (H.Id('0'), ChildLocationPlan.WithParent, 1, 15)
+            );
+
+            var result = ReferralCalculations.CreateChildLocationBasedTimeline(hist.ToImmutableList());
+
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline(
+                    [new DateRange(DateOnly.FromDateTime(H.DateTime(1, 10)), DateOnly.FromDateTime(H.DateTime(1, 15)))]
+                )
+            );
+        }
     }
 }

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CreateChildLocationBasedTimeline.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CreateChildLocationBasedTimeline.cs
@@ -16,23 +16,29 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
         {
             var result = ReferralCalculations.CreateChildLocationBasedTimeline(
                 H.ChildLocationHistory(
-                    (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 1, 12),
-                    (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 20),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 1, 25)
-                ).ToImmutableList()
+                        (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 1, 12),
+                        (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 20),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 1, 25)
+                    )
+                    .ToImmutableList()
             );
 
-            AssertEx.SequenceIs(result, new DateOnlyTimeline([
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 1)),
-                    DateOnly.FromDateTime(H.DateTime(1, 12))
-                ),
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 20)),
-                    DateOnly.FromDateTime(H.DateTime(1, 25))
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline(
+                    [
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 1)),
+                            DateOnly.FromDateTime(H.DateTime(1, 12))
+                        ),
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 20)),
+                            DateOnly.FromDateTime(H.DateTime(1, 25))
+                        ),
+                    ]
                 )
-            ]));
+            );
         }
 
         [TestMethod]
@@ -40,29 +46,35 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
         {
             var result = ReferralCalculations.CreateChildLocationBasedTimeline(
                 H.ChildLocationHistory(
-                    (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 1, 12),
-                    (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 20),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 1, 25),
-                    (H.Id('2'), ChildLocationPlan.DaytimeChildCare, 1, 30),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 2, 5)
-                ).ToImmutableList()
+                        (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 1, 12),
+                        (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 20),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 1, 25),
+                        (H.Id('2'), ChildLocationPlan.DaytimeChildCare, 1, 30),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 2, 5)
+                    )
+                    .ToImmutableList()
             );
 
-            AssertEx.SequenceIs(result, new DateOnlyTimeline([
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 1)),
-                    DateOnly.FromDateTime(H.DateTime(1, 12))
-                ),
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 20)),
-                    DateOnly.FromDateTime(H.DateTime(1, 25))
-                ),
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 30)),
-                    DateOnly.FromDateTime(H.DateTime(2, 5))
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline(
+                    [
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 1)),
+                            DateOnly.FromDateTime(H.DateTime(1, 12))
+                        ),
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 20)),
+                            DateOnly.FromDateTime(H.DateTime(1, 25))
+                        ),
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 30)),
+                            DateOnly.FromDateTime(H.DateTime(2, 5))
+                        ),
+                    ]
                 )
-            ]));
+            );
         }
 
         [TestMethod]
@@ -70,26 +82,32 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
         {
             var result = ReferralCalculations.CreateChildLocationBasedTimeline(
                 H.ChildLocationHistory(
-                    (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 1, 12),
-                    (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 20),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 1, 25),
-                    (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 30),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 2, 5)
-                ).ToImmutableList(),
+                        (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 1, 12),
+                        (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 20),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 1, 25),
+                        (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 30),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 2, 5)
+                    )
+                    .ToImmutableList(),
                 filterToFamilyId: H.Id('0')
             );
 
-            AssertEx.SequenceIs(result, new DateOnlyTimeline([
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 1)),
-                    DateOnly.FromDateTime(H.DateTime(1, 12))
-                ),
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 30)),
-                    DateOnly.FromDateTime(H.DateTime(2, 5))
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline(
+                    [
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 1)),
+                            DateOnly.FromDateTime(H.DateTime(1, 12))
+                        ),
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 30)),
+                            DateOnly.FromDateTime(H.DateTime(2, 5))
+                        ),
+                    ]
                 )
-            ]));
+            );
         }
 
         [TestMethod]
@@ -97,21 +115,43 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
         {
             var result = ReferralCalculations.CreateChildLocationBasedTimeline(
                 H.ChildLocationHistory(
-                    (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
-                    (Guid.Empty, ChildLocationPlan.WithParent, 1, 12),
-                    (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 20)
-                ).ToImmutableList()
+                        (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
+                        (Guid.Empty, ChildLocationPlan.WithParent, 1, 12),
+                        (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 20)
+                    )
+                    .ToImmutableList()
             );
 
-            AssertEx.SequenceIs(result, new DateOnlyTimeline([
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 1)),
-                    DateOnly.FromDateTime(H.DateTime(1, 12))
-                ),
-                new DateRange(
-                    DateOnly.FromDateTime(H.DateTime(1, 20))
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline(
+                    [
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 1)),
+                            DateOnly.FromDateTime(H.DateTime(1, 12))
+                        ),
+                        new DateRange(DateOnly.FromDateTime(H.DateTime(1, 20))),
+                    ]
                 )
-            ]));
+            );
+        }
+
+        [TestMethod]
+        public void CreateTimelineFilteredByFamilyIdNoPauses()
+        {
+            var result = ReferralCalculations.CreateChildLocationBasedTimeline(
+                H.ChildLocationHistory(
+                        (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
+                        (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 20)
+                    )
+                    .ToImmutableList(),
+                H.Id('1')
+            );
+
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline([new DateRange(DateOnly.FromDateTime(H.DateTime(1, 20)))])
+            );
         }
     }
 }

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CreateChildLocationBasedTimeline.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CreateChildLocationBasedTimeline.cs
@@ -155,6 +155,38 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
         }
 
         [TestMethod]
+        public void CreateTimelineFilteredByFamilyIdWithPauses()
+        {
+            var result = ReferralCalculations.CreateChildLocationBasedTimeline(
+                H.ChildLocationHistory(
+                        (H.Id('0'), ChildLocationPlan.DaytimeChildCare, 1, 1),
+                        (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 10),
+                        (H.Id('2'), ChildLocationPlan.WithParent, 1, 12),
+                        (H.Id('1'), ChildLocationPlan.DaytimeChildCare, 1, 15),
+                        (H.Id('2'), ChildLocationPlan.WithParent, 1, 20)
+                    )
+                    .ToImmutableList(),
+                H.Id('1')
+            );
+
+            AssertEx.SequenceIs(
+                result,
+                new DateOnlyTimeline(
+                    [
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 10)),
+                            DateOnly.FromDateTime(H.DateTime(1, 12))
+                        ),
+                        new DateRange(
+                            DateOnly.FromDateTime(H.DateTime(1, 15)),
+                            DateOnly.FromDateTime(H.DateTime(1, 20))
+                        ),
+                    ]
+                )
+            );
+        }
+
+        [TestMethod]
         public void CreateTimelineFilteredByFamilyIdMultipleChangesInSameDay()
         {
             var hist = H.ChildLocationHistory(

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/Helpers.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/Helpers.cs
@@ -79,7 +79,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                 ))
                 .ToImmutableSortedSet();
 
-        public static ImmutableSortedSet<ChildLocation> ChildLocationHistory(
+        public static ImmutableList<ChildLocation> ChildLocationHistory(
             params (Guid childLocationFamilyId, ChildLocationPlan plan, int month, int day)[] values
         ) =>
             values
@@ -88,7 +88,7 @@ namespace CareTogether.Core.Test.ReferralCalculationTests
                     DateOnly.FromDateTime(DateTime(value.month, value.day)),
                     value.plan == ChildLocationPlan.WithParent
                 ))
-                .ToImmutableSortedSet();
+                .ToImmutableList();
 
         public static ArrangementFunction FunctionWithoutEligibility(
             string arrangementFunction,

--- a/test/Timelines.Test/DateOnlyTimelineTest.cs
+++ b/test/Timelines.Test/DateOnlyTimelineTest.cs
@@ -6,7 +6,9 @@ namespace Timelines.Test;
 public class DateOnlyTimelineTest
 {
     private static DateOnly D(int day) => new(2024, 1, day);
+
     private static DateRange DR(int start, int end) => new(D(start), D(end));
+
     private static DateRange<T> DR<T>(int start, int end, T tag) => new(D(start), D(end), tag);
 
     private static void AssertDatesAre(DateOnlyTimeline dut, params int[] dates)
@@ -16,26 +18,22 @@ public class DateOnlyTimelineTest
             Assert.AreEqual(dates.Contains(i), dut.Contains(D(i)), $"Failed on {i}");
     }
 
-
     [TestMethod]
     public void ConstructorForbidsEmptyList()
     {
-        Assert.ThrowsException<ArgumentException>(() =>
-            new DateOnlyTimeline(ImmutableList<DateRange>.Empty));
+        Assert.ThrowsException<ArgumentException>(() => new DateOnlyTimeline(ImmutableList<DateRange>.Empty));
     }
 
     [TestMethod]
     public void ConstructorForbidsOverlappingRanges()
     {
-        Assert.ThrowsException<ArgumentException>(() =>
-            new DateOnlyTimeline([DR(1, 2), DR(2, 3)]));
+        Assert.ThrowsException<ArgumentException>(() => new DateOnlyTimeline([DR(1, 2), DR(2, 3)]));
     }
 
     [TestMethod]
     public void ConstructorForbidsOverlappingRanges2()
     {
-        Assert.ThrowsException<ArgumentException>(() =>
-            new DateOnlyTimeline([DR(1, 3), DR(2, 4)]));
+        Assert.ThrowsException<ArgumentException>(() => new DateOnlyTimeline([DR(1, 3), DR(2, 4)]));
     }
 
     [TestMethod]
@@ -44,9 +42,23 @@ public class DateOnlyTimelineTest
         var dut = new DateOnlyTimeline([DR(1, 2), DR(3, 4)]);
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 2), DR(3, 4)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 2), DR(3, 4)]));
+    }
+
+    [TestMethod]
+    public void CreateTimelineFromOverlappingDateRanges()
+    {
+        var dut = DateOnlyTimeline.FromOverlappingDateRanges([DR(1, 2), DR(2, 4)]);
+
+        Assert.AreEqual(dut, new DateOnlyTimeline([DR(1, 4)]));
+    }
+
+    [TestMethod]
+    public void CreateTimelineFromOverlappingDateRangesWithNonOverlappingDateRanges()
+    {
+        var dut = DateOnlyTimeline.FromOverlappingDateRanges([DR(1, 2), DR(4, 5)]);
+
+        Assert.AreEqual(dut, new DateOnlyTimeline([DR(1, 2), DR(4, 5)]));
     }
 
     [TestMethod]
@@ -96,9 +108,7 @@ public class DateOnlyTimelineTest
         var result = dut.TakeDays(10);
 
         Assert.IsNotNull(result);
-        Assert.IsTrue(result.Ranges.SequenceEqual([
-            DR(1, 3), DR(5, 6)
-        ]));
+        Assert.IsTrue(result.Ranges.SequenceEqual([DR(1, 3), DR(5, 6)]));
     }
 
     [TestMethod]
@@ -108,9 +118,7 @@ public class DateOnlyTimelineTest
         var result = dut.TakeDays(4);
 
         Assert.IsNotNull(result);
-        Assert.IsTrue(result.Ranges.SequenceEqual([
-            DR(1, 3), DR(5, 5)
-        ]));
+        Assert.IsTrue(result.Ranges.SequenceEqual([DR(1, 3), DR(5, 5)]));
     }
 
     [TestMethod]
@@ -120,9 +128,7 @@ public class DateOnlyTimelineTest
         var result = dut.TakeDays(3);
 
         Assert.IsNotNull(result);
-        Assert.IsTrue(result.Ranges.SequenceEqual([
-            DR(1, 3)
-        ]));
+        Assert.IsTrue(result.Ranges.SequenceEqual([DR(1, 3)]));
     }
 
     [TestMethod]
@@ -136,105 +142,81 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void UnionOfSingleOneDayStage()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            DR(1, 1)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(1, 1)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 1);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1)]));
     }
 
     [TestMethod]
     public void UnionOfMultipleOverlappingOneDayStages()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            DR(1, 1), DR(1, 1)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(1, 1), DR(1, 1)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 1);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1)]));
     }
 
     [TestMethod]
     public void UnionOfTwoContiguousOneDayStages()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            DR(1, 1), DR(2, 2)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(1, 1), DR(2, 2)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 1, 2);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 2)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 2)]));
     }
 
     [TestMethod]
     public void UnionOfOneMultipleDayRange()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            DR(2, 4)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(2, 4)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 2, 3, 4);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(2, 4)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(2, 4)]));
     }
 
     [TestMethod]
     public void UnionOfTwoDiscontinuousMultipleDayRanges()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            DR(2, 3), DR(5, 5), DR(6, 8)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(2, 3), DR(5, 5), DR(6, 8)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 2, 3, 5, 6, 7, 8);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(2, 3), DR(5, 8)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(2, 3), DR(5, 8)]));
     }
 
     [TestMethod]
     public void UnionOfTwoOverlappingMultipleDayRanges()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            DR(2, 5), DR(4, 7)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(2, 5), DR(4, 7)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 2, 3, 4, 5, 6, 7);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(2, 7)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(2, 7)]));
     }
 
     [TestMethod]
     public void UnionOfTwoOverlappingMultipleDayRangesInReverseOrder()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            DR(4, 7), DR(2, 5)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(4, 7), DR(2, 5)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 2, 3, 4, 5, 6, 7);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(2, 7)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(2, 7)]));
     }
 
     [TestMethod]
     public void UnionOfTwoFullyOverlappingMultipleDayRanges()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            DR(2, 7), DR(4, 5)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(2, 7), DR(4, 5)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 2, 3, 4, 5, 6, 7);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(2, 7)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(2, 7)]));
     }
 
     [TestMethod]
@@ -248,8 +230,7 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void UnionOfNullableNullElementReturnsNull()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty
-            .Add(null));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty.Add(null));
 
         Assert.IsNull(dut);
     }
@@ -257,8 +238,7 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void UnionOfNullableNullElementsReturnsNull()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty
-            .AddRange([null, null]));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty.AddRange([null, null]));
 
         Assert.IsNull(dut);
     }
@@ -266,60 +246,50 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void UnionOfNullableSingleOneDayStage()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty
-            .Add(DR(1, 1)));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty.Add(DR(1, 1)));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 1);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1)]));
     }
 
     [TestMethod]
     public void UnionOfNullableSingleOneDayStageWithNulls()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty
-            .AddRange([null, DR(1, 1), null]));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty.AddRange([null, DR(1, 1), null]));
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 1);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1)]));
     }
 
     [TestMethod]
     public void UnionOfNullableTwoDiscontinuousMultipleDayRangesWithNulls()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateRange?>.Empty
-            .AddRange([DR(2, 3), null, null, DR(5, 5), null, null, DR(6, 8), null]));
+        var dut = DateOnlyTimeline.UnionOf(
+            ImmutableList<DateRange?>.Empty.AddRange([DR(2, 3), null, null, DR(5, 5), null, null, DR(6, 8), null])
+        );
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 2, 3, 5, 6, 7, 8);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(2, 3), DR(5, 8)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(2, 3), DR(5, 8)]));
     }
 
     [TestMethod]
     public void UnionOfTwoUnendingRangesReturnsSingleOverlappingRange()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList.Create(
-            new DateRange(D(2), DateOnly.MaxValue),
-            new DateRange(D(4), DateOnly.MaxValue)));
+        var dut = DateOnlyTimeline.UnionOf(
+            ImmutableList.Create(new DateRange(D(2), DateOnly.MaxValue), new DateRange(D(4), DateOnly.MaxValue))
+        );
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(D(2), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([new DateRange(D(2), DateOnly.MaxValue)]));
     }
 
     [TestMethod]
     public void UnionOfTimelinesReturnsNullIfAllNull()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateOnlyTimeline?>.Empty
-            .AddRange([null, null]));
+        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateOnlyTimeline?>.Empty.AddRange([null, null]));
 
         Assert.IsNull(dut);
     }
@@ -327,21 +297,22 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void UnionOfTimelinesReturnsUnionOfAllNonNullRanges()
     {
-        var dut = DateOnlyTimeline.UnionOf(ImmutableList<DateOnlyTimeline?>.Empty
-            .AddRange([
-                null,
-                DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(1, 1))),
-                null,
-                DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(2, 2))),
-                DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(4, 5))),
-                null
-            ]));
+        var dut = DateOnlyTimeline.UnionOf(
+            ImmutableList<DateOnlyTimeline?>.Empty.AddRange(
+                [
+                    null,
+                    DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(1, 1))),
+                    null,
+                    DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(2, 2))),
+                    DateOnlyTimeline.UnionOf(ImmutableList.Create(DR(4, 5))),
+                    null,
+                ]
+            )
+        );
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 1, 2, 4, 5);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 2), DR(4, 5)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 2), DR(4, 5)]));
     }
 
     [TestMethod]
@@ -355,40 +326,35 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void IntersectionOfSingleOneDayTimeline()
     {
-        var dut = DateOnlyTimeline.IntersectionOf(ImmutableList.Create<DateOnlyTimeline?>([
-            new DateOnlyTimeline([DR(1, 1)])
-        ]));
+        var dut = DateOnlyTimeline.IntersectionOf(
+            ImmutableList.Create<DateOnlyTimeline?>([new DateOnlyTimeline([DR(1, 1)])])
+        );
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 1);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1)]));
     }
 
     [TestMethod]
     public void IntersectionOfTwoOverlappingTimelines()
     {
-        var dut = DateOnlyTimeline.IntersectionOf(ImmutableList.Create<DateOnlyTimeline?>([
-            new DateOnlyTimeline([DR(2, 2)]),
-            new DateOnlyTimeline([DR(1, 3)])
-        ]));
+        var dut = DateOnlyTimeline.IntersectionOf(
+            ImmutableList.Create<DateOnlyTimeline?>(
+                [new DateOnlyTimeline([DR(2, 2)]), new DateOnlyTimeline([DR(1, 3)])]
+            )
+        );
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 2);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(2, 2)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(2, 2)]));
     }
 
     [TestMethod]
     public void IntersectionOfTwoOverlappingTimelinesAndNull()
     {
-        var dut = DateOnlyTimeline.IntersectionOf(ImmutableList.Create([
-            new DateOnlyTimeline([DR(2, 2)]),
-            new DateOnlyTimeline([DR(1, 3)]),
-            null
-        ]));
+        var dut = DateOnlyTimeline.IntersectionOf(
+            ImmutableList.Create([new DateOnlyTimeline([DR(2, 2)]), new DateOnlyTimeline([DR(1, 3)]), null])
+        );
 
         Assert.IsNull(dut);
     }
@@ -396,11 +362,11 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void IntersectionOfThreeDisjointTimelines()
     {
-        var dut = DateOnlyTimeline.IntersectionOf(ImmutableList.Create<DateOnlyTimeline?>([
-            new DateOnlyTimeline([DR(2, 2)]),
-            new DateOnlyTimeline([DR(1, 3)]),
-            new DateOnlyTimeline([DR(4, 4)])
-        ]));
+        var dut = DateOnlyTimeline.IntersectionOf(
+            ImmutableList.Create<DateOnlyTimeline?>(
+                [new DateOnlyTimeline([DR(2, 2)]), new DateOnlyTimeline([DR(1, 3)]), new DateOnlyTimeline([DR(4, 4)])]
+            )
+        );
 
         Assert.IsNull(dut);
     }
@@ -408,17 +374,15 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void IntersectionOfThreeOverlappingTimelines()
     {
-        var dut = DateOnlyTimeline.IntersectionOf(ImmutableList.Create<DateOnlyTimeline?>([
-            new DateOnlyTimeline([DR(2, 2)]),
-            new DateOnlyTimeline([DR(1, 3)]),
-            new DateOnlyTimeline([DR(2, 4)])
-        ]));
+        var dut = DateOnlyTimeline.IntersectionOf(
+            ImmutableList.Create<DateOnlyTimeline?>(
+                [new DateOnlyTimeline([DR(2, 2)]), new DateOnlyTimeline([DR(1, 3)]), new DateOnlyTimeline([DR(2, 4)])]
+            )
+        );
 
         Assert.IsNotNull(dut);
         AssertDatesAre(dut, 2);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(2, 2)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(2, 2)]));
     }
 
     [TestMethod]
@@ -460,9 +424,7 @@ public class DateOnlyTimelineTest
 
         Assert.IsNotNull(intersection);
         AssertDatesAre(intersection, 3, 4);
-        Assert.IsTrue(intersection.Ranges.SequenceEqual([
-            DR(3, 4)
-        ]));
+        Assert.IsTrue(intersection.Ranges.SequenceEqual([DR(3, 4)]));
     }
 
     public void IntersectionWithDisjointDateRangeReturnsNull()
@@ -483,9 +445,7 @@ public class DateOnlyTimelineTest
 
         Assert.IsNotNull(intersection);
         AssertDatesAre(intersection, 3);
-        Assert.IsTrue(intersection.Ranges.SequenceEqual([
-            DR(3, 3)
-        ]));
+        Assert.IsTrue(intersection.Ranges.SequenceEqual([DR(3, 3)]));
     }
 
     [TestMethod]
@@ -494,17 +454,13 @@ public class DateOnlyTimelineTest
         var dut = DateOnlyTimeline.ComplementOf(null);
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(DateOnly.MinValue, DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([new DateRange(DateOnly.MinValue, DateOnly.MaxValue)]));
     }
 
     [TestMethod]
     public void ComplementOfAllOfTimeIsNull()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(DateOnly.MinValue, DateOnly.MaxValue)
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(DateOnly.MinValue, DateOnly.MaxValue)]);
         var dut = DateOnlyTimeline.ComplementOf(input);
 
         Assert.IsNull(dut);
@@ -513,9 +469,7 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void ComplementOfAllOfTimeIsNullViaInstanceMethod()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(DateOnly.MinValue, DateOnly.MaxValue)
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(DateOnly.MinValue, DateOnly.MaxValue)]);
         var dut = input.Complement();
 
         Assert.IsNull(dut);
@@ -524,114 +478,97 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void ComplementOfSingleRangeIsTwoRanges()
     {
-        var input = new DateOnlyTimeline([
-            DR(1, 3)
-        ]);
+        var input = new DateOnlyTimeline([DR(1, 3)]);
         var dut = input.Complement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(DateOnly.MinValue, D(1).AddDays(-1)),
-            new DateRange(D(3).AddDays(1), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(
+            dut.Ranges.SequenceEqual(
+                [new DateRange(DateOnly.MinValue, D(1).AddDays(-1)), new DateRange(D(3).AddDays(1), DateOnly.MaxValue)]
+            )
+        );
     }
 
     [TestMethod]
     public void ComplementOfTwoRangesIsThreeRanges()
     {
-        var input = new DateOnlyTimeline([
-            DR(1, 3), DR(5, 5)
-        ]);
+        var input = new DateOnlyTimeline([DR(1, 3), DR(5, 5)]);
         var dut = input.Complement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(DateOnly.MinValue, D(1).AddDays(-1)),
-            new DateRange(D(3).AddDays(1), D(5).AddDays(-1)),
-            new DateRange(D(5).AddDays(1), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(
+            dut.Ranges.SequenceEqual(
+                [
+                    new DateRange(DateOnly.MinValue, D(1).AddDays(-1)),
+                    new DateRange(D(3).AddDays(1), D(5).AddDays(-1)),
+                    new DateRange(D(5).AddDays(1), DateOnly.MaxValue),
+                ]
+            )
+        );
     }
 
     [TestMethod]
     public void ComplementOfTwoAdjacentRangesIsTwoRanges()
     {
-        var input = new DateOnlyTimeline([
-            DR(1, 3), DR(4, 5)
-        ]);
+        var input = new DateOnlyTimeline([DR(1, 3), DR(4, 5)]);
         var dut = input.Complement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(DateOnly.MinValue, D(1).AddDays(-1)),
-            new DateRange(D(5).AddDays(1), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(
+            dut.Ranges.SequenceEqual(
+                [new DateRange(DateOnly.MinValue, D(1).AddDays(-1)), new DateRange(D(5).AddDays(1), DateOnly.MaxValue)]
+            )
+        );
     }
 
     [TestMethod]
     public void ComplementOfRangeBeforeBeginningOfTimeDoesNotExist()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(DateOnly.MinValue, D(3))
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(DateOnly.MinValue, D(3))]);
         var dut = input.Complement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(D(3).AddDays(1), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([new DateRange(D(3).AddDays(1), DateOnly.MaxValue)]));
     }
 
     [TestMethod]
     public void ComplementOfRangeAfterEndOfTimeDoesNotExist()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(D(1), DateOnly.MaxValue)
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(D(1), DateOnly.MaxValue)]);
         var dut = input.Complement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(DateOnly.MinValue, D(1).AddDays(-1))
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([new DateRange(DateOnly.MinValue, D(1).AddDays(-1))]));
     }
 
     [TestMethod]
     public void ComplementOfSecondRangeAfterEndOfTimeDoesNotExist()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(D(1), D(3)),
-            new DateRange(D(4), DateOnly.MaxValue)
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(D(1), D(3)), new DateRange(D(4), DateOnly.MaxValue)]);
         var dut = input.Complement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(DateOnly.MinValue, D(1).AddDays(-1))
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([new DateRange(DateOnly.MinValue, D(1).AddDays(-1))]));
     }
 
     [TestMethod]
     public void ComplementOfSecondRangeAfterEndOfTimeDoesNotExist2()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(D(1), D(2)),
-            new DateRange(D(4), DateOnly.MaxValue)
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(D(1), D(2)), new DateRange(D(4), DateOnly.MaxValue)]);
         var dut = input.Complement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(DateOnly.MinValue, D(1).AddDays(-1)),
-            new DateRange(D(2).AddDays(1), D(4).AddDays(-1))
-        ]));
+        Assert.IsTrue(
+            dut.Ranges.SequenceEqual(
+                [new DateRange(DateOnly.MinValue, D(1).AddDays(-1)), new DateRange(D(2).AddDays(1), D(4).AddDays(-1))]
+            )
+        );
     }
 
     [TestMethod]
     public void ForwardOnlyComplementOfAllOfTimeIsNull()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(DateOnly.MinValue, DateOnly.MaxValue)
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(DateOnly.MinValue, DateOnly.MaxValue)]);
         var dut = input.ForwardOnlyComplement();
 
         Assert.IsNull(dut);
@@ -640,68 +577,55 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void ForwardOnlyComplementOfSingleRangeIsOneRange()
     {
-        var input = new DateOnlyTimeline([
-            DR(1, 3)
-        ]);
+        var input = new DateOnlyTimeline([DR(1, 3)]);
         var dut = input.ForwardOnlyComplement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(D(3).AddDays(1), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([new DateRange(D(3).AddDays(1), DateOnly.MaxValue)]));
     }
 
     [TestMethod]
     public void ForwardOnlyComplementOfTwoRangesIsTwoRanges()
     {
-        var input = new DateOnlyTimeline([
-            DR(1, 3), DR(5, 5)
-        ]);
+        var input = new DateOnlyTimeline([DR(1, 3), DR(5, 5)]);
         var dut = input.ForwardOnlyComplement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(D(3).AddDays(1), D(5).AddDays(-1)),
-            new DateRange(D(5).AddDays(1), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(
+            dut.Ranges.SequenceEqual(
+                [new DateRange(D(3).AddDays(1), D(5).AddDays(-1)), new DateRange(D(5).AddDays(1), DateOnly.MaxValue)]
+            )
+        );
     }
 
     [TestMethod]
     public void ForwardOnlyComplementOfTwoAdjacentRangesIsOneRange()
     {
-        var input = new DateOnlyTimeline([
-            DR(1, 3), DR(4, 5)
-        ]);
+        var input = new DateOnlyTimeline([DR(1, 3), DR(4, 5)]);
         var dut = input.ForwardOnlyComplement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(D(5).AddDays(1), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([new DateRange(D(5).AddDays(1), DateOnly.MaxValue)]));
     }
 
     [TestMethod]
     public void ForwardOnlyComplementOfRangeBeforeBeginningOfTimeDoesNotExist()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(DateOnly.MinValue, D(3)),
-            new DateRange(D(5), D(7))
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(DateOnly.MinValue, D(3)), new DateRange(D(5), D(7))]);
         var dut = input.ForwardOnlyComplement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(D(3).AddDays(1), D(5).AddDays(-1)),
-            new DateRange(D(7).AddDays(1), DateOnly.MaxValue)
-        ]));
+        Assert.IsTrue(
+            dut.Ranges.SequenceEqual(
+                [new DateRange(D(3).AddDays(1), D(5).AddDays(-1)), new DateRange(D(7).AddDays(1), DateOnly.MaxValue)]
+            )
+        );
     }
 
     [TestMethod]
     public void ForwardOnlyComplementOfRangeAfterEndOfTimeDoesNotExist()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(D(1), DateOnly.MaxValue)
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(D(1), DateOnly.MaxValue)]);
         var dut = input.ForwardOnlyComplement();
 
         Assert.IsNull(dut);
@@ -710,16 +634,11 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void ForwardOnlyComplementOfSecondRangeAfterEndOfTimeDoesNotExist()
     {
-        var input = new DateOnlyTimeline([
-            new DateRange(D(1), D(2)),
-            new DateRange(D(4), DateOnly.MaxValue)
-        ]);
+        var input = new DateOnlyTimeline([new DateRange(D(1), D(2)), new DateRange(D(4), DateOnly.MaxValue)]);
         var dut = input.ForwardOnlyComplement();
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            new DateRange(D(2).AddDays(1), D(4).AddDays(-1))
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([new DateRange(D(2).AddDays(1), D(4).AddDays(-1))]));
     }
 
     [TestMethod]
@@ -729,18 +648,14 @@ public class DateOnlyTimelineTest
         var dut = input.Difference(null);
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1), DR(3, 4)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1), DR(3, 4)]));
     }
 
     [TestMethod]
     public void DifferenceWithAllOfTimeReturnsNull()
     {
         var input = new DateOnlyTimeline([DR(1, 1), DR(3, 4)]);
-        var dut = input.Difference(new DateOnlyTimeline([
-            new DateRange(DateOnly.MinValue, DateOnly.MaxValue)
-        ]));
+        var dut = input.Difference(new DateOnlyTimeline([new DateRange(DateOnly.MinValue, DateOnly.MaxValue)]));
 
         Assert.IsNull(dut);
     }
@@ -752,9 +667,7 @@ public class DateOnlyTimelineTest
         var dut = input.Difference(new DateOnlyTimeline([DR(5, 7)]));
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1), DR(3, 4)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1), DR(3, 4)]));
     }
 
     [TestMethod]
@@ -764,9 +677,7 @@ public class DateOnlyTimelineTest
         var dut = input.Difference(new DateOnlyTimeline([DR(4, 7)]));
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1), DR(3, 3)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1), DR(3, 3)]));
     }
 
     [TestMethod]
@@ -776,9 +687,7 @@ public class DateOnlyTimelineTest
         var dut = input.Difference(new DateOnlyTimeline([DR(2, 7)]));
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 1)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 1)]));
     }
 
     [TestMethod]
@@ -788,9 +697,7 @@ public class DateOnlyTimelineTest
         var dut = input.Difference(new DateOnlyTimeline([DR(1, 3)]));
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(4, 4)
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(4, 4)]));
     }
 
     [TestMethod]
@@ -866,22 +773,21 @@ public class DateOnlyTimelineTest
     [TestMethod]
     public void TaggedConstructorForbidsEmptyList()
     {
-        Assert.ThrowsException<ArgumentException>(() =>
-            new DateOnlyTimeline<char>(ImmutableList<DateRange<char>>.Empty));
+        Assert.ThrowsException<ArgumentException>(
+            () => new DateOnlyTimeline<char>(ImmutableList<DateRange<char>>.Empty)
+        );
     }
 
     [TestMethod]
     public void TaggedConstructorForbidsOverlappingRanges()
     {
-        Assert.ThrowsException<ArgumentException>(() =>
-            new DateOnlyTimeline<char>([DR(1, 2, 'A'), DR(2, 3, 'A')]));
+        Assert.ThrowsException<ArgumentException>(() => new DateOnlyTimeline<char>([DR(1, 2, 'A'), DR(2, 3, 'A')]));
     }
 
     [TestMethod]
     public void TaggedConstructorForbidsOverlappingRanges2()
     {
-        Assert.ThrowsException<ArgumentException>(() =>
-            new DateOnlyTimeline<char>([DR(1, 3, 'A'), DR(2, 4, 'A')]));
+        Assert.ThrowsException<ArgumentException>(() => new DateOnlyTimeline<char>([DR(1, 3, 'A'), DR(2, 4, 'A')]));
     }
 
     [TestMethod]
@@ -890,9 +796,7 @@ public class DateOnlyTimelineTest
         var dut = new DateOnlyTimeline<char>([DR(1, 2, 'A'), DR(3, 4, 'B')]);
 
         Assert.IsNotNull(dut);
-        Assert.IsTrue(dut.Ranges.SequenceEqual([
-            DR(1, 2, 'A'), DR(3, 4, 'B')
-        ]));
+        Assert.IsTrue(dut.Ranges.SequenceEqual([DR(1, 2, 'A'), DR(3, 4, 'B')]));
     }
 
     [DataRow(1, default(char))]


### PR DESCRIPTION
When multiple location changes happens without a pause in the middle (when the child goes to the parent), the calculation ignores the subsequential locations and only calculates the due dates for the first location. This PR changes that so all location changes are taken into account.

Changes in code style were made by csharpier.