### PR TITLE
Fix select label rendering

### DIFF
--- a/src/caretogether-pwa/src/Families/AddAdultDialog.tsx
+++ b/src/caretogether-pwa/src/Families/AddAdultDialog.tsx
@@ -183,6 +183,7 @@ export function AddAdultDialog({ onClose }: AddAdultDialogProps) {
                 </InputLabel>
                 <Select
                   labelId="family-relationship-label"
+                  label="Relationship to Family"
                   id="family-relationship"
                   value={relationshipToFamily}
                   onChange={(e) =>
@@ -279,6 +280,7 @@ export function AddAdultDialog({ onClose }: AddAdultDialogProps) {
                 <InputLabel id="ethnicity-label">Ethnicity</InputLabel>
                 <Select
                   labelId="ethnicity-label"
+                  label="Ethnicity"
                   id="ethnicity"
                   value={ethnicity}
                   onChange={(e) =>

--- a/src/caretogether-pwa/src/Families/AddChildDialog.tsx
+++ b/src/caretogether-pwa/src/Families/AddChildDialog.tsx
@@ -287,6 +287,7 @@ export function AddChildDialog({ onClose }: AddChildDialogProps) {
                 <InputLabel id="ethnicity-label">Ethnicity</InputLabel>
                 <Select
                   labelId="ethnicity-label"
+                  label="Ethnicity"
                   id="ethnicity"
                   value={ethnicity}
                   onChange={(e) =>

--- a/src/caretogether-pwa/src/Families/AdultFamilyRelationshipEditor.tsx
+++ b/src/caretogether-pwa/src/Families/AdultFamilyRelationshipEditor.tsx
@@ -55,6 +55,7 @@ export function AdultFamilyRelationshipEditor({
               </InputLabel>
               <Select
                 labelId="family-relationship-label"
+                label="Relationship to Family"
                 id="family-relationship"
                 value={editor.value?.relationshipToFamily}
                 onChange={(e) =>

--- a/src/caretogether-pwa/src/Families/EthnicityEditor.tsx
+++ b/src/caretogether-pwa/src/Families/EthnicityEditor.tsx
@@ -28,6 +28,7 @@ export function EthnicityEditor({ familyId, person }: PersonEditorProps) {
               <InputLabel id="ethnicity-label">Ethnicity</InputLabel>
               <Select
                 labelId="ethnicity-label"
+                label="Ethnicity"
                 id="ethnicity"
                 value={editor.value || ''}
                 onChange={(e) => editor.setValue(e.target.value as string)}

--- a/src/caretogether-pwa/src/Families/PrimaryContactEditor.tsx
+++ b/src/caretogether-pwa/src/Families/PrimaryContactEditor.tsx
@@ -44,6 +44,7 @@ export function PrimaryContactEditor({ family }: PrimaryContactEditorProps) {
         <InputLabel id="primarycontact-label">Primary Contact</InputLabel>
         <Select
           labelId="primarycontact-label"
+          label="Primary Contact"
           id="primarycontact"
           value={editor.value}
           onChange={(e) => editor.setValue(e.target.value as string)}

--- a/src/caretogether-pwa/src/Requirements/CompleteOtherDialog.tsx
+++ b/src/caretogether-pwa/src/Requirements/CompleteOtherDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogActions,
   Button,
   Autocomplete,
+  Box,
   TextField,
 } from '@mui/material';
 import { useState, useMemo } from 'react';
@@ -54,16 +55,18 @@ export function CompleteOtherDialog({
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>Complete other...</DialogTitle>
 
-      <DialogContent sx={{ mt: 2 }}>
-        <Autocomplete
-          options={allActionNames}
-          getOptionLabel={(opt) => opt}
-          value={selectedRequirement}
-          onChange={(_, value) => setSelectedRequirement(value)}
-          renderInput={(params) => (
-            <TextField {...params} label="Search any action" fullWidth />
-          )}
-        />
+      <DialogContent>
+        <Box sx={{ pt: 2 }}>
+          <Autocomplete
+            options={allActionNames}
+            getOptionLabel={(opt) => opt}
+            value={selectedRequirement}
+            onChange={(_, value) => setSelectedRequirement(value)}
+            renderInput={(params) => (
+              <TextField {...params} label="Search any action" fullWidth />
+            )}
+          />
+        </Box>
       </DialogContent>
 
       <DialogActions>

--- a/src/caretogether-pwa/src/Requirements/MissingRequirementDialog.tsx
+++ b/src/caretogether-pwa/src/Requirements/MissingRequirementDialog.tsx
@@ -653,6 +653,7 @@ export function MissingRequirementDialog({
                     <InputLabel id="document-label">Document</InputLabel>
                     <Select
                       labelId="document-label"
+                      label="Document"
                       id="document"
                       value={documentId}
                       onChange={(e) => setDocumentId(e.target.value as string)}

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementReason.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementReason.tsx
@@ -46,11 +46,12 @@ export function ArrangementReason({
           Reason:&nbsp;
           {editor.editing ? (
             <FormControl required fullWidth size="small">
-              <InputLabel id="arrangement-reason">
+              <InputLabel id="arrangement-reason-label">
                 Reason for Request
               </InputLabel>
               <Select
                 labelId="arrangement-reason-label"
+                label="Reason for Request"
                 id="arrangement-reason"
                 value={editor.value || ''}
                 onChange={(e) => editor.setValue(e.target.value)}

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/CreateArrangementDialog.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/CreateArrangementDialog.tsx
@@ -162,6 +162,7 @@ export function CreateArrangementDialog({
                   </InputLabel>
                   <Select
                     labelId="arrangement-reason-label"
+                    label="Reason for Request"
                     id="arrangement-reason"
                     value={reason || ''}
                     onChange={(e) =>

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/TrackChildLocationDialog.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/TrackChildLocationDialog.tsx
@@ -475,6 +475,7 @@ export function TrackChildLocationDialog({
                       </InputLabel>
                       <Select
                         labelId="assignee-label"
+                        label="Receiving Adult"
                         id="assignee"
                         value={selectedAssigneeKey}
                         onChange={(e) =>
@@ -589,6 +590,7 @@ export function TrackChildLocationDialog({
                       </InputLabel>
                       <Select
                         labelId="assignee-label"
+                        label="Planned Receiving Adult"
                         id="assignee"
                         value={selectedAssigneeKey}
                         onChange={(e) =>

--- a/src/caretogether-pwa/src/V1Cases/CreatePartneringFamilyDrawer.tsx
+++ b/src/caretogether-pwa/src/V1Cases/CreatePartneringFamilyDrawer.tsx
@@ -280,8 +280,10 @@ export function CreatePartneringFamilyDrawer({
 
         <Grid item xs={12} sm={6}>
           <FormControl fullWidth size="small">
-            <InputLabel>Ethnicity</InputLabel>
+            <InputLabel id="ethnicity-label">Ethnicity</InputLabel>
             <Select
+              labelId="ethnicity-label"
+              label="Ethnicity"
               value={ethnicity}
               onChange={(e) =>
                 setFields({ ...fields, ethnicity: e.target.value as string })

--- a/src/caretogether-pwa/src/Volunteers/BulkSmsSideSheet.tsx
+++ b/src/caretogether-pwa/src/Volunteers/BulkSmsSideSheet.tsx
@@ -131,6 +131,7 @@ export function BulkSmsSideSheet({
         <InputLabel id="sourcenumber-label">Source number</InputLabel>
         <Select
           labelId="sourcenumber-label"
+          label="Source number"
           id="sourcenumber"
           value={selectedSourceNumber}
           onChange={(e) => setSelectedSourceNumber(e.target.value as string)}

--- a/src/caretogether-pwa/src/Volunteers/CreateVolunteerFamilyDialog.tsx
+++ b/src/caretogether-pwa/src/Volunteers/CreateVolunteerFamilyDialog.tsx
@@ -182,6 +182,7 @@ export function CreateVolunteerFamilyDialog({
                 </InputLabel>
                 <Select
                   labelId="family-relationship-label"
+                  label="Relationship to Family"
                   id="family-relationship"
                   value={relationshipToFamily}
                   onChange={(e) =>
@@ -278,6 +279,7 @@ export function CreateVolunteerFamilyDialog({
                 <InputLabel id="ethnicity-label">Ethnicity</InputLabel>
                 <Select
                   labelId="ethnicity-label"
+                  label="Ethnicity"
                   id="ethnicity"
                   value={ethnicity}
                   onChange={(e) =>


### PR DESCRIPTION
## Summary
- add missing MUI Select label props so outlined select notches do not strike through labels
- add inner spacing in Complete Other dialog so the autocomplete label is not clipped by DialogContent

## Tests
- npm run type-check
- git diff --check

Before:
<img width="585" height="381" alt="image" src="https://github.com/user-attachments/assets/00e36376-93cb-424e-bd8f-fa6d8ebbcc1b" />
After:
<img width="569" height="365" alt="image" src="https://github.com/user-attachments/assets/d6d3da4f-8ed6-4b5f-9c5b-c8419c96b307" />
