### PR TITLE
 show columns in ActionDefinitions order

### DIFF
--- a/src/caretogether-pwa/src/Model/ConfigurationModel.ts
+++ b/src/caretogether-pwa/src/Model/ConfigurationModel.ts
@@ -83,13 +83,13 @@ export const allApprovalAndOnboardingRequirementsData = selector({
   key: 'allApprovalAndOnboardingRequirementsData',
   get: ({ get }) => {
     const policy = get(policyData);
-    const sortedActionNames =
+    const ActionNames =
       (policy.actionDefinitions &&
-        Object.entries(policy.actionDefinitions)
-          .map(([actionName]) => actionName)
-          .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))) ||
+        Object.entries(policy.actionDefinitions).map(
+          ([actionName]) => actionName
+        )) ||
       [];
-    return sortedActionNames.filter(
+    return ActionNames.filter(
       (actionName) =>
         (policy.volunteerPolicy?.volunteerFamilyRoles &&
           Object.entries(policy.volunteerPolicy.volunteerFamilyRoles).some(


### PR DESCRIPTION
Previously, the Volunteers -Progress view displayed columns in alphabetical order (see 1st screenshot).  
This update changes the logic to follow the ActionDefinitions array order, so columns now appear in the policy order instead (see 2nd screenshot).
<img width="1906" height="962" alt="Screenshot (410)" src="https://github.com/user-attachments/assets/851aabe5-b208-4a78-8f34-f8f532ed3f50" />
<img width="1906" height="934" alt="Screenshot (411)" src="https://github.com/user-attachments/assets/c8b8769a-04e0-4fd8-bcd8-faa87d6ad829" />
