### PR TITLE
Add grouped permissions for better organization in PermissionsSelect

### DIFF
--- a/src/caretogether-pwa/src/Settings/Roles/PermissionsSelect.tsx
+++ b/src/caretogether-pwa/src/Settings/Roles/PermissionsSelect.tsx
@@ -2,6 +2,7 @@ import { Autocomplete, TextField, Button, Stack } from '@mui/material';
 import { Permission } from '../../GeneratedClient';
 import { spacesBeforeCapitalLetters } from './spacesBeforeCapitalLetters';
 import { useState } from 'react';
+import { groupedPermissions } from './groupedPermissions';
 
 interface PermissionSelectProps {
   availablePermissions: [string, string | Permission][];
@@ -11,6 +12,7 @@ interface PermissionSelectProps {
 type Option = {
   title: string;
   value: Permission;
+  group: string;
 };
 
 export function PermissionsSelect({
@@ -19,10 +21,25 @@ export function PermissionsSelect({
 }: PermissionSelectProps) {
   const [value, setValue] = useState<Option[]>([]);
 
-  const options = availablePermissions.map(([name, value]) => ({
-    title: spacesBeforeCapitalLetters(name),
-    value: value as Permission,
-  }));
+  // Build options with group labels using GroupedPermissions
+  const groupedOptions: Option[] = Object.entries(groupedPermissions).flatMap(
+    ([group, permissions]) =>
+      permissions
+        .map((permission) => {
+          const found = availablePermissions.find(
+            ([, value]) => Number(value) === permission
+          );
+
+          return found
+            ? {
+                title: spacesBeforeCapitalLetters(found[0]),
+                value: found[1],
+                group,
+              }
+            : null;
+        })
+        .filter((item): item is Option => item !== null)
+  );
 
   return (
     <Stack mt={1} direction="row" spacing={1} alignItems="center">
@@ -34,9 +51,10 @@ export function PermissionsSelect({
         value={value}
         onChange={(_, newValue: Option[]) => setValue(newValue)}
         id="tags-outlined"
-        options={options}
-        isOptionEqualToValue={(option, value) => option.value === value.value}
+        options={groupedOptions}
+        groupBy={(option) => option.group}
         getOptionLabel={(option) => option.title}
+        isOptionEqualToValue={(option, value) => option.value === value.value}
         filterSelectedOptions
         renderInput={(params) => (
           <TextField

--- a/src/caretogether-pwa/src/Settings/Roles/PermissionsSelect.tsx
+++ b/src/caretogether-pwa/src/Settings/Roles/PermissionsSelect.tsx
@@ -12,8 +12,13 @@ interface PermissionSelectProps {
 type Option = {
   title: string;
   value: Permission;
+  disabled: boolean;
   group: string;
 };
+
+const allPermissions = Object.entries(Permission).filter(
+  ([, permission]) => typeof permission !== 'string'
+);
 
 export function PermissionsSelect({
   availablePermissions,
@@ -26,17 +31,19 @@ export function PermissionsSelect({
     ([group, permissions]) =>
       permissions
         .map((permission) => {
+          const [permissionName, permissionValue] =
+            allPermissions.find(([, value]) => value === permission) || [];
+
           const found = availablePermissions.find(
             ([, value]) => Number(value) === permission
           );
 
-          return found
-            ? {
-                title: spacesBeforeCapitalLetters(found[0]),
-                value: found[1],
-                group,
-              }
-            : null;
+          return {
+            title: spacesBeforeCapitalLetters(permissionName || ''),
+            value: permissionValue,
+            disabled: !found,
+            group,
+          };
         })
         .filter((item): item is Option => item !== null)
   );
@@ -54,6 +61,7 @@ export function PermissionsSelect({
         options={groupedOptions}
         groupBy={(option) => option.group}
         getOptionLabel={(option) => option.title}
+        getOptionDisabled={(option) => option.disabled}
         isOptionEqualToValue={(option, value) => option.value === value.value}
         filterSelectedOptions
         renderInput={(params) => (

--- a/src/caretogether-pwa/src/Settings/Roles/groupedPermissions.tsx
+++ b/src/caretogether-pwa/src/Settings/Roles/groupedPermissions.tsx
@@ -1,0 +1,111 @@
+import { Permission } from '../../GeneratedClient';
+
+// Grouped permissions by logical categories
+const groupedPermissionsWithoutOther = {
+  FamilyDocuments: [
+    Permission.ViewFamilyDocumentMetadata,
+    Permission.ReadFamilyDocuments,
+    Permission.UploadFamilyDocuments,
+    Permission.DeleteFamilyDocuments,
+  ],
+  PersonUser: [
+    Permission.InvitePersonUser,
+    Permission.EditPersonUserProtectedRoles,
+    Permission.EditPersonUserStandardRoles,
+    Permission.ViewPersonUserLoginInfo,
+  ],
+  ScreensAccess: [
+    Permission.AccessVolunteersScreen,
+    Permission.AccessPartneringFamiliesScreen,
+    Permission.AccessSettingsScreen,
+    Permission.AccessCommunitiesScreen,
+    Permission.AccessReportsScreen,
+    Permission.AccessSupportScreen,
+  ],
+  RolesAndSettings: [Permission.AddEditRoles],
+  FamilyAndPersonInfo: [
+    Permission.ViewFamilyCustomFields,
+    Permission.ViewFamilyHistory,
+    Permission.ViewPersonConcerns,
+    Permission.ViewPersonNotes,
+    Permission.ViewPersonContactInfo,
+    Permission.EditFamilyInfo,
+    Permission.EditPersonConcerns,
+    Permission.EditPersonNotes,
+    Permission.EditPersonContactInfo,
+    Permission.ViewPersonDateOfBirth,
+  ],
+  Notes: [
+    Permission.AddEditDraftNotes,
+    Permission.DiscardDraftNotes,
+    Permission.ApproveNotes,
+    Permission.ViewAllNotes,
+    Permission.AddEditOwnDraftNotes,
+    Permission.DiscardOwnDraftNotes,
+  ],
+  Approval: [
+    Permission.ViewApprovalStatus,
+    Permission.EditApprovalRequirementCompletion,
+    Permission.EditApprovalRequirementExemption,
+    Permission.EditVolunteerRoleParticipation,
+    Permission.ViewApprovalProgress,
+    Permission.ViewApprovalHistory,
+    Permission.ActivateVolunteerFamily,
+  ],
+  Referrals: [
+    Permission.CreateReferral,
+    Permission.EditReferral,
+    Permission.CloseReferral,
+    Permission.ViewReferralCustomFields,
+    Permission.ViewReferralComments,
+    Permission.ViewReferralProgress,
+    Permission.EditReferralRequirementCompletion,
+    Permission.EditReferralRequirementExemption,
+    Permission.ViewReferralHistory,
+  ],
+  Arrangements: [
+    Permission.CreateArrangement,
+    Permission.EditArrangement,
+    Permission.ViewAssignments,
+    Permission.EditAssignments,
+    Permission.ViewArrangementProgress,
+    Permission.ViewAssignedArrangementProgress,
+    Permission.EditArrangementRequirementCompletion,
+    Permission.EditArrangementRequirementExemption,
+    Permission.DeleteArrangement,
+  ],
+  ChildLocation: [
+    Permission.ViewChildLocationHistory,
+    Permission.TrackChildLocationChange,
+  ],
+  Communication: [Permission.SendBulkSms],
+  Communities: [
+    Permission.CreateCommunity,
+    Permission.EditCommunity,
+    Permission.DeleteCommunity,
+    Permission.EditCommunityMemberFamilies,
+    Permission.EditCommunityRoleAssignments,
+    Permission.ViewCommunityDocumentMetadata,
+    Permission.ReadCommunityDocuments,
+    Permission.UploadCommunityDocuments,
+    Permission.DeleteCommunityDocuments,
+  ],
+};
+
+const groupedPermissionsWithoutOtherFlat = Object.values(
+  groupedPermissionsWithoutOther
+).flat();
+
+// In case there are permissions not included in the groupedPermissionsWithoutOther,
+// we add them under the "Other" category.
+export const groupedPermissions =
+  groupedPermissionsWithoutOtherFlat.length < Object.values(Permission).length
+    ? {
+        ...groupedPermissionsWithoutOther,
+        Other: Object.values(Permission).filter(
+          (permission) =>
+            typeof permission !== 'string' && // Exclude string permissions
+            !groupedPermissionsWithoutOtherFlat.includes(permission)
+        ),
+      }
+    : groupedPermissionsWithoutOther;


### PR DESCRIPTION
Organized related permissions into groups to make it easier to find them inside the select:

![image](https://github.com/user-attachments/assets/2feea41e-3d68-4495-8d1c-025dd59fd513)

I also included the permissions that are already added, but disabled them. This way the select options are always the same, creating a more consistent experience.