### PR TITLE
Use autocomplete for adding permissions to a context in a Role  @PabloDinella

### DIFF
--- a/src/caretogether-pwa/src/Settings/Roles/PermissionsSelect.tsx
+++ b/src/caretogether-pwa/src/Settings/Roles/PermissionsSelect.tsx
@@ -1,0 +1,62 @@
+import { Autocomplete, TextField, Button, Stack } from '@mui/material';
+import { Permission } from '../../GeneratedClient';
+import { spacesBeforeCapitalLetters } from './spacesBeforeCapitalLetters';
+import { useState } from 'react';
+
+interface PermissionSelectProps {
+  availablePermissions: [string, string | Permission][];
+  onAdd: (permissions: Permission[]) => void;
+}
+
+type Option = {
+  title: string;
+  value: Permission;
+};
+
+export function PermissionsSelect({
+  availablePermissions,
+  onAdd,
+}: PermissionSelectProps) {
+  const [value, setValue] = useState<Option[]>([]);
+
+  const options = availablePermissions.map(([name, value]) => ({
+    title: spacesBeforeCapitalLetters(name),
+    value: value as Permission,
+  }));
+
+  return (
+    <Stack mt={1} direction="row" spacing={1} alignItems="center">
+      <Autocomplete
+        sx={{ mt: 1, flexGrow: 1 }}
+        fullWidth
+        size="small"
+        multiple
+        value={value}
+        onChange={(_, newValue: Option[]) => setValue(newValue)}
+        id="tags-outlined"
+        options={options}
+        isOptionEqualToValue={(option, value) => option.value === value.value}
+        getOptionLabel={(option) => option.title}
+        filterSelectedOptions
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Add Permissions"
+            placeholder="Start typing to search..."
+          />
+        )}
+      />
+
+      <Button
+        variant="contained"
+        disabled={!value.length}
+        onClick={() => {
+          onAdd(value.map((v) => v.value));
+          setValue([]);
+        }}
+      >
+        Add
+      </Button>
+    </Stack>
+  );
+}

--- a/src/caretogether-pwa/src/Settings/Roles/RoleEdit.tsx
+++ b/src/caretogether-pwa/src/Settings/Roles/RoleEdit.tsx
@@ -43,6 +43,8 @@ import { Link } from 'react-router-dom';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import { Box } from '@mui/system';
 import { isRoleEditable } from './isRoleEditable';
+import { ContextualPermissionSetRowAutocomplete } from './ContextualPermissionSetRowWithAutocomplete';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 
 export function RoleEdit({
   roleDefinition,
@@ -130,6 +132,10 @@ export function RoleEdit({
     setAddPermissionSetMenuAnchorEl(null);
   }
 
+  const shouldUseAutocomplete = useFeatureFlagEnabled(
+    'permissionsAutocomplete'
+  );
+
   return (
     <Stack paddingY={2} height="calc(100vh - 48px)" spacing={0}>
       <Box>
@@ -162,6 +168,11 @@ export function RoleEdit({
 
       <TableContainer>
         <Table sx={{ minWidth: '700px' }} stickyHeader size="small">
+          <colgroup>
+            <col />
+            <col style={{ width: '50%' }} />
+            <col style={{ width: '50%' }} />
+          </colgroup>
           <TableHead>
             <TableRow>
               <TableCell></TableCell>
@@ -170,17 +181,29 @@ export function RoleEdit({
             </TableRow>
           </TableHead>
           <TableBody>
-            {workingRole?.permissionSets?.map((permissionSet, i) => (
-              <ContextualPermissionSetRow
-                key={`${workingRole.permissionSets?.length}-${i}`}
-                editable={isEditable}
-                permissionSet={permissionSet}
-                onDelete={() => deletePermissionSetAtIndex(i)}
-                onUpdate={(newValue: IContextualPermissionSet) =>
-                  updatePermissionSetAtIndex(i, newValue)
-                }
-              />
-            ))}
+            {workingRole?.permissionSets?.map((permissionSet, i) =>
+              shouldUseAutocomplete ? (
+                <ContextualPermissionSetRowAutocomplete
+                  key={`${workingRole.permissionSets?.length}-${i}`}
+                  editable={isEditable}
+                  permissionSet={permissionSet}
+                  onDelete={() => deletePermissionSetAtIndex(i)}
+                  onUpdate={(newValue: IContextualPermissionSet) =>
+                    updatePermissionSetAtIndex(i, newValue)
+                  }
+                />
+              ) : (
+                <ContextualPermissionSetRow
+                  key={`${workingRole.permissionSets?.length}-${i}`}
+                  editable={isEditable}
+                  permissionSet={permissionSet}
+                  onDelete={() => deletePermissionSetAtIndex(i)}
+                  onUpdate={(newValue: IContextualPermissionSet) =>
+                    updatePermissionSetAtIndex(i, newValue)
+                  }
+                />
+              )
+            )}
             {isEditable && (
               <TableRow>
                 <TableCell>
@@ -287,7 +310,13 @@ export function RoleEdit({
       </Menu>
 
       <Box paddingY={2} borderTop={1} borderColor="divider">
-        <Stack direction="row" justifyContent="flex-end">
+        <Stack direction="row" justifyContent="flex-end" alignItems="center">
+          {dirty && (
+            <Typography sx={{ fontStyle: 'italic' }} mr={2}>
+              There are pending changes to be saved
+            </Typography>
+          )}
+
           {isEditable && (
             <Button
               color="secondary"

--- a/src/caretogether-pwa/src/Settings/Roles/RoleEditScreen.tsx
+++ b/src/caretogether-pwa/src/Settings/Roles/RoleEditScreen.tsx
@@ -1,0 +1,33 @@
+import { Typography } from '@mui/material';
+import { useLoadable } from '../../Hooks/useLoadable';
+import { organizationConfigurationQuery } from '../../Model/ConfigurationModel';
+import { ProgressBackdrop } from '../../Shell/ProgressBackdrop';
+import { useDataLoaded } from '../../Model/Data';
+import { useParams } from 'react-router-dom';
+import { RoleEdit } from './RoleEdit';
+import useScreenTitle from '../../Shell/ShellScreenTitle';
+
+export function RoleEditScreen() {
+  useScreenTitle('Roles');
+
+  const { roleName } = useParams<{ roleName: string }>();
+  const configuration = useLoadable(organizationConfigurationQuery);
+  const dataLoaded = useDataLoaded();
+
+  if (!dataLoaded || !configuration) {
+    return <ProgressBackdrop>Loading role...</ProgressBackdrop>;
+  }
+
+  const roles = configuration?.roles;
+  const selectedRole = roles?.find((role) => role.roleName === roleName);
+
+  if (!selectedRole) {
+    return (
+      <Typography align="center" mt={10}>
+        Role not found.
+      </Typography>
+    );
+  }
+
+  return <RoleEdit roleDefinition={selectedRole} />;
+}

--- a/src/caretogether-pwa/src/Settings/Roles/spacesBeforeCapitalLetters.tsx
+++ b/src/caretogether-pwa/src/Settings/Roles/spacesBeforeCapitalLetters.tsx
@@ -1,0 +1,10 @@
+export function spacesBeforeCapitalLetters(value: string) {
+  let result = '';
+  for (const c of value) {
+    result += result.length > 0 && c.toUpperCase() === c ? ' ' + c : c;
+    if (result === 'Add Edit') {
+      result = 'Add/Edit';
+    }
+  }
+  return result;
+}

--- a/src/caretogether-pwa/src/Settings/Settings.tsx
+++ b/src/caretogether-pwa/src/Settings/Settings.tsx
@@ -1,12 +1,12 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { SettingsScreen } from './SettingsScreen';
-import { RoleEdit } from './Roles/RoleEdit';
+import { RoleEditScreen } from './Roles/RoleEditScreen';
 
 function Settings() {
   return (
     <Routes>
       <Route path="" element={<SettingsScreen />} />
-      <Route path="roles/:roleName" element={<RoleEdit />} />
+      <Route path="roles/:roleName" element={<RoleEditScreen />} />
       <Route path="*" element={<Navigate to="./roles" replace />} />
     </Routes>
   );


### PR DESCRIPTION
This will make UX for adding permissions easier.

User can select multiple permissions to add and click **ADD**.

Feature flag: `permissionsAutocomplete`

![image](https://github.com/user-attachments/assets/8808c550-ee3c-4005-b493-4cc9b60b5e96)
