### PR TITLE
Performance improvements on authorization checks

### DIFF
--- a/src/CareTogether.Api/Startup.cs
+++ b/src/CareTogether.Api/Startup.cs
@@ -274,6 +274,7 @@ namespace CareTogether.Api
             );
             services.AddSingleton<IRecordsManager>(
                 new RecordsManager(
+                    policiesResource,
                     authorizationEngine,
                     userAccessCalculation,
                     directoryResource,

--- a/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
@@ -43,14 +43,14 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeFamilyCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             FamilyCommand command
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new FamilyAuthorizationContext(command.FamilyId)
             );
             return permissions.Contains(
@@ -80,7 +80,7 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizePersonCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             Guid familyId,
             PersonCommand command
         )
@@ -88,7 +88,7 @@ namespace CareTogether.Engines.Authorization
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new FamilyAuthorizationContext(familyId)
             );
             return permissions.Contains(
@@ -118,14 +118,14 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeV1CaseCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             V1CaseCommand command
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new FamilyAuthorizationContext(command.FamilyId)
             );
             return permissions.Contains(
@@ -133,8 +133,7 @@ namespace CareTogether.Engines.Authorization
                 {
                     CreateReferral => Permission.CreateV1Case,
                     CompleteReferralRequirement => Permission.EditV1CaseRequirementCompletion,
-                    MarkReferralRequirementIncomplete =>
-                        Permission.EditV1CaseRequirementCompletion,
+                    MarkReferralRequirementIncomplete => Permission.EditV1CaseRequirementCompletion,
                     ExemptReferralRequirement => Permission.EditV1CaseRequirementExemption,
                     UnexemptReferralRequirement => Permission.EditV1CaseRequirementExemption,
                     UpdateCustomReferralField => Permission.EditV1Case,
@@ -150,14 +149,14 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeArrangementsCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             ArrangementsCommand command
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new FamilyAuthorizationContext(command.FamilyId)
             );
             return permissions.Contains(
@@ -218,14 +217,14 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeNoteCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             NoteCommand command
         )
         {
             var userPermissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new FamilyAuthorizationContext(command.FamilyId)
             );
 
@@ -236,11 +235,11 @@ namespace CareTogether.Engines.Authorization
                 command.NoteId
             );
 
-            var noteBelongsToUser = noteEntry?.AuthorId == user.UserId();
+            var noteBelongsToUser = noteEntry?.AuthorId == userContext.User.UserId();
 
             var allowedPerAccessLevel = await CheckAccessLevel(
                 noteEntry?.AccessLevel,
-                user,
+                userContext.User,
                 organizationId,
                 locationId
             );
@@ -508,13 +507,13 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeSendSmsAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user
+            SessionUserContext userContext
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new AllVolunteerFamiliesAuthorizationContext()
             ); //TODO: This could simplify down to 'Global'
             return permissions.Contains(Permission.SendBulkSms);
@@ -523,14 +522,14 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeVolunteerFamilyCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             VolunteerFamilyCommand command
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new FamilyAuthorizationContext(command.FamilyId)
             );
             return permissions.Contains(
@@ -557,14 +556,14 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeVolunteerCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             VolunteerCommand command
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new FamilyAuthorizationContext(command.FamilyId)
             );
             return permissions.Contains(
@@ -587,14 +586,14 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeCommunityCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             CommunityCommand command
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new CommunityAuthorizationContext(command.CommunityId)
             );
             return permissions.Contains(
@@ -619,14 +618,14 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizePersonAccessCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             PersonAccessCommand command
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new GlobalAuthorizationContext()
             );
 
@@ -669,79 +668,69 @@ namespace CareTogether.Engines.Authorization
         public async Task<bool> AuthorizeGenerateUserInviteNonceAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user
+            SessionUserContext userContext
         )
         {
             var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new GlobalAuthorizationContext()
             );
             return permissions.Contains(Permission.InvitePersonUser);
         }
 
         public async Task<CombinedFamilyInfo> DiscloseFamilyAsync(
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             Guid organizationId,
             Guid locationId,
             CombinedFamilyInfo family
         )
         {
-            var userPersonId = user.PersonId(organizationId, locationId);
-            var userFamily =
-                userPersonId == null
-                    ? null
-                    : await directoryResource.FindPersonFamilyAsync(
-                        organizationId,
-                        locationId,
-                        userPersonId.Value
-                    );
-
             var contextPermissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
-                new FamilyAuthorizationContext(family.Family.Id)
+                userContext,
+                new FamilyAuthorizationContext(family.Family.Id, family.Family)
             );
 
             return family with
             {
                 PartneringFamilyInfo =
-                    family.PartneringFamilyInfo == null
-                        ? null
-                        : DisclosePartneringFamilyInfo(
-                            family.PartneringFamilyInfo,
-                            userFamily,
-                            contextPermissions
+                family.PartneringFamilyInfo == null
+                    ? null
+                    : DisclosePartneringFamilyInfo(
+                        family.PartneringFamilyInfo,
+                        userContext.UserFamily,
+                        contextPermissions
                         ),
                 VolunteerFamilyInfo =
-                    family.VolunteerFamilyInfo == null
-                        ? null
+                family.VolunteerFamilyInfo == null
+                    ? null
                         : DiscloseVolunteerFamilyInfo(
                             family.VolunteerFamilyInfo,
                             contextPermissions
                         ),
                 Family = DiscloseFamily(family.Family, contextPermissions),
                 Notes = (
-                    await family
-                        .Notes.Select(async note =>
-                            (
+                await family
+                    .Notes.Select(async note =>
+                        (
+                            note,
+                            canDisclose: await DiscloseNoteAsync(
                                 note,
-                                canDisclose: await DiscloseNoteAsync(
-                                    note,
-                                    organizationId,
-                                    locationId,
-                                    userPersonId,
-                                    contextPermissions,
-                                    user
-                                )
+                                organizationId,
+                                locationId,
+                                userContext.User.PersonId(organizationId, locationId),
+                                contextPermissions,
+                                userContext.User
                             )
                         )
-                        .WhenAll()
-                )
-                    .Where(x => x.canDisclose)
-                    .Select(x => x.note)
+                    )
+                    .WhenAll()
+            )
+                .Where(x => x.canDisclose)
+                .Select(x => x.note)
                     .ToImmutableList(),
                 UploadedDocuments = family.UploadedDocuments, //TODO: Disclosure logic is needed here as well,
                 MissingCustomFields = contextPermissions.Contains(Permission.ViewFamilyCustomFields)
@@ -752,7 +741,7 @@ namespace CareTogether.Engines.Authorization
         }
 
         public async Task<CommunityInfo> DiscloseCommunityAsync(
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             Guid organizationId,
             Guid locationId,
             CommunityInfo community
@@ -761,7 +750,7 @@ namespace CareTogether.Engines.Authorization
             var contextPermissions = await userAccessCalculation.AuthorizeUserAccessAsync(
                 organizationId,
                 locationId,
-                user,
+                userContext,
                 new CommunityAuthorizationContext(community.Community.Id)
             );
 
@@ -819,9 +808,7 @@ namespace CareTogether.Engines.Authorization
                 )
                     ? v1Case.CompletedCustomFields
                     : ImmutableList<CompletedCustomFieldInfo>.Empty,
-                MissingCustomFields = contextPermissions.Contains(
-                    Permission.ViewV1CaseCustomFields
-                )
+                MissingCustomFields = contextPermissions.Contains(Permission.ViewV1CaseCustomFields)
                     ? v1Case.MissingCustomFields
                     : ImmutableList<string>.Empty,
                 CompletedRequirements = contextPermissions.Contains(Permission.ViewV1CaseProgress)
@@ -854,9 +841,7 @@ namespace CareTogether.Engines.Authorization
                                 )
                                     ? arrangement.Comments
                                     : null,
-                                Reason = contextPermissions.Contains(
-                                    Permission.ViewV1CaseComments
-                                )
+                                Reason = contextPermissions.Contains(Permission.ViewV1CaseComments)
                                     ? arrangement.Reason
                                     : null,
                                 CompletedRequirements = contextPermissions.Contains(

--- a/src/CareTogether.Core/Engines/Authorization/IAuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/IAuthorizationEngine.cs
@@ -22,23 +22,26 @@ namespace CareTogether.Engines.Authorization
 
     public sealed record AllVolunteerFamiliesAuthorizationContext() : AuthorizationContext;
 
-    public sealed record FamilyAuthorizationContext(Guid FamilyId) : AuthorizationContext;
+    public sealed record FamilyAuthorizationContext(Guid FamilyId, Family? Family = null)
+        : AuthorizationContext;
 
     public sealed record CommunityAuthorizationContext(Guid CommunityId) : AuthorizationContext;
+
+    public sealed record SessionUserContext(ClaimsPrincipal User, Family? UserFamily);
 
     public interface IAuthorizationEngine
     {
         Task<bool> AuthorizeFamilyCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             FamilyCommand command
         );
 
         Task<bool> AuthorizePersonCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             Guid familyId,
             PersonCommand command
         );
@@ -46,73 +49,73 @@ namespace CareTogether.Engines.Authorization
         Task<bool> AuthorizeV1CaseCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             V1CaseCommand command
         );
 
         Task<bool> AuthorizeArrangementsCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             ArrangementsCommand command
         );
 
         Task<bool> AuthorizeNoteCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             NoteCommand command
         );
 
         Task<bool> AuthorizeSendSmsAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user
+            SessionUserContext user
         );
 
         Task<bool> AuthorizeVolunteerFamilyCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             VolunteerFamilyCommand command
         );
 
         Task<bool> AuthorizeVolunteerCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             VolunteerCommand command
         );
 
         Task<bool> AuthorizeCommunityCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             CommunityCommand command
         );
 
         Task<bool> AuthorizePersonAccessCommandAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext user,
             PersonAccessCommand command
         );
 
         Task<bool> AuthorizeGenerateUserInviteNonceAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user
+            SessionUserContext user
         );
 
         Task<CombinedFamilyInfo> DiscloseFamilyAsync(
-            ClaimsPrincipal user,
+            SessionUserContext user,
             Guid organizationId,
             Guid locationId,
             CombinedFamilyInfo family
         );
 
         Task<CommunityInfo> DiscloseCommunityAsync(
-            ClaimsPrincipal user,
+            SessionUserContext user,
             Guid organizationId,
             Guid locationId,
             CommunityInfo community

--- a/src/CareTogether.Core/Engines/Authorization/IUserAccessCalculation.cs
+++ b/src/CareTogether.Core/Engines/Authorization/IUserAccessCalculation.cs
@@ -10,7 +10,7 @@ namespace CareTogether.Engines.Authorization
         Task<ImmutableList<Permission>> AuthorizeUserAccessAsync(
             Guid organizationId,
             Guid locationId,
-            ClaimsPrincipal user,
+            SessionUserContext userContext,
             AuthorizationContext context
         );
     }

--- a/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
+++ b/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using CareTogether.Engines.Authorization;
 using CareTogether.Engines.PolicyEvaluation;
@@ -50,21 +49,17 @@ namespace CareTogether.Managers
 
         public async Task<CombinedFamilyInfo?> RenderCombinedFamilyInfoAsync(
             Guid organizationId,
+            EffectiveLocationPolicy locationPolicy,
             Guid locationId,
             Guid familyId,
-            ClaimsPrincipal user
+            Family? family,
+            SessionUserContext userContext
         )
         {
-            var locationPolicy = await policiesResource.GetCurrentPolicy(
-                organizationId,
-                locationId
-            );
+            family =
+                family
+                ?? await directoryResource.FindFamilyAsync(organizationId, locationId, familyId);
 
-            var family = await directoryResource.FindFamilyAsync(
-                organizationId,
-                locationId,
-                familyId
-            );
             if (family == null)
                 throw new InvalidOperationException("The specified family ID was not found.");
 
@@ -184,11 +179,12 @@ namespace CareTogether.Managers
             );
 
             var disclosedFamily = await authorizationEngine.DiscloseFamilyAsync(
-                user,
+                userContext,
                 organizationId,
                 locationId,
                 renderedFamily
             );
+
             return disclosedFamily;
         }
 

--- a/test/CareTogether.Core.Test/AuthorizationEngineTests/AuthorizeNoteCommandAsync.cs
+++ b/test/CareTogether.Core.Test/AuthorizationEngineTests/AuthorizeNoteCommandAsync.cs
@@ -104,7 +104,7 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
                     x.AuthorizeUserAccessAsync(
                         It.IsAny<Guid>(),
                         It.IsAny<Guid>(),
-                        It.IsAny<ClaimsPrincipal>(),
+                        It.IsAny<SessionUserContext>(),
                         It.IsAny<AuthorizationContext>()
                     )
                 )
@@ -178,7 +178,7 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
             var response = await dut!.AuthorizeNoteCommandAsync(
                 noteId1,
                 noteId2,
-                user,
+                new SessionUserContext(user, null),
                 new CreateDraftNote(guid1, newDraftNoteGuid, "Test Note", null)
             );
 
@@ -207,7 +207,7 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
                 _ => throw new ArgumentException("Invalid command type", nameof(commandType)),
             };
 
-            var response = await dut!.AuthorizeNoteCommandAsync(guid1, guid2, user, command);
+            var response = await dut!.AuthorizeNoteCommandAsync(guid1, guid2, new SessionUserContext(user, null), command);
 
             Assert.IsTrue(response);
         }
@@ -230,7 +230,7 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
                 _ => throw new ArgumentException("Invalid command type", nameof(commandType)),
             };
 
-            var response = await dut!.AuthorizeNoteCommandAsync(guid1, guid2, user, command);
+            var response = await dut!.AuthorizeNoteCommandAsync(guid1, guid2, new SessionUserContext(user, null), command);
 
             Assert.IsFalse(response);
         }
@@ -253,7 +253,7 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
                 _ => throw new ArgumentException("Invalid command type", nameof(commandType)),
             };
 
-            var response = await dut!.AuthorizeNoteCommandAsync(guid1, guid2, user, command);
+            var response = await dut!.AuthorizeNoteCommandAsync(guid1, guid2, new SessionUserContext(user, null), command);
 
             Assert.IsFalse(response);
         }
@@ -287,7 +287,7 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
                 _ => throw new ArgumentException("Invalid command type", nameof(commandType)),
             };
 
-            var response = await dut!.AuthorizeNoteCommandAsync(guid1, guid2, user, command);
+            var response = await dut!.AuthorizeNoteCommandAsync(guid1, guid2, new SessionUserContext(user, null), command);
 
             Assert.IsTrue(response);
         }

--- a/test/CareTogether.Core.Test/AuthorizationEngineTests/AuthorizeUserAccess.cs
+++ b/test/CareTogether.Core.Test/AuthorizationEngineTests/AuthorizeUserAccess.cs
@@ -306,49 +306,49 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
             var result0 = await userAccessCalculation!.AuthorizeUserAccessAsync(
                 guid1,
                 guid2,
-                user,
+                new SessionUserContext(user, null),
                 new FamilyAuthorizationContext(guid0)
             );
             var result1 = await userAccessCalculation!.AuthorizeUserAccessAsync(
                 guid1,
                 guid2,
-                user,
+                new SessionUserContext(user, null),
                 new FamilyAuthorizationContext(guid1)
             );
             var result2 = await userAccessCalculation!.AuthorizeUserAccessAsync(
                 guid1,
                 guid2,
-                user,
+                new SessionUserContext(user, null),
                 new FamilyAuthorizationContext(guid2)
             );
             var result3 = await userAccessCalculation!.AuthorizeUserAccessAsync(
                 guid1,
                 guid2,
-                user,
+                new SessionUserContext(user, null),
                 new FamilyAuthorizationContext(guid3)
             );
             var result4 = await userAccessCalculation!.AuthorizeUserAccessAsync(
                 guid1,
                 guid2,
-                user,
+                new SessionUserContext(user, null),
                 new FamilyAuthorizationContext(guid4)
             );
             var result5 = await userAccessCalculation!.AuthorizeUserAccessAsync(
                 guid1,
                 guid2,
-                user,
+                new SessionUserContext(user, null),
                 new FamilyAuthorizationContext(guid5)
             );
             var resultCommunity1 = await userAccessCalculation!.AuthorizeUserAccessAsync(
                 guid1,
                 guid2,
-                user,
+                new SessionUserContext(user, null),
                 new CommunityAuthorizationContext(guid1)
             );
             var resultCommunity2 = await userAccessCalculation!.AuthorizeUserAccessAsync(
                 guid1,
                 guid2,
-                user,
+                new SessionUserContext(user, null),
                 new CommunityAuthorizationContext(guid2)
             );
 


### PR DESCRIPTION
While working with big datasets (4,000+ records), the /Records endpoint gets incredibly slow to respond.

This PR introduces some changes in the way we handle authorization and data disclosure, moving some lookups up in the call tree, so that those lookups are done only once per request, instead of being done on every family disclose and authorization check. 

This reduced the average time for the endpoint to respond on my machine, from ~4min to less than 10s:

## Before:

<img width="794" height="509" alt="2025-11-27_22-43_before" src="https://github.com/user-attachments/assets/7b4d6488-96f9-4155-8d8a-67396c1c2c82" />

## After:

<img width="796" height="460" alt="2025-11-27_22-28_after" src="https://github.com/user-attachments/assets/983f7aab-555b-4f33-85d5-9fc961e166f9" />

## Profilling before:
(lots of family lookups for user in session, for example)

<img width="2507" height="1224" alt="image" src="https://github.com/user-attachments/assets/026ffdc7-99c5-4747-9823-d248f5ac70cd" />

## Profilling after:
(family lookup is made only a few times at the beginning)

<img width="2508" height="1226" alt="image" src="https://github.com/user-attachments/assets/f4af2af6-37ec-4ad9-b630-d7e1c73646d8" />
