### PR TITLE
Handle signed-in users without organization access

### DIFF
--- a/src/caretogether-pwa/src/Access/NoOrganizationAccessScreen.tsx
+++ b/src/caretogether-pwa/src/Access/NoOrganizationAccessScreen.tsx
@@ -1,0 +1,63 @@
+import {
+  Box,
+  Button,
+  Container,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import {
+  Logout as LogoutIcon,
+  Refresh as RefreshIcon,
+} from '@mui/icons-material';
+import { useRecoilRefresher_UNSTABLE } from 'recoil';
+import { logoutAsync } from '../Authentication/Auth';
+import { userOrganizationAccessQuery } from '../Model/Data';
+
+export function NoOrganizationAccessScreen() {
+  const refreshUserOrganizationAccess = useRecoilRefresher_UNSTABLE(
+    userOrganizationAccessQuery
+  );
+
+  return (
+    <Container maxWidth="sm" sx={{ py: { xs: 6, sm: 10 } }}>
+      <Paper variant="outlined" sx={{ p: { xs: 3, sm: 5 } }}>
+        <Stack spacing={3}>
+          <Box>
+            <Typography variant="h4" component="h1" gutterBottom>
+              No organization access yet
+            </Typography>
+            <Typography color="text.secondary">
+              You're signed in, but this account is not connected to a
+              CareTogether organization or location yet.
+            </Typography>
+          </Box>
+
+          <Typography color="text.secondary">
+            Ask your CareTogether administrator to send or resend your invite.
+            If you already have an invite, open that link from this browser and
+            accept it to finish connecting your account.
+          </Typography>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+            <Button
+              variant="contained"
+              startIcon={<RefreshIcon />}
+              onClick={refreshUserOrganizationAccess}
+            >
+              Check Again
+            </Button>
+            <Button
+              variant="text"
+              color="inherit"
+              startIcon={<LogoutIcon />}
+              onClick={() => logoutAsync()}
+            >
+              Log Out
+            </Button>
+          </Stack>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/caretogether-pwa/src/Access/RootRoute.tsx
+++ b/src/caretogether-pwa/src/Access/RootRoute.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useLoadable } from '../Hooks/useLoadable';
+import { useLocalStorage } from '../Hooks/useLocalStorage';
+import { userOrganizationAccessQuery } from '../Model/Data';
+import type { LocationContext } from '../Model/Data';
+import { ProgressBackdrop } from '../Shell/ProgressBackdrop';
+import {
+  LAST_VISITED_LOCATION,
+  preferredAccessibleLocation,
+} from './accessRouteHelpers';
+import { NoOrganizationAccessScreen } from './NoOrganizationAccessScreen';
+
+export function RootRoute() {
+  const userOrganizationAccess = useLoadable(userOrganizationAccessQuery);
+  const [lastVisitedLocation] = useLocalStorage<LocationContext | null>(
+    LAST_VISITED_LOCATION,
+    null
+  );
+  const targetContext = useMemo(
+    () =>
+      userOrganizationAccess
+        ? preferredAccessibleLocation(
+            userOrganizationAccess,
+            lastVisitedLocation
+          )
+        : null,
+    [userOrganizationAccess, lastVisitedLocation]
+  );
+
+  if (userOrganizationAccess == null) {
+    return (
+      <ProgressBackdrop opaque>
+        <p>Loading access...</p>
+      </ProgressBackdrop>
+    );
+  }
+
+  if (targetContext == null) {
+    return <NoOrganizationAccessScreen />;
+  }
+
+  return (
+    <Navigate
+      to={`/org/${targetContext.organizationId}/${targetContext.locationId}/`}
+      replace
+    />
+  );
+}

--- a/src/caretogether-pwa/src/Access/accessRouteHelpers.ts
+++ b/src/caretogether-pwa/src/Access/accessRouteHelpers.ts
@@ -1,0 +1,55 @@
+import type { LocationContext } from '../Model/Data';
+import type { UserAccess } from '../GeneratedClient';
+
+export const LAST_VISITED_LOCATION = 'lastVisitedLocation';
+
+export function hasLocationAccess(
+  userOrganizationAccess: UserAccess,
+  locationContext: LocationContext
+) {
+  return (
+    userOrganizationAccess.organizations?.some(
+      (organization) =>
+        organization.organizationId === locationContext.organizationId &&
+        organization.locations?.some(
+          (location) => location.locationId === locationContext.locationId
+        )
+    ) ?? false
+  );
+}
+
+function firstAccessibleLocation(
+  userOrganizationAccess: UserAccess
+): LocationContext | null {
+  const firstOrganization = userOrganizationAccess.organizations?.find(
+    (organization) =>
+      organization.organizationId &&
+      organization.locations?.some((location) => location.locationId)
+  );
+  const firstLocation = firstOrganization?.locations?.find(
+    (location) => location.locationId
+  );
+
+  if (!firstOrganization?.organizationId || !firstLocation?.locationId) {
+    return null;
+  }
+
+  return {
+    organizationId: firstOrganization.organizationId,
+    locationId: firstLocation.locationId,
+  };
+}
+
+export function preferredAccessibleLocation(
+  userOrganizationAccess: UserAccess,
+  lastVisitedLocation: LocationContext | null
+): LocationContext | null {
+  if (
+    lastVisitedLocation &&
+    hasLocationAccess(userOrganizationAccess, lastVisitedLocation)
+  ) {
+    return lastVisitedLocation;
+  }
+
+  return firstAccessibleLocation(userOrganizationAccess);
+}

--- a/src/caretogether-pwa/src/AppRoutes.tsx
+++ b/src/caretogether-pwa/src/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Dashboard } from './Dashboard/Dashboard';
 import {
   Navigate,
@@ -33,8 +33,13 @@ import { usePostHogGroups } from './Utilities/Instrumentation/usePostHogGroups';
 import { Support } from './Support';
 import { Reports } from './Reports/Reports';
 import { V1Referrals } from './V1Referrals/V1Referrals';
-
-const LAST_VISITED_LOCATION = 'lastVisitedLocation';
+import {
+  hasLocationAccess,
+  LAST_VISITED_LOCATION,
+  preferredAccessibleLocation,
+} from './Access/accessRouteHelpers';
+import { NoOrganizationAccessScreen } from './Access/NoOrganizationAccessScreen';
+import { RootRoute } from './Access/RootRoute';
 
 function RouteMigrator() {
   const trace = useScopedTrace('RouteMigrator');
@@ -61,39 +66,44 @@ function RouteMigrator() {
   );
   trace(`lastVisitedLocation contents: ${JSON.stringify(lastVisitedLocation)}`);
 
+  const migrationTargetContext = useMemo(
+    () =>
+      userOrganizationAccess
+        ? preferredAccessibleLocation(
+            userOrganizationAccess,
+            lastVisitedLocation
+          )
+        : null,
+    [userOrganizationAccess, lastVisitedLocation]
+  );
+
   useEffect(() => {
     if (userOrganizationAccess == null) {
       return;
     }
 
-    let migrationTargetContext: LocationContext | null = null;
-
-    if (lastVisitedLocation) {
-      migrationTargetContext = lastVisitedLocation;
-    } else {
-      const firstOrganization = userOrganizationAccess?.organizations?.at(0);
-      const firstLocation = firstOrganization?.locations?.at(0);
-      trace(`firstLocation ID: ${JSON.stringify(firstLocation?.locationId)}`);
-      migrationTargetContext =
-        firstOrganization && firstLocation
-          ? {
-              organizationId: firstOrganization.organizationId!,
-              locationId: firstLocation.locationId!,
-            }
-          : null;
-    }
-
-    if (migrationTargetContext != null) {
-      //TODO: Only do this if the old path is a valid/migrate-able path to begin with.
-      const target =
-        `/org/${migrationTargetContext.organizationId}/${migrationTargetContext.locationId}${location.pathname}` +
-        `${location.search}${location.hash}`;
-      trace(`Attempting to migrate route to: ${target}`);
-      navigate(target);
-    } else {
+    if (migrationTargetContext == null) {
       trace('Could not migrate route.');
+      return;
     }
-  }, [trace, navigate, location, userOrganizationAccess, lastVisitedLocation]);
+
+    //TODO: Only do this if the old path is a valid/migrate-able path to begin with.
+    const target =
+      `/org/${migrationTargetContext.organizationId}/${migrationTargetContext.locationId}${location.pathname}` +
+      `${location.search}${location.hash}`;
+    trace(`Attempting to migrate route to: ${target}`);
+    navigate(target);
+  }, [
+    trace,
+    navigate,
+    location,
+    userOrganizationAccess,
+    migrationTargetContext,
+  ]);
+
+  if (userOrganizationAccess != null && migrationTargetContext == null) {
+    return <NoOrganizationAccessScreen />;
+  }
 
   return (
     <ProgressBackdrop opaque>
@@ -115,10 +125,7 @@ function CasesToClientsRedirect() {
   const targetPath = location.pathname.replace('/cases', '/clients');
 
   return (
-    <Navigate
-      to={`${targetPath}${location.search}${location.hash}`}
-      replace
-    />
+    <Navigate to={`${targetPath}${location.search}${location.hash}`} replace />
   );
 }
 
@@ -126,12 +133,16 @@ function CasesToClientsRedirect() {
 //   throw new Error(`The URL path '${window.location.href}' is invalid.`);
 // }
 
-function LocationContextWrapper() {
+type AuthorizedLocationContextWrapperProps = {
+  organizationId: string;
+  locationId: string;
+};
+
+function AuthorizedLocationContextWrapper({
+  organizationId,
+  locationId,
+}: AuthorizedLocationContextWrapperProps) {
   const trace = useScopedTrace('LocationContext');
-  const { organizationId, locationId } = useParams<{
-    organizationId: string;
-    locationId: string;
-  }>();
 
   const [selectedLocationContext, setSelectedLocationContext] =
     useRecoilStateLoadable(selectedLocationContextState);
@@ -198,6 +209,68 @@ function LocationContextWrapper() {
   );
 }
 
+function LocationContextWrapper() {
+  const { organizationId, locationId } = useParams<{
+    organizationId: string;
+    locationId: string;
+  }>();
+  const userOrganizationAccess = useLoadable(userOrganizationAccessQuery);
+  const [lastVisitedLocation] = useLocalStorage<LocationContext | null>(
+    LAST_VISITED_LOCATION,
+    null
+  );
+
+  const requestedLocationContext = useMemo(
+    () =>
+      organizationId && locationId
+        ? { organizationId: organizationId, locationId: locationId }
+        : null,
+    [organizationId, locationId]
+  );
+
+  const fallbackLocationContext = useMemo(
+    () =>
+      userOrganizationAccess
+        ? preferredAccessibleLocation(
+            userOrganizationAccess,
+            lastVisitedLocation
+          )
+        : null,
+    [userOrganizationAccess, lastVisitedLocation]
+  );
+
+  if (userOrganizationAccess == null) {
+    return (
+      <ProgressBackdrop opaque>
+        <p>Loading access...</p>
+      </ProgressBackdrop>
+    );
+  }
+
+  if (
+    requestedLocationContext == null ||
+    !hasLocationAccess(userOrganizationAccess, requestedLocationContext)
+  ) {
+    if (fallbackLocationContext == null) {
+      return <NoOrganizationAccessScreen />;
+    }
+
+    return (
+      <Navigate
+        to={`/org/${fallbackLocationContext.organizationId}/${fallbackLocationContext.locationId}/`}
+        replace
+      />
+    );
+  }
+
+  return (
+    <AuthorizedLocationContextWrapper
+      organizationId={requestedLocationContext.organizationId}
+      locationId={requestedLocationContext.locationId}
+    />
+  );
+}
+
 export function AppRoutes() {
   return (
     <Routes>
@@ -217,7 +290,7 @@ export function AppRoutes() {
       <Route path="/communities/*" element={<RouteMigrator />} />
       <Route path="/settings/*" element={<RouteMigrator />} />
       <Route path="/support/*" element={<RouteMigrator />} />
-      <Route path="/" element={<RouteMigrator />} />
+      <Route path="/" element={<RootRoute />} />
       <Route path="*" element={<RouteError />} />
     </Routes>
   );


### PR DESCRIPTION
## Summary
- Add a dedicated no-organization-access screen for signed-in users who are not connected to any CareTogether org/location
- Route post-login root traffic through a new RootRoute that redirects to a valid location or shows the no-access screen
- Guard scoped /org/:organizationId/:locationId routes so stale URLs from another account do not set invalid location context
- Extract access route helpers and screen components into src/caretogether-pwa/src/Access

<img width="1564" height="1217" alt="localhost_3000_org_11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-222222222222_referrals" src="https://github.com/user-attachments/assets/1ba5f4c7-52db-4568-b4a3-8123d5e80546" />


## Validation
- npm run type-check
- npx eslint src/AppRoutes.tsx src/Access/accessRouteHelpers.ts src/Access/NoOrganizationAccessScreen.tsx src/Access/RootRoute.tsx --ext ts,tsx --report-unused-disable-directives --max-warnings 0
- npm run build