### PR TITLE
Exemption fix

### DIFF
--- a/src/caretogether-pwa/src/Model/ReferralsModel.ts
+++ b/src/caretogether-pwa/src/Model/ReferralsModel.ts
@@ -55,6 +55,7 @@ import {
 } from '../GeneratedClient';
 import { useAtomicRecordsCommandCallback } from './DirectoryModel';
 import { visibleFamiliesQuery } from './Data';
+import { convertUtcDateToLocalDate } from '../Utilities/dateUtils';
 
 export const partneringFamiliesData = selector({
   key: 'partneringFamiliesData',
@@ -243,6 +244,8 @@ export function useReferralsModel() {
         additionalComments: string,
         exemptionExpiresAtLocal: Date | null
       ) => {
+        const dueDateUtc = requirement.dueBy || requirement.pastDueSince;
+
         const command = new ExemptArrangementRequirement({
           familyId: partneringFamilyId,
           referralId: referralId,
@@ -251,7 +254,7 @@ export function useReferralsModel() {
         command.requirementName = requirement.actionName;
         command.dueDate = exemptAll
           ? undefined
-          : requirement.dueBy || requirement.pastDueSince;
+          : dueDateUtc && convertUtcDateToLocalDate(dueDateUtc);
         command.additionalComments = additionalComments;
         command.exemptionExpiresAtUtc = exemptionExpiresAtLocal ?? undefined;
         return command;

--- a/src/caretogether-pwa/src/Model/ReferralsModel.ts
+++ b/src/caretogether-pwa/src/Model/ReferralsModel.ts
@@ -344,6 +344,8 @@ export function useReferralsModel() {
         additionalComments: string,
         exemptionExpiresAtLocal: Date | null
       ) => {
+        const dueDateUtc = requirement.dueBy || requirement.pastDueSince;
+
         const command = new ExemptVolunteerFamilyAssignmentRequirement({
           familyId: partneringFamilyId,
           referralId: referralId,
@@ -356,7 +358,7 @@ export function useReferralsModel() {
         command.requirementName = requirement.actionName;
         command.dueDate = exemptAll
           ? undefined
-          : requirement.dueBy || requirement.pastDueSince;
+          : dueDateUtc && convertUtcDateToLocalDate(dueDateUtc);
         command.additionalComments = additionalComments;
         command.exemptionExpiresAtUtc = exemptionExpiresAtLocal ?? undefined;
         return command;

--- a/src/caretogether-pwa/src/Requirements/CompletedRequirementRow.tsx
+++ b/src/caretogether-pwa/src/Requirements/CompletedRequirementRow.tsx
@@ -13,6 +13,7 @@ import { PersonName } from '../Families/PersonName';
 import { IconRow } from '../Generic/IconRow';
 import { CompletedRequirementDialog } from './CompletedRequirementDialog';
 import { RequirementContext } from './RequirementContext';
+import { formatUtcDateOnly } from '../Utilities/dateUtils';
 
 type CompletedRequirementRowProps = {
   requirement: CompletedRequirementInfo;
@@ -44,8 +45,6 @@ export function CompletedRequirementRow({
         ? permissions(Permission.EditArrangementRequirementCompletion)
         : permissions(Permission.EditApprovalRequirementCompletion);
 
-  const dateFormat = 'M/d/yy';
-
   const familyLookup = useFamilyLookup();
   const personLookup = usePersonLookup();
 
@@ -68,7 +67,7 @@ export function CompletedRequirementRow({
               {requirement.requirementName}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               {requirement.completedAtUtc && (
                 <span style={{ float: 'right' }}>
-                  {format(requirement.completedAtUtc, dateFormat)}
+                  {formatUtcDateOnly(requirement.completedAtUtc)}
                 </span>
               )}
             </span>
@@ -77,10 +76,10 @@ export function CompletedRequirementRow({
                 <br />
                 <span style={{ paddingLeft: '30px' }}>
                   {requirement.expiresAtUtc > new Date() ? (
-                    `⏰ Expires ${format(requirement.expiresAtUtc, dateFormat)}`
+                    `⏰ Expires ${formatUtcDateOnly(requirement.expiresAtUtc)}`
                   ) : (
                     <span style={{ fontWeight: 'bold' }}>
-                      ⚠ Expired {format(requirement.expiresAtUtc, dateFormat)}
+                      ⚠ Expired {formatUtcDateOnly(requirement.expiresAtUtc)}
                     </span>
                   )}
                 </span>

--- a/src/caretogether-pwa/src/Requirements/ExemptedRequirementRow.tsx
+++ b/src/caretogether-pwa/src/Requirements/ExemptedRequirementRow.tsx
@@ -15,6 +15,7 @@ import { ExemptedRequirementDialog } from './ExemptedRequirementDialog';
 import { RequirementContext } from './RequirementContext';
 import { useRecoilValue } from 'recoil';
 import { policyData } from '../Model/ConfigurationModel';
+import { formatUtcDateOnly } from '../Utilities/dateUtils';
 
 type ExemptedRequirementRowProps = {
   requirement: ExemptedRequirementInfo;
@@ -99,6 +100,7 @@ export function ExemptedRequirementRow({
                 <span style={{ fontWeight: 'bold' }}>All&nbsp;</span>
               )}
               {requirement.requirementName}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+              {requirement.dueDate && formatUtcDateOnly(requirement.dueDate)}
               {requirement.exemptionExpiresAtUtc && (
                 <span style={{ float: 'right' }}>
                   until {format(requirement.exemptionExpiresAtUtc, 'M/d/yy')}

--- a/src/caretogether-pwa/src/Requirements/ExemptedRequirementRow.tsx
+++ b/src/caretogether-pwa/src/Requirements/ExemptedRequirementRow.tsx
@@ -100,7 +100,11 @@ export function ExemptedRequirementRow({
                 <span style={{ fontWeight: 'bold' }}>All&nbsp;</span>
               )}
               {requirement.requirementName}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              {requirement.dueDate && formatUtcDateOnly(requirement.dueDate)}
+              {requirement.dueDate && (
+                <span style={{ float: 'right' }}>
+                  {formatUtcDateOnly(requirement.dueDate)}
+                </span>
+              )}
               {requirement.exemptionExpiresAtUtc && (
                 <span style={{ float: 'right' }}>
                   until {format(requirement.exemptionExpiresAtUtc, 'M/d/yy')}

--- a/src/caretogether-pwa/src/Utilities/dateUtils.tsx
+++ b/src/caretogether-pwa/src/Utilities/dateUtils.tsx
@@ -5,3 +5,14 @@ export function formatUtcDateOnly(input: Date) {
     timeZone: 'UTC',
   }).format(input);
 }
+
+export function convertUtcDateToLocalDate(input: Date) {
+  return new Date(
+    input.getUTCFullYear(),
+    input.getUTCMonth(),
+    input.getUTCDate(),
+    input.getUTCHours(),
+    input.getUTCMinutes(),
+    input.getUTCSeconds()
+  );
+}

--- a/src/caretogether-pwa/src/Utilities/dateUtils.tsx
+++ b/src/caretogether-pwa/src/Utilities/dateUtils.tsx
@@ -3,6 +3,9 @@ export function formatUtcDateOnly(input: Date) {
   // 2025-11-22T00:00:00.000Z will output 11/22/2025, independently of browser's time zone
   return new Intl.DateTimeFormat('en-US', {
     timeZone: 'UTC',
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
   }).format(input);
 }
 


### PR DESCRIPTION
This fixes a bug where a missing requirement was still showing, even if it was exempted.

This scenario explains the problem:
  - Missing requirement completion with date 1/1/25 UTC. We show this date on UI as is, without converting to local time, which in probably all cases (because customers are in US) would show 12/31/24.
  - Marking it as exempted sends the exemption date as 1/1/25 12AM to server, when it should send 1/1/25 5AM (in case customer's time is EST)
  - When the server calculates missing dates, it converts the UTC dates to customers local time (based on `location.timeZone`, which defaults to EST)
  - So the exempted date ends up being 12/31/24, which don't match the missing date.

So the solution was to convert the date to local time before sending to server.

The completion works fine because the date is set from a datepicker, so it's already the local date. In the exemption, we were just getting the UTC date that was sent from the server before.

I will review the other functions as `exemptVolunteerFamilyAssignmentRequirement` to implement the same fix.

Before:

![image](https://github.com/user-attachments/assets/d08b748b-2b6f-4323-b9eb-3570068121cc)

After:

![image](https://github.com/user-attachments/assets/899dc9a6-03b2-4b6f-92b7-882f06f6d810)

## Other changes

Also added the exempted date to the UI, and standardized date format to dd/mm/yy.

## Follow up

What should we do with existing exempted dates? 