### PR TITLE
Corretly capture exceptions with posthog in global error boundary

### DIFF
--- a/src/caretogether-pwa/src/GlobalErrorBoundary.tsx
+++ b/src/caretogether-pwa/src/GlobalErrorBoundary.tsx
@@ -29,9 +29,8 @@ export class GlobalErrorBoundary extends React.Component<
         errorInfo: JSON.stringify(errorInfo),
       },
     });
-    posthog.capture('GlobalErrorBoundary', {
-      error: error,
-      errorInfo: errorInfo,
+    posthog.captureException(error, {
+      errorInfo,
     });
   }
 


### PR DESCRIPTION
This will help us track errors in PostHog, with stacktraces + sourcemaps. Currently it's only capturing errors in ErrorBoundary as normal events.

Reference: https://posthog.com/docs/error-tracking/installation/react#set-up-error-boundaries