### PR TITLE
PostHog.Identify(), unmask some UI components, and mask all events by default

### DIFF
--- a/src/b2c/CustomPolicies/Dev/SignUpOrSignin.xml
+++ b/src/b2c/CustomPolicies/Dev/SignUpOrSignin.xml
@@ -26,7 +26,9 @@
         <OutputClaim ClaimTypeReferenceId="displayName" />
         <OutputClaim ClaimTypeReferenceId="givenName" />
         <OutputClaim ClaimTypeReferenceId="surname" />
-        <OutputClaim ClaimTypeReferenceId="email" />
+        <!-- <OutputClaim ClaimTypeReferenceId="email" /> -->
+        <!-- Temporary workaround for missing email claims -->
+        <OutputClaim ClaimTypeReferenceId="signInNames.emailAddress" PartnerClaimType="email" />
         <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub"/>
         <OutputClaim ClaimTypeReferenceId="identityProvider" />
         <OutputClaim ClaimTypeReferenceId="tenantId" AlwaysUseDefaultValue="true" DefaultValue="{Policy:TenantObjectId}" />

--- a/src/caretogether-pwa/src/AppRoutes.tsx
+++ b/src/caretogether-pwa/src/AppRoutes.tsx
@@ -27,11 +27,8 @@ import { useLocalStorage } from './Hooks/useLocalStorage';
 import { InboxScreen } from './Inbox/InboxScreen';
 import { FamilyScreenV2 } from './Families/FamilyScreenV2';
 import { familyScreenV2State } from './Families/familyScreenV2State';
-import posthog from 'posthog-js';
-import {
-  locationConfigurationQuery,
-  organizationConfigurationQuery,
-} from './Model/ConfigurationModel';
+import { usePostHogIdentify } from './Utilities/Instrumentation/usePostHogIdentify';
+import { usePostHogGroups } from './Utilities/Instrumentation/usePostHogGroups';
 
 const LAST_VISITED_LOCATION = 'lastVisitedLocation';
 
@@ -146,24 +143,9 @@ function LocationContextWrapper() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organizationId, locationId, trace, setSelectedLocationContext]);
 
-  const organizationConfiguration = useLoadable(organizationConfigurationQuery);
-  const locationConfiguration = useLoadable(locationConfigurationQuery);
+  usePostHogGroups();
 
-  useEffect(() => {
-    if (organizationId && locationId) {
-      posthog.group('organization', organizationId, {
-        name: organizationConfiguration?.organizationName,
-      });
-      posthog.group('location', locationId, {
-        name: locationConfiguration?.name,
-      });
-    }
-  }, [
-    organizationId,
-    locationId,
-    organizationConfiguration?.organizationName,
-    locationConfiguration?.name,
-  ]);
+  usePostHogIdentify();
 
   return (
     // We need to wait for this to have a value before rendering the child tree; otherwise,

--- a/src/caretogether-pwa/src/Authentication/AuthenticationWrapper.tsx
+++ b/src/caretogether-pwa/src/Authentication/AuthenticationWrapper.tsx
@@ -1,14 +1,14 @@
 import React, { Suspense } from 'react';
 import { ProgressBackdrop } from '../Shell/ProgressBackdrop';
 import { useScopedTrace } from '../Hooks/useScopedTrace';
-import { userIdState } from '../Authentication/Auth';
+import { accountInfoState } from '../Authentication/Auth';
 import { useLoadable } from '../Hooks/useLoadable';
 
 function AuthenticatedUserWrapper({ children }: React.PropsWithChildren) {
   const trace = useScopedTrace('AuthenticatedUserWrapper');
 
-  // This will suspend until a user ID has been set by the `userIdState` initialization logic.
-  const userId = useLoadable(userIdState);
+  // This will suspend until a user ID has been set by the `accountInfoState` initialization logic.
+  const userId = useLoadable(accountInfoState)?.userId;
   trace(`userId: ${userId}`);
 
   return <>{userId ? children : <></>}</>;

--- a/src/caretogether-pwa/src/Model/Data.tsx
+++ b/src/caretogether-pwa/src/Model/Data.tsx
@@ -7,16 +7,16 @@ import {
   RecordsAggregate,
 } from '../GeneratedClient';
 import { loggingEffect } from '../Utilities/loggingEffect';
-import { userIdState } from '../Authentication/Auth';
+import { accountInfoState } from '../Authentication/Auth';
 
-// This will be available to query (asynchronously) after the userIdState is set (i.e., post-authentication).
+// This will be available to query (asynchronously) after the accountInfoState is set (i.e., post-authentication).
 export const userOrganizationAccessQuery = selector({
   key: 'userOrganizationAccessQuery',
   get: async ({ get }) => {
     //HACK: Requiring the user ID state to be set is a workaround for fall-through issues with the AuthenticationWrapper
     //      and AuthenticatedUserWrapper. Removing this currently would cause runtime errors regarding the MsalProvider
     //      being updated while a child component is being rendered (e.g., the ShellContextSwitcher).
-    get(userIdState);
+    get(accountInfoState);
     const userResponse = await api.users.getUserOrganizationAccess();
     return userResponse;
   },

--- a/src/caretogether-pwa/src/Shell/ListItemLink.tsx
+++ b/src/caretogether-pwa/src/Shell/ListItemLink.tsx
@@ -18,6 +18,7 @@ interface ListItemLinkProps {
   to: string;
   newTab?: boolean;
   darkColor?: boolean;
+  className?: string;
 }
 
 function ListItemLink(props: ListItemLinkProps) {
@@ -44,7 +45,7 @@ function ListItemLink(props: ListItemLinkProps) {
   );
 
   return (
-    <li>
+    <li className={props.className}>
       <ListItem
         button
         component={renderLink}

--- a/src/caretogether-pwa/src/Shell/ShellContextSwitcher.tsx
+++ b/src/caretogether-pwa/src/Shell/ShellContextSwitcher.tsx
@@ -48,6 +48,7 @@ export function ShellContextSwitcher() {
     <Stack sx={{ position: 'absolute' }}>
       {organizationConfiguration ? (
         <Typography
+          className="ph-unmask"
           variant="subtitle1"
           component="h1"
           sx={{ position: 'relative', top: -4, left: 8 }}
@@ -68,6 +69,7 @@ export function ShellContextSwitcher() {
       selectedLocationContext ? (
         availableLocations.length >= 1 ? (
           <Select
+            className="ph-unmask"
             size={isDesktop ? 'small' : 'medium'}
             variant="outlined"
             sx={{

--- a/src/caretogether-pwa/src/Shell/ShellSideNavigation.tsx
+++ b/src/caretogether-pwa/src/Shell/ShellSideNavigation.tsx
@@ -76,11 +76,13 @@ function SideNavigationMenu({ open }: SideNavigationMenuProps) {
       ) : (
         <>
           <ListItemLink
+            className="ph-unmask"
             to={`${locationPrefix}`}
             primary="Dashboard"
             icon={<DashboardIcon sx={{ color: '#fff8' }} />}
           />
           <ListItemLink
+            className="ph-unmask"
             to={`${locationPrefix}/inbox`}
             primary="Inbox"
             icon={
@@ -91,6 +93,7 @@ function SideNavigationMenu({ open }: SideNavigationMenuProps) {
           />
           {permissions(Permission.AccessPartneringFamiliesScreen) && (
             <ListItemLink
+              className="ph-unmask"
               to={`${locationPrefix}/referrals`}
               primary="Referrals"
               icon={<PermPhoneMsgIcon sx={{ color: '#fff8' }} />}
@@ -98,6 +101,7 @@ function SideNavigationMenu({ open }: SideNavigationMenuProps) {
           )}
           {permissions(Permission.AccessVolunteersScreen) && (
             <ListItemLink
+              className="ph-unmask"
               to={`${locationPrefix}/volunteers`}
               primary="Volunteers"
               icon={<PeopleIcon sx={{ color: '#fff8' }} />}
@@ -105,6 +109,7 @@ function SideNavigationMenu({ open }: SideNavigationMenuProps) {
           )}
           {permissions(Permission.AccessCommunitiesScreen) && (
             <ListItemLink
+              className="ph-unmask"
               to={`${locationPrefix}/communities`}
               primary="Communities"
               icon={<Diversity3Icon sx={{ color: '#fff8' }} />}
@@ -114,11 +119,13 @@ function SideNavigationMenu({ open }: SideNavigationMenuProps) {
             <>
               <Divider />
               <ListItemLink
+                className="ph-unmask"
                 to={`${locationPrefix}/settings`}
                 primary="Settings"
                 icon={<SettingsIcon sx={{ color: '#fff8' }} />}
               />
               <ListItemLink
+                className="ph-unmask"
                 to="http://support.caretogether.io"
                 newTab
                 primary="Support"

--- a/src/caretogether-pwa/src/Utilities/Instrumentation/postHogOptions.ts
+++ b/src/caretogether-pwa/src/Utilities/Instrumentation/postHogOptions.ts
@@ -1,0 +1,21 @@
+import { PostHogConfig } from 'posthog-js';
+
+export const postHogOptions: Partial<PostHogConfig> = {
+  session_recording: {
+    // `maskTextFn` only applies to selected elements, so make sure to set to "*" if you want this to work globally.
+    maskTextSelector: '*',
+    maskTextFn: (text, element) => {
+      // To unmask text in a specific element, add the class `ph-unmask` to that element or the closest possible parent.
+      // Sometimes adding the class to the element itself is difficult due to how the 3rd party component was implemented,
+      // so you may need to add it to a parent.
+      // Adding it to an element too high up in the DOM tree may unmask more text than you want and cause performance issues,
+      // as the browser will have to work more to find an element with that class in the elements tree.
+      if (element?.closest('.ph-unmask') !== null) {
+        return text;
+      }
+
+      return '*'.repeat(text.length);
+    },
+  },
+  mask_all_text: true,
+};

--- a/src/caretogether-pwa/src/Utilities/Instrumentation/usePostHogGroups.ts
+++ b/src/caretogether-pwa/src/Utilities/Instrumentation/usePostHogGroups.ts
@@ -17,10 +17,13 @@ export const usePostHogGroups = () => {
   const locationConfiguration = useLoadable(locationConfigurationQuery);
 
   useEffect(() => {
-    if (organizationId && locationId) {
+    if (organizationId) {
       posthog.group('organization', organizationId, {
         name: organizationConfiguration?.organizationName,
       });
+    }
+
+    if (organizationId && locationId) {
       posthog.group('location', locationId, {
         name: locationConfiguration?.name,
       });

--- a/src/caretogether-pwa/src/Utilities/Instrumentation/usePostHogGroups.ts
+++ b/src/caretogether-pwa/src/Utilities/Instrumentation/usePostHogGroups.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useLoadable } from '../../Hooks/useLoadable';
+import posthog from 'posthog-js';
+import {
+  locationConfigurationQuery,
+  organizationConfigurationQuery,
+} from '../../Model/ConfigurationModel';
+import { useParams } from 'react-router-dom';
+
+export const usePostHogGroups = () => {
+  const { organizationId, locationId } = useParams<{
+    organizationId: string;
+    locationId: string;
+  }>();
+
+  const organizationConfiguration = useLoadable(organizationConfigurationQuery);
+  const locationConfiguration = useLoadable(locationConfigurationQuery);
+
+  useEffect(() => {
+    if (organizationId && locationId) {
+      posthog.group('organization', organizationId, {
+        name: organizationConfiguration?.organizationName,
+      });
+      posthog.group('location', locationId, {
+        name: locationConfiguration?.name,
+      });
+    }
+  }, [
+    organizationId,
+    locationId,
+    organizationConfiguration?.organizationName,
+    locationConfiguration?.name,
+  ]);
+};

--- a/src/caretogether-pwa/src/Utilities/Instrumentation/usePostHogIdentify.ts
+++ b/src/caretogether-pwa/src/Utilities/Instrumentation/usePostHogIdentify.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { accountInfoState } from '../../Authentication/Auth';
+import { useLoadable } from '../../Hooks/useLoadable';
+import posthog from 'posthog-js';
+
+export const usePostHogIdentify = () => {
+  const accountInfo = useLoadable(accountInfoState);
+
+  // Passing the properties to the deps array avoids calling the effect twice.
+  useEffect(() => {
+    if (accountInfo?.userId) {
+      posthog.identify(accountInfo.userId, {
+        email: accountInfo.email,
+        name: accountInfo.name,
+      });
+    }
+  }, [accountInfo?.userId, accountInfo?.email, accountInfo?.name]);
+};

--- a/src/caretogether-pwa/src/Utilities/instrumentation.ts
+++ b/src/caretogether-pwa/src/Utilities/instrumentation.ts
@@ -1,5 +1,0 @@
-export const postHogOptions = {
-  session_recording: {
-    maskTextSelector: '*',
-  },
-};

--- a/src/caretogether-pwa/src/main.tsx
+++ b/src/caretogether-pwa/src/main.tsx
@@ -16,7 +16,7 @@ import RequestBackdrop from './Shell/RequestBackdrop';
 import { ProgressBackdrop } from './Shell/ProgressBackdrop';
 
 import { PostHogProvider } from 'posthog-js/react';
-import { postHogOptions } from './Utilities/instrumentation';
+import { postHogOptions } from './Utilities/Instrumentation/postHogOptions';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement


### PR DESCRIPTION
This PR ended up tackling multiple subjects:

- Identify users with id, email and name from Azure AD
  - The email is not returning even after adding the scope, not sure why
- Move posthog instrumentation to custom hooks to keep AppRoutes component clean
- Mask all text sent to posthog (`mask_all_text: true`), before only the session recordings text was masked
- Implement an unmasking pattern with css class