### PR TITLE
support chat bubble

### DIFF
--- a/src/caretogether-pwa/src/Hooks/useFeaturebase.tsx
+++ b/src/caretogether-pwa/src/Hooks/useFeaturebase.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useMediaQuery, useTheme } from '@mui/material';
 import { atom, useSetRecoilState } from 'recoil';
 import { useLoadable } from './useLoadable';
 import { accountInfoState } from '../Authentication/Auth';
@@ -28,6 +29,9 @@ declare global {
 }
 
 export const useFeaturebase = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
   // Get user data from Recoil state
   const accountInfo = useLoadable(accountInfoState);
   const organizationConfiguration = useLoadable(organizationConfigurationQuery);
@@ -67,6 +71,7 @@ export const useFeaturebase = () => {
           userHash: userHash, // Add the generated userHash for identity verification
           theme: 'light',
           language: 'en',
+          ...(isMobile ? { verticalPadding: 70 } : {}),
           companies: [
             {
               id: locationContext?.organizationId,
@@ -114,6 +119,7 @@ export const useFeaturebase = () => {
     organizationConfiguration,
     locationConfiguration,
     locationContext,
+    isMobile,
     setChangelogUnreadCount,
   ]);
 

--- a/src/caretogether-pwa/src/Settings/Roles/RoleEdit.tsx
+++ b/src/caretogether-pwa/src/Settings/Roles/RoleEdit.tsx
@@ -44,6 +44,10 @@ import { isRoleEditable } from './isRoleEditable';
 import { ContextualPermissionSetRowAutocomplete } from './ContextualPermissionSetRowWithAutocomplete';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { Breadcrumbs } from '../../Generic/Breadcrumbs';
+import {
+  DESKTOP_BOTTOM_SAFE_AREA,
+  MOBILE_BOTTOM_SAFE_AREA,
+} from '../../Shell/ShellRootLayout';
 
 export function RoleEdit({
   roleDefinition,
@@ -138,8 +142,11 @@ export function RoleEdit({
   return (
     <Stack
       className="ph-unmask"
-      paddingY={2}
-      height="calc(100vh - 48px)"
+      paddingTop={2}
+      height={{
+        xs: `calc(100vh - 48px - ${MOBILE_BOTTOM_SAFE_AREA}px)`,
+        md: `calc(100vh - 48px - ${DESKTOP_BOTTOM_SAFE_AREA}px)`,
+      }}
       spacing={0}
     >
       <Box>
@@ -331,7 +338,7 @@ export function RoleEdit({
         </MenuItem>
       </Menu>
 
-      <Box paddingY={2} borderTop={1} borderColor="divider">
+      <Box paddingTop={2} borderTop={1} borderColor="divider">
         <Stack direction="row" justifyContent="flex-end" alignItems="center">
           {dirty && (
             <Typography sx={{ fontStyle: 'italic' }} mr={2}>

--- a/src/caretogether-pwa/src/Shell/ShellRootLayout.tsx
+++ b/src/caretogether-pwa/src/Shell/ShellRootLayout.tsx
@@ -14,6 +14,13 @@ import React from 'react';
 import { ProgressBackdrop } from './ProgressBackdrop';
 import { useGlobalSnackBar } from '../Hooks/useGlobalSnackBar';
 
+const CHAT_WIDGET_SAFE_HEIGHT = 96;
+const MOBILE_BOTTOM_NAV_HEIGHT = 56;
+
+export const DESKTOP_BOTTOM_SAFE_AREA = CHAT_WIDGET_SAFE_HEIGHT;
+export const MOBILE_BOTTOM_SAFE_AREA =
+  CHAT_WIDGET_SAFE_HEIGHT + MOBILE_BOTTOM_NAV_HEIGHT;
+
 function ShellRootLayout({ children }: React.PropsWithChildren) {
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
@@ -24,8 +31,6 @@ function ShellRootLayout({ children }: React.PropsWithChildren) {
   );
 
   const drawerWidth = menuDrawerOpen ? 190 : 48;
-  const CHAT_WIDGET_SAFE_HEIGHT = 96;
-  const MOBILE_BOTTOM_NAV_HEIGHT = 56;
 
   const { message, resetSnackBar } = useGlobalSnackBar();
 
@@ -54,8 +59,8 @@ function ShellRootLayout({ children }: React.PropsWithChildren) {
           sx={{
             marginTop: { xs: 7, sm: 8, md: 6 },
             paddingBottom: {
-              xs: CHAT_WIDGET_SAFE_HEIGHT + MOBILE_BOTTOM_NAV_HEIGHT,
-              md: CHAT_WIDGET_SAFE_HEIGHT,
+              xs: `${MOBILE_BOTTOM_SAFE_AREA}px`,
+              md: `${DESKTOP_BOTTOM_SAFE_AREA}px`,
             },
             backgroundColor: '#fff',
           }}


### PR DESCRIPTION
Added a global bottom safe area in the root layout so content is never covered by the support chat widget, including Save buttons and other page actions. Extra padding is applied on mobile to account for the bottom navigation.