### PR TITLE
Add LocationUsers to OData controller

### DIFF
--- a/src/CareTogether.Api/OData/LiveODataModelController.cs
+++ b/src/CareTogether.Api/OData/LiveODataModelController.cs
@@ -521,10 +521,8 @@ namespace CareTogether.Api.OData
                     )
                 )
                 .WhenAll()
-                .Result.Select(item => new LocationUserAccess(
-                    item.userId ?? Guid.Empty,
-                    item.locationId
-                ));
+                .Result.Where(item => item.userId != null)
+                .Select(item => new LocationUserAccess(item.userId ?? Guid.Empty, item.locationId));
 
             var communitiesWithInfo = communitiesByLocation
                 .Select(x => RenderCommunity(x.location, x.Item2.Community))

--- a/src/CareTogether.Api/OData/ODataModelProvider.cs
+++ b/src/CareTogether.Api/OData/ODataModelProvider.cs
@@ -12,7 +12,7 @@ namespace CareTogether.Api.OData
             builder.ContainerName = "CareTogether Data";
 
             builder.EntitySet<Location>("Location");
-            builder.EntitySet<LocationUsers>("LocationUsers");
+            builder.EntitySet<LocationUserAccess>("LocationUserAccess");
             builder.EntitySet<Family>("Family");
             builder.EntitySet<Person>("Person");
             builder.EntitySet<Role>("Role");

--- a/src/CareTogether.Api/OData/ODataModelProvider.cs
+++ b/src/CareTogether.Api/OData/ODataModelProvider.cs
@@ -12,6 +12,7 @@ namespace CareTogether.Api.OData
             builder.ContainerName = "CareTogether Data";
 
             builder.EntitySet<Location>("Location");
+            builder.EntitySet<LocationUsers>("LocationUsers");
             builder.EntitySet<Family>("Family");
             builder.EntitySet<Person>("Person");
             builder.EntitySet<Role>("Role");

--- a/src/caretogether-pwa/src/GeneratedClient.ts
+++ b/src/caretogether-pwa/src/GeneratedClient.ts
@@ -953,10 +953,6 @@ export class MetadataClient {
         this.baseUrl = baseUrl ?? "";
     }
 
-    /**
-     * Generates the OData $metadata document.
-     * @return The IEdmModel representing $metadata.
-     */
     getMetadata(): Promise<IEdmModel> {
         let url_ = this.baseUrl + "/api/odata/live/$metadata";
         url_ = url_.replace(/[?&]$/, "");
@@ -991,10 +987,6 @@ export class MetadataClient {
         return Promise.resolve<IEdmModel>(null as any);
     }
 
-    /**
-     * Generates the OData service document.
-     * @return The service document for the service.
-     */
     getServiceDocument(): Promise<ODataServiceDocument> {
         let url_ = this.baseUrl + "/api/odata/live";
         url_ = url_.replace(/[?&]$/, "");
@@ -12696,19 +12688,12 @@ export interface IAccountLocationAccess {
     roles?: string[];
 }
 
-/** Semantic representation of an EDM model. */
 export abstract class IEdmModel implements IIEdmModel {
-    /** Gets the collection of schema elements that are contained in this model. */
     schemaElements?: IEdmSchemaElement[] | undefined;
-    /** Gets the collection of vocabulary annotations that are contained in this model. */
     vocabularyAnnotations?: IEdmVocabularyAnnotation[] | undefined;
-    /** Gets the collection of models referred to by this model (mainly by the this.References). */
     referencedModels?: IEdmModel[] | undefined;
-    /** Gets the collection of namespaces that schema elements use contained in this model. */
     declaredNamespaces?: string[] | undefined;
-    /** Gets the model's annotations manager. */
     directValueAnnotationsManager?: IEdmDirectValueAnnotationsManager | undefined;
-    /** Gets the only one entity container of the model. */
     entityContainer?: IEdmEntityContainer | undefined;
 
     constructor(data?: IIEdmModel) {
@@ -12780,27 +12765,17 @@ export abstract class IEdmModel implements IIEdmModel {
     }
 }
 
-/** Semantic representation of an EDM model. */
 export interface IIEdmModel {
-    /** Gets the collection of schema elements that are contained in this model. */
     schemaElements?: IEdmSchemaElement[] | undefined;
-    /** Gets the collection of vocabulary annotations that are contained in this model. */
     vocabularyAnnotations?: IEdmVocabularyAnnotation[] | undefined;
-    /** Gets the collection of models referred to by this model (mainly by the this.References). */
     referencedModels?: IEdmModel[] | undefined;
-    /** Gets the collection of namespaces that schema elements use contained in this model. */
     declaredNamespaces?: string[] | undefined;
-    /** Gets the model's annotations manager. */
     directValueAnnotationsManager?: IEdmDirectValueAnnotationsManager | undefined;
-    /** Gets the only one entity container of the model. */
     entityContainer?: IEdmEntityContainer | undefined;
 }
 
-/** Common base interface for all named children of EDM schema. */
 export abstract class IEdmSchemaElement implements IIEdmSchemaElement {
-    /** Gets the kind of this schema element. */
     schemaElementKind?: EdmSchemaElementKind;
-    /** Gets the namespace this schema element belongs to. */
     namespace?: string | undefined;
 
     constructor(data?: IIEdmSchemaElement) {
@@ -12832,15 +12807,11 @@ export abstract class IEdmSchemaElement implements IIEdmSchemaElement {
     }
 }
 
-/** Common base interface for all named children of EDM schema. */
 export interface IIEdmSchemaElement {
-    /** Gets the kind of this schema element. */
     schemaElementKind?: EdmSchemaElementKind;
-    /** Gets the namespace this schema element belongs to. */
     namespace?: string | undefined;
 }
 
-/** Defines EDM schema element types. */
 export enum EdmSchemaElementKind {
     None = 0,
     TypeDefinition = 1,
@@ -12850,15 +12821,10 @@ export enum EdmSchemaElementKind {
     Function = 5,
 }
 
-/** Represents an EDM vocabulary annotation. */
 export abstract class IEdmVocabularyAnnotation implements IIEdmVocabularyAnnotation {
-    /** Gets the qualifier used to discriminate between multiple bindings of the same property or type. */
     qualifier?: string | undefined;
-    /** Gets the term bound by the annotation. */
     term?: IEdmTerm | undefined;
-    /** Gets the element the annotation applies to. */
     target?: IEdmVocabularyAnnotatable | undefined;
-    /** Gets the expression producing the value of the annotation. */
     value?: IEdmExpression | undefined;
 
     constructor(data?: IIEdmVocabularyAnnotation) {
@@ -12894,25 +12860,16 @@ export abstract class IEdmVocabularyAnnotation implements IIEdmVocabularyAnnotat
     }
 }
 
-/** Represents an EDM vocabulary annotation. */
 export interface IIEdmVocabularyAnnotation {
-    /** Gets the qualifier used to discriminate between multiple bindings of the same property or type. */
     qualifier?: string | undefined;
-    /** Gets the term bound by the annotation. */
     term?: IEdmTerm | undefined;
-    /** Gets the element the annotation applies to. */
     target?: IEdmVocabularyAnnotatable | undefined;
-    /** Gets the expression producing the value of the annotation. */
     value?: IEdmExpression | undefined;
 }
 
-/** Represents an EDM term. */
 export abstract class IEdmTerm implements IIEdmTerm {
-    /** Gets the type of this term. */
     type?: IEdmTypeReference | undefined;
-    /** Gets the AppliesTo of this term. */
     appliesTo?: string | undefined;
-    /** Gets the DefaultValue of this term. */
     defaultValue?: string | undefined;
 
     constructor(data?: IIEdmTerm) {
@@ -12946,21 +12903,14 @@ export abstract class IEdmTerm implements IIEdmTerm {
     }
 }
 
-/** Represents an EDM term. */
 export interface IIEdmTerm {
-    /** Gets the type of this term. */
     type?: IEdmTypeReference | undefined;
-    /** Gets the AppliesTo of this term. */
     appliesTo?: string | undefined;
-    /** Gets the DefaultValue of this term. */
     defaultValue?: string | undefined;
 }
 
-/** Represents a references to a type. */
 export abstract class IEdmTypeReference implements IIEdmTypeReference {
-    /** Gets a value indicating whether this type is nullable. */
     isNullable?: boolean;
-    /** Gets the definition to which this type refers. */
     definition?: IEdmType | undefined;
 
     constructor(data?: IIEdmTypeReference) {
@@ -12992,17 +12942,12 @@ export abstract class IEdmTypeReference implements IIEdmTypeReference {
     }
 }
 
-/** Represents a references to a type. */
 export interface IIEdmTypeReference {
-    /** Gets a value indicating whether this type is nullable. */
     isNullable?: boolean;
-    /** Gets the definition to which this type refers. */
     definition?: IEdmType | undefined;
 }
 
-/** Represents the definition of an EDM type. */
 export abstract class IEdmType implements IIEdmType {
-    /** Gets the kind of this type. */
     typeKind?: EdmTypeKind;
 
     constructor(data?: IIEdmType) {
@@ -13032,13 +12977,10 @@ export abstract class IEdmType implements IIEdmType {
     }
 }
 
-/** Represents the definition of an EDM type. */
 export interface IIEdmType {
-    /** Gets the kind of this type. */
     typeKind?: EdmTypeKind;
 }
 
-/** Defines EDM metatypes. */
 export enum EdmTypeKind {
     None = 0,
     Primitive = 1,
@@ -13052,7 +12994,6 @@ export enum EdmTypeKind {
     Path = 9,
 }
 
-/** Represents an element that can be targeted by Vocabulary Annotations */
 export abstract class IEdmVocabularyAnnotatable implements IIEdmVocabularyAnnotatable {
 
     constructor(data?: IIEdmVocabularyAnnotatable) {
@@ -13078,13 +13019,10 @@ export abstract class IEdmVocabularyAnnotatable implements IIEdmVocabularyAnnota
     }
 }
 
-/** Represents an element that can be targeted by Vocabulary Annotations */
 export interface IIEdmVocabularyAnnotatable {
 }
 
-/** Represents an EDM expression. */
 export abstract class IEdmExpression implements IIEdmExpression {
-    /** Gets the kind of this expression. */
     expressionKind?: EdmExpressionKind;
 
     constructor(data?: IIEdmExpression) {
@@ -13114,13 +13052,10 @@ export abstract class IEdmExpression implements IIEdmExpression {
     }
 }
 
-/** Represents an EDM expression. */
 export interface IIEdmExpression {
-    /** Gets the kind of this expression. */
     expressionKind?: EdmExpressionKind;
 }
 
-/** Defines EDM expression kinds. */
 export enum EdmExpressionKind {
     None = 0,
     BinaryConstant = 1,
@@ -13150,7 +13085,6 @@ export enum EdmExpressionKind {
     AnnotationPath = 25,
 }
 
-/** Manages getting and setting direct annotations on EDM elements. */
 export abstract class IEdmDirectValueAnnotationsManager implements IIEdmDirectValueAnnotationsManager {
 
     constructor(data?: IIEdmDirectValueAnnotationsManager) {
@@ -13176,13 +13110,10 @@ export abstract class IEdmDirectValueAnnotationsManager implements IIEdmDirectVa
     }
 }
 
-/** Manages getting and setting direct annotations on EDM elements. */
 export interface IIEdmDirectValueAnnotationsManager {
 }
 
-/** Represents an EDM entity container. */
 export abstract class IEdmEntityContainer implements IIEdmEntityContainer {
-    /** Gets a collection of the elements of this entity container. */
     elements?: IEdmEntityContainerElement[] | undefined;
 
     constructor(data?: IIEdmEntityContainer) {
@@ -13220,17 +13151,12 @@ export abstract class IEdmEntityContainer implements IIEdmEntityContainer {
     }
 }
 
-/** Represents an EDM entity container. */
 export interface IIEdmEntityContainer {
-    /** Gets a collection of the elements of this entity container. */
     elements?: IEdmEntityContainerElement[] | undefined;
 }
 
-/** Represents the common elements of all EDM entity container elements. */
 export abstract class IEdmEntityContainerElement implements IIEdmEntityContainerElement {
-    /** Gets the kind of element of this container element. */
     containerElementKind?: EdmContainerElementKind;
-    /** Gets the container that contains this element. */
     container?: IEdmEntityContainer | undefined;
 
     constructor(data?: IIEdmEntityContainerElement) {
@@ -13262,15 +13188,11 @@ export abstract class IEdmEntityContainerElement implements IIEdmEntityContainer
     }
 }
 
-/** Represents the common elements of all EDM entity container elements. */
 export interface IIEdmEntityContainerElement {
-    /** Gets the kind of element of this container element. */
     containerElementKind?: EdmContainerElementKind;
-    /** Gets the container that contains this element. */
     container?: IEdmEntityContainer | undefined;
 }
 
-/** Defines EDM container element types. */
 export enum EdmContainerElementKind {
     None = 0,
     EntitySet = 1,
@@ -13279,9 +13201,7 @@ export enum EdmContainerElementKind {
     Singleton = 4,
 }
 
-/** Base class for all annotatable types in OData library. */
 export abstract class ODataAnnotatable implements IODataAnnotatable {
-    /** The annotation for storing @odata.type. */
     typeAnnotation?: ODataTypeAnnotation | undefined;
 
     constructor(data?: IODataAnnotatable) {
@@ -13311,19 +13231,13 @@ export abstract class ODataAnnotatable implements IODataAnnotatable {
     }
 }
 
-/** Base class for all annotatable types in OData library. */
 export interface IODataAnnotatable {
-    /** The annotation for storing @odata.type. */
     typeAnnotation?: ODataTypeAnnotation | undefined;
 }
 
-/** Class representing the a service document. */
 export class ODataServiceDocument extends ODataAnnotatable implements IODataServiceDocument {
-    /** Gets or sets the set of entity sets in the service document. */
     entitySets?: ODataEntitySetInfo[] | undefined;
-    /** Gets or sets the set of singletons in the service document. */
     singletons?: ODataSingletonInfo[] | undefined;
-    /** Gets or sets the set of function imports in the service document. */
     functionImports?: ODataFunctionImportInfo[] | undefined;
 
     constructor(data?: IODataServiceDocument) {
@@ -13380,23 +13294,15 @@ export class ODataServiceDocument extends ODataAnnotatable implements IODataServ
     }
 }
 
-/** Class representing the a service document. */
 export interface IODataServiceDocument extends IODataAnnotatable {
-    /** Gets or sets the set of entity sets in the service document. */
     entitySets?: ODataEntitySetInfo[] | undefined;
-    /** Gets or sets the set of singletons in the service document. */
     singletons?: ODataSingletonInfo[] | undefined;
-    /** Gets or sets the set of function imports in the service document. */
     functionImports?: ODataFunctionImportInfo[] | undefined;
 }
 
-/** Abstract class representing an element (EntitySet, Singleton) in a service document. */
 export abstract class ODataServiceDocumentElement extends ODataAnnotatable implements IODataServiceDocumentElement {
-    /** Gets or sets the URI representing the Unified Resource Locator (URL) to the element. */
     url?: string | undefined;
-    /** Gets or sets the name of the element; this is the entity set or singleton name in JSON and the HREF in Atom. */
     name?: string | undefined;
-    /** Gets or sets the title of the element; this is the title in JSON. */
     title?: string | undefined;
 
     constructor(data?: IODataServiceDocumentElement) {
@@ -13427,17 +13333,12 @@ export abstract class ODataServiceDocumentElement extends ODataAnnotatable imple
     }
 }
 
-/** Abstract class representing an element (EntitySet, Singleton) in a service document. */
 export interface IODataServiceDocumentElement extends IODataAnnotatable {
-    /** Gets or sets the URI representing the Unified Resource Locator (URL) to the element. */
     url?: string | undefined;
-    /** Gets or sets the name of the element; this is the entity set or singleton name in JSON and the HREF in Atom. */
     name?: string | undefined;
-    /** Gets or sets the title of the element; this is the title in JSON. */
     title?: string | undefined;
 }
 
-/** Class representing a entity set in a service document. */
 export class ODataEntitySetInfo extends ODataServiceDocumentElement implements IODataEntitySetInfo {
 
     constructor(data?: IODataEntitySetInfo) {
@@ -13462,13 +13363,10 @@ export class ODataEntitySetInfo extends ODataServiceDocumentElement implements I
     }
 }
 
-/** Class representing a entity set in a service document. */
 export interface IODataEntitySetInfo extends IODataServiceDocumentElement {
 }
 
-/** Annotation which stores the EDM type information of a value. */
 export class ODataTypeAnnotation implements IODataTypeAnnotation {
-    /** Gets the type name to serialize, for the annotated item.  */
     typeName?: string | undefined;
 
     constructor(data?: IODataTypeAnnotation) {
@@ -13500,13 +13398,10 @@ export class ODataTypeAnnotation implements IODataTypeAnnotation {
     }
 }
 
-/** Annotation which stores the EDM type information of a value. */
 export interface IODataTypeAnnotation {
-    /** Gets the type name to serialize, for the annotated item.  */
     typeName?: string | undefined;
 }
 
-/** Class representing a singleton in a service document. */
 export class ODataSingletonInfo extends ODataServiceDocumentElement implements IODataSingletonInfo {
 
     constructor(data?: IODataSingletonInfo) {
@@ -13531,11 +13426,9 @@ export class ODataSingletonInfo extends ODataServiceDocumentElement implements I
     }
 }
 
-/** Class representing a singleton in a service document. */
 export interface IODataSingletonInfo extends IODataServiceDocumentElement {
 }
 
-/** Class representing a function Import in a service document. */
 export class ODataFunctionImportInfo extends ODataServiceDocumentElement implements IODataFunctionImportInfo {
 
     constructor(data?: IODataFunctionImportInfo) {
@@ -13560,7 +13453,6 @@ export class ODataFunctionImportInfo extends ODataServiceDocumentElement impleme
     }
 }
 
-/** Class representing a function Import in a service document. */
 export interface IODataFunctionImportInfo extends IODataServiceDocumentElement {
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -985,11 +985,10 @@
         "tags": [
           "Metadata"
         ],
-        "summary": "Generates the OData $metadata document.",
         "operationId": "Metadata_GetMetadata",
         "responses": {
           "200": {
-            "description": "The IEdmModel representing $metadata.",
+            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -1006,11 +1005,10 @@
         "tags": [
           "Metadata"
         ],
-        "summary": "Generates the OData service document.",
         "operationId": "Metadata_GetServiceDocument",
         "responses": {
           "200": {
-            "description": "The service document for the service.",
+            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -7135,13 +7133,11 @@
       },
       "IEdmModel": {
         "type": "object",
-        "description": "Semantic representation of an EDM model.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "schemaElements": {
             "type": "array",
-            "description": "Gets the collection of schema elements that are contained in this model.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/IEdmSchemaElement"
@@ -7149,7 +7145,6 @@
           },
           "vocabularyAnnotations": {
             "type": "array",
-            "description": "Gets the collection of vocabulary annotations that are contained in this model.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/IEdmVocabularyAnnotation"
@@ -7157,7 +7152,6 @@
           },
           "referencedModels": {
             "type": "array",
-            "description": "Gets the collection of models referred to by this model (mainly by the this.References).",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/IEdmModel"
@@ -7165,14 +7159,12 @@
           },
           "declaredNamespaces": {
             "type": "array",
-            "description": "Gets the collection of namespaces that schema elements use contained in this model.",
             "nullable": true,
             "items": {
               "type": "string"
             }
           },
           "directValueAnnotationsManager": {
-            "description": "Gets the model's annotations manager.",
             "nullable": true,
             "oneOf": [
               {
@@ -7181,7 +7173,6 @@
             ]
           },
           "entityContainer": {
-            "description": "Gets the only one entity container of the model.",
             "nullable": true,
             "oneOf": [
               {
@@ -7193,28 +7184,21 @@
       },
       "IEdmSchemaElement": {
         "type": "object",
-        "description": "Common base interface for all named children of EDM schema.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "schemaElementKind": {
-            "description": "Gets the kind of this schema element.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EdmSchemaElementKind"
-              }
-            ]
+            "$ref": "#/components/schemas/EdmSchemaElementKind"
           },
           "namespace": {
             "type": "string",
-            "description": "Gets the namespace this schema element belongs to.",
             "nullable": true
           }
         }
       },
       "EdmSchemaElementKind": {
         "type": "integer",
-        "description": "Defines EDM schema element types.",
+        "description": "",
         "x-enumNames": [
           "None",
           "TypeDefinition",
@@ -7234,17 +7218,14 @@
       },
       "IEdmVocabularyAnnotation": {
         "type": "object",
-        "description": "Represents an EDM vocabulary annotation.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "qualifier": {
             "type": "string",
-            "description": "Gets the qualifier used to discriminate between multiple bindings of the same property or type.",
             "nullable": true
           },
           "term": {
-            "description": "Gets the term bound by the annotation.",
             "nullable": true,
             "oneOf": [
               {
@@ -7253,7 +7234,6 @@
             ]
           },
           "target": {
-            "description": "Gets the element the annotation applies to.",
             "nullable": true,
             "oneOf": [
               {
@@ -7262,7 +7242,6 @@
             ]
           },
           "value": {
-            "description": "Gets the expression producing the value of the annotation.",
             "nullable": true,
             "oneOf": [
               {
@@ -7274,12 +7253,10 @@
       },
       "IEdmTerm": {
         "type": "object",
-        "description": "Represents an EDM term.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "type": {
-            "description": "Gets the type of this term.",
             "nullable": true,
             "oneOf": [
               {
@@ -7289,28 +7266,23 @@
           },
           "appliesTo": {
             "type": "string",
-            "description": "Gets the AppliesTo of this term.",
             "nullable": true
           },
           "defaultValue": {
             "type": "string",
-            "description": "Gets the DefaultValue of this term.",
             "nullable": true
           }
         }
       },
       "IEdmTypeReference": {
         "type": "object",
-        "description": "Represents a references to a type.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "isNullable": {
-            "type": "boolean",
-            "description": "Gets a value indicating whether this type is nullable."
+            "type": "boolean"
           },
           "definition": {
-            "description": "Gets the definition to which this type refers.",
             "nullable": true,
             "oneOf": [
               {
@@ -7322,23 +7294,17 @@
       },
       "IEdmType": {
         "type": "object",
-        "description": "Represents the definition of an EDM type.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "typeKind": {
-            "description": "Gets the kind of this type.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EdmTypeKind"
-              }
-            ]
+            "$ref": "#/components/schemas/EdmTypeKind"
           }
         }
       },
       "EdmTypeKind": {
         "type": "integer",
-        "description": "Defines EDM metatypes.",
+        "description": "",
         "x-enumNames": [
           "None",
           "Primitive",
@@ -7366,29 +7332,22 @@
       },
       "IEdmVocabularyAnnotatable": {
         "type": "object",
-        "description": "Represents an element that can be targeted by Vocabulary Annotations",
         "x-abstract": true,
         "additionalProperties": false
       },
       "IEdmExpression": {
         "type": "object",
-        "description": "Represents an EDM expression.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "expressionKind": {
-            "description": "Gets the kind of this expression.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EdmExpressionKind"
-              }
-            ]
+            "$ref": "#/components/schemas/EdmExpressionKind"
           }
         }
       },
       "EdmExpressionKind": {
         "type": "integer",
-        "description": "Defines EDM expression kinds.",
+        "description": "",
         "x-enumNames": [
           "None",
           "BinaryConstant",
@@ -7448,19 +7407,16 @@
       },
       "IEdmDirectValueAnnotationsManager": {
         "type": "object",
-        "description": "Manages getting and setting direct annotations on EDM elements.",
         "x-abstract": true,
         "additionalProperties": false
       },
       "IEdmEntityContainer": {
         "type": "object",
-        "description": "Represents an EDM entity container.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "elements": {
             "type": "array",
-            "description": "Gets a collection of the elements of this entity container.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/IEdmEntityContainerElement"
@@ -7470,20 +7426,13 @@
       },
       "IEdmEntityContainerElement": {
         "type": "object",
-        "description": "Represents the common elements of all EDM entity container elements.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "containerElementKind": {
-            "description": "Gets the kind of element of this container element.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EdmContainerElementKind"
-              }
-            ]
+            "$ref": "#/components/schemas/EdmContainerElementKind"
           },
           "container": {
-            "description": "Gets the container that contains this element.",
             "nullable": true,
             "oneOf": [
               {
@@ -7495,7 +7444,7 @@
       },
       "EdmContainerElementKind": {
         "type": "integer",
-        "description": "Defines EDM container element types.",
+        "description": "",
         "x-enumNames": [
           "None",
           "EntitySet",
@@ -7518,12 +7467,10 @@
           },
           {
             "type": "object",
-            "description": "Class representing the a service document.",
             "additionalProperties": false,
             "properties": {
               "entitySets": {
                 "type": "array",
-                "description": "Gets or sets the set of entity sets in the service document.",
                 "nullable": true,
                 "items": {
                   "$ref": "#/components/schemas/ODataEntitySetInfo"
@@ -7531,7 +7478,6 @@
               },
               "singletons": {
                 "type": "array",
-                "description": "Gets or sets the set of singletons in the service document.",
                 "nullable": true,
                 "items": {
                   "$ref": "#/components/schemas/ODataSingletonInfo"
@@ -7539,7 +7485,6 @@
               },
               "functionImports": {
                 "type": "array",
-                "description": "Gets or sets the set of function imports in the service document.",
                 "nullable": true,
                 "items": {
                   "$ref": "#/components/schemas/ODataFunctionImportInfo"
@@ -7556,7 +7501,6 @@
           },
           {
             "type": "object",
-            "description": "Class representing a entity set in a service document.",
             "additionalProperties": false
           }
         ]
@@ -7568,24 +7512,20 @@
           },
           {
             "type": "object",
-            "description": "Abstract class representing an element (EntitySet, Singleton) in a service document.",
             "x-abstract": true,
             "additionalProperties": false,
             "properties": {
               "url": {
                 "type": "string",
-                "description": "Gets or sets the URI representing the Unified Resource Locator (URL) to the element.",
                 "format": "uri",
                 "nullable": true
               },
               "name": {
                 "type": "string",
-                "description": "Gets or sets the name of the element; this is the entity set or singleton name in JSON and the HREF in Atom.",
                 "nullable": true
               },
               "title": {
                 "type": "string",
-                "description": "Gets or sets the title of the element; this is the title in JSON.",
                 "nullable": true
               }
             }
@@ -7594,12 +7534,10 @@
       },
       "ODataAnnotatable": {
         "type": "object",
-        "description": "Base class for all annotatable types in OData library.",
         "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "typeAnnotation": {
-            "description": "The annotation for storing @odata.type.",
             "nullable": true,
             "oneOf": [
               {
@@ -7611,12 +7549,10 @@
       },
       "ODataTypeAnnotation": {
         "type": "object",
-        "description": "Annotation which stores the EDM type information of a value.",
         "additionalProperties": false,
         "properties": {
           "typeName": {
             "type": "string",
-            "description": "Gets the type name to serialize, for the annotated item. ",
             "nullable": true
           }
         }
@@ -7628,7 +7564,6 @@
           },
           {
             "type": "object",
-            "description": "Class representing a singleton in a service document.",
             "additionalProperties": false
           }
         ]
@@ -7640,7 +7575,6 @@
           },
           {
             "type": "object",
-            "description": "Class representing a function Import in a service document.",
             "additionalProperties": false
           }
         ]


### PR DESCRIPTION
I have some questions here:

1) From what I understood, we have to set a primary key, is that right?

2) If so, are user ids the same across locations? If so, I guess we must group the user ids like this:

```json
{
  "@odata.context": "http://localhost:5000/api/odata/live/$metadata#LocationUsers",
  "value": [
    {
      "LocationId": "22222222-2222-2222-2222-222222222222",
      "UserIds": [
        "00000000-0000-0000-0000-000000000000"
      ]
    }
  ]
}
```

3) This user id currently is the person id, how do I get the actual user id?