### PR TITLE
Add missing canExempt prop

### DIFF
--- a/src/caretogether-pwa/src/Requirements/MissingRequirementRow.tsx
+++ b/src/caretogether-pwa/src/Requirements/MissingRequirementRow.tsx
@@ -76,6 +76,7 @@ export function MissingRequirementRow({
           context={context}
           policy={requirementPolicy}
           referralId={referralId}
+          canExempt={canExempt}
         />
       )}
     </>


### PR DESCRIPTION
Fixes #881

There was a missing prop in `src/caretogether-pwa/src/Requirements/MissingRequirementRow.tsx`.

After adding it and testing with a user with a role that includes the following permissions, everything seems to be working fine now (exempt tab shows up on family member cards and referral intake items):

![image](https://github.com/user-attachments/assets/3d9beed0-f926-4e5d-a3fd-7f0c6369de6f)
