### PR TITLE
Hide settings submenu when sidebar collapsed

### DIFF
--- a/src/caretogether-pwa/src/Shell/ShellSideNavigation.tsx
+++ b/src/caretogether-pwa/src/Shell/ShellSideNavigation.tsx
@@ -141,13 +141,13 @@ function SideNavigationMenu({ open }: SideNavigationMenuProps) {
             permissions(Permission.AccessSupportScreen)) && <Divider />}
 
           {permissions(Permission.AccessSettingsScreen) && (
-            <>
-              <ListItemLink
-                className="ph-unmask"
-                to={`${locationPrefix}/settings`}
-                primary="Settings"
-                icon={<SettingsIcon sx={{ color: '#fff8' }} />}
-                subitems={[
+            <ListItemLink
+              className="ph-unmask"
+              to={`${locationPrefix}/settings`}
+              primary="Settings"
+              icon={<SettingsIcon sx={{ color: '#fff8' }} />}
+              {...(open && {
+                subitems: [
                   {
                     label: 'Roles',
                     isActive: location.pathname.includes('/settings/roles'),
@@ -158,9 +158,9 @@ function SideNavigationMenu({ open }: SideNavigationMenuProps) {
                     isActive: location.pathname.includes('/settings/locations'),
                     onClick: () => appNavigate.settingsLocations(),
                   },
-                ]}
-              />
-            </>
+                ],
+              })}
+            />
           )}
 
           {permissions(Permission.AccessSupportScreen) && (


### PR DESCRIPTION
Fixed settings menu to show only icon when sidebar is collapsed #959 

<img width="392" height="753" alt="Screenshot (297)" src="https://github.com/user-attachments/assets/9c61dba9-9fb0-48c5-a648-95adb8bc79f8" />
