### PR TITLE
Fix free solo auto complete no working

### DIFF
--- a/src/caretogether-pwa/src/Generic/Forms/CTAutocomplete.tsx
+++ b/src/caretogether-pwa/src/Generic/Forms/CTAutocomplete.tsx
@@ -47,7 +47,31 @@ export function CTAutocomplete<T extends FieldValues>({
           multiple
           freeSolo={freeSolo}
           options={options}
-          isOptionEqualToValue={(option, value) => option.value === value.value}
+          isOptionEqualToValue={(option, value) => {
+            // Handle string vs object comparison
+            if (typeof option === 'string' && typeof value === 'string') {
+              return option === value;
+            }
+
+            if (
+              typeof option === 'object' &&
+              typeof value === 'object' &&
+              option !== null &&
+              value !== null
+            ) {
+              return option.value === value.value;
+            }
+
+            // Handle mixed types - convert to comparable format
+            const optionValue =
+              typeof option === 'string'
+                ? option
+                : option?.title || option?.value;
+            const valueValue =
+              typeof value === 'string' ? value : value?.title || value?.value;
+
+            return optionValue === valueValue;
+          }}
           getOptionLabel={(option) =>
             typeof option === 'string' ? option : option.title
           }


### PR DESCRIPTION
While testing these autocompletes, I realize it wasn't working, probably after https://github.com/CareTogether/CareTogetherCMS/pull/948/files#diff-26b82bc96a9091aefc1afa17dfd7c54683a0a93558f0733ec7af291ebf5b5bb5R50-R53

This isn't the best fix, we might need to rework this component. The typing here is challenging, especially because of react-hook-form integration.