### PR TITLE
Added a margin-bottom to side menu navigation, so feedback button doesn't overlap with menu items

### DIFF
--- a/src/caretogether-pwa/src/Shell/ShellSideNavigation.tsx
+++ b/src/caretogether-pwa/src/Shell/ShellSideNavigation.tsx
@@ -56,6 +56,7 @@ function SideNavigationMenu({ open }: SideNavigationMenuProps) {
       sx={{
         '& .MuiListItem-root.Mui-selected': { color: '#ffff' },
         '& .MuiListItem-root.Mui-selected svg': { color: '#ffff' },
+        marginBottom: 17,
       }}
     >
       {flags === null ? (


### PR DESCRIPTION
This a little adjustment, before:

![Image](https://github.com/user-attachments/assets/9197246b-4c13-4bd5-8b03-608869bd83a7)

After:

![image](https://github.com/user-attachments/assets/26bef6e0-26a5-4a33-8a9c-1344d524b028)
