### PR TITLE
Sort requested date

### DIFF
--- a/src/caretogether-pwa/src/Referrals/Arrangements/ArrangementsSection/getFilteredArrangements.tsx
+++ b/src/caretogether-pwa/src/Referrals/Arrangements/ArrangementsSection/getFilteredArrangements.tsx
@@ -21,11 +21,8 @@ export const getFilteredArrangements = (
       });
     })
     .sort((a, b) => {
-      const aStart = a.startedAtUtc?.getTime() || 0;
-      const bStart = b.startedAtUtc?.getTime() || 0;
-      const aRequested = a.requestedAtUtc?.getTime() || 0;
-      const bRequested = b.requestedAtUtc?.getTime() || 0;
-
-      return bStart - aStart || bRequested - aRequested;
+      const aDate = a.requestedAtUtc ?? a.startedAtUtc ?? new Date(0);
+      const bDate = b.requestedAtUtc ?? b.startedAtUtc ?? new Date(0);
+      return bDate.getTime() - aDate.getTime();
     });
 };


### PR DESCRIPTION
Arrangement cards are now displayed from newest to oldest based on the requestedAtUtc date. If requestedAtUtc is missing, the fallback is startedAtUtc. Previously, the cards were sorted by startedAtUtc first, with requestedAtUtc as a secondary fallback.