### PR TITLE
Fix individual missing requirements handling

### DIFF
--- a/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
@@ -148,6 +148,7 @@ namespace CareTogether.Engines.PolicyEvaluation
                     {
                         var roleName = kv.Key;
 
+                        // If role has achieved Prospective or higher status, hide applications
                         var individualHighestStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
                             kv.Value.RoleVersionApprovals
                         );


### PR DESCRIPTION
With #1023, a bug was introduced where when completing an application for an individual role in a family member, it would the application requirement from the other family members. This PR fixes that.

## Before

Family Coach Application is missing

<img width="681" height="562" alt="Screenshot 2025-12-01 at 16 18 36" src="https://github.com/user-attachments/assets/d02497a6-4810-4869-a800-426c214f99ed" />

## After

Family Coach Application is **not** missing

<img width="679" height="558" alt="Screenshot 2025-12-01 at 16 22 37" src="https://github.com/user-attachments/assets/ca91425e-82b8-4998-b0c6-d0365a37ca1d" />
