### PR TITLE
Add staff assignment backend contracts

### DIFF
--- a/docs/staff-assignment-plan.md
+++ b/docs/staff-assignment-plan.md
@@ -1,0 +1,72 @@
+# Staff Assignment Feature Plan
+
+## PR 1: Backend Contracts, Domain, Authorization, Tests
+
+- Add shared `StaffAssignment(PersonId, AssignmentRole, AssignedAtUtc, AssignedByUserId)` resource contract.
+- Add active `StaffAssignments` to `V1Referral`, `V1CaseEntry`, and manager-level `V1Case`.
+- Add `V1ReferralInfo` in `Managers/SharedContracts.cs` with disclosed referral data and per-referral `UserPermissions`.
+- Add policy contracts:
+  - `EffectiveLocationPolicy.V1ReferralPolicy`
+  - `V1ReferralPolicy.StaffAssignmentPolicies`
+  - `V1CasePolicy.StaffAssignmentPolicies`
+  - `StaffAssignmentPolicy(AssignmentRole, Eligibility)`
+  - `StaffAssignmentEligibility(EligibleLocationRoles, EligibleIndividualVolunteerRoles, EligibleVolunteerFamilyRoles, EligiblePeople)`
+- Add commands:
+  - `AssignStaffToV1Referral`
+  - `UnassignStaffFromV1Referral`
+  - `AssignStaffToV1Case`
+  - `UnassignStaffFromV1Case`
+- Add dedicated permissions:
+  - `ViewV1ReferralStaffAssignments`
+  - `EditV1ReferralStaffAssignments`
+  - `ViewV1CaseStaffAssignments`
+  - `EditV1CaseStaffAssignments`
+- Add authorization contexts:
+  - `V1ReferralAuthorizationContext(referralId)`
+  - `AssignedStaffInV1ReferralPermissionContext(WhenReferralIsOpen, WhenAssignmentRoleIsIn)`
+  - `AssignedStaffInV1CasePermissionContext(WhenCaseIsOpen, WhenAssignmentRoleIsIn)`
+- Keep case assignment permissions flowing through existing `FamilyAuthorizationContext`.
+- Change referral listing from global all-or-nothing to per-referral `ViewV1Referral`.
+- Keep family/case listing minimum-effort with existing "any meaningful non-screen permission" behavior.
+- Validate staff assignment eligibility in `RecordsManager` before resource execution.
+- Keep unassign permissive: no current policy/eligibility validation needed, only edit permission.
+- Copy active referral assignments to case during accept/link:
+  - only roles configured in case staff assignment policy
+  - no person eligibility revalidation
+  - copied as normal case assignment events
+  - assigned timestamp and assigned-by user come from accept/link operation
+- Add staff assignment activities/history in backend, filtered from disclosure unless user has relevant view staff assignment permission.
+- Add focused tests:
+  - resource assign/unassign/idempotency/current-state
+  - authorization contexts, role filters, open/closed filters
+  - referral listing/disclosure with `V1ReferralInfo`
+  - case/family access through assigned-case context
+- Add minimal test data/config examples.
+- Run `dotnet build` to regenerate `swagger.json` and `src/caretogether-pwa/src/GeneratedClient.ts`; do not edit them manually.
+- Include only minimal frontend compile fixes if generated client changes require them.
+
+## PR 2: Frontend Operational UI
+
+- Shared staff assignment component for referrals and cases.
+- Role-grouped display.
+- Policy-order sorting, then person name; unconfigured roles last.
+- Assign one person at a time.
+- Add/remove exact assignment only; no edit command.
+- Candidate picker computed from visible data and policy.
+- Deduplicate candidates by `PersonId`.
+- Eligibility paths are OR'd:
+  - location roles
+  - approved/onboarded individual volunteer roles
+  - approved/onboarded volunteer family roles, where any person in that family can qualify
+  - explicit people
+- Referral assignment UI gated by `ViewV1ReferralStaffAssignments` / `EditV1ReferralStaffAssignments`.
+- Case assignment UI gated by `ViewV1CaseStaffAssignments` / `EditV1CaseStaffAssignments`.
+- Add Settings role-editor support for the two new assigned-staff permission contexts and `WhenAssignmentRoleIsIn`.
+
+## Known Follow-Ups
+
+- Referral document valet authorization remains global/broad in PR 1.
+- Referral note command authorization remains global/broad in PR 1.
+- Settings UI for editing `StaffAssignmentPolicies` is deferred.
+- Existing arrangement assignment backend eligibility validation remains unchanged.
+- Timeline rendering for staff assignment activities is only included if low-effort; backend history should still be correct.

--- a/src/CareTogether.Api/Startup.cs
+++ b/src/CareTogether.Api/Startup.cs
@@ -264,6 +264,7 @@ namespace CareTogether.Api
                 policiesResource,
                 directoryResource,
                 v1CasesResource,
+                v1ReferralsResource,
                 approvalsResource,
                 communitiesResource
             );
@@ -309,6 +310,7 @@ namespace CareTogether.Api
                     policyEvaluationEngine,
                     userAccessCalculation,
                     directoryResource,
+                    accountsResource,
                     approvalsResource,
                     v1CasesResource,
                     v1ReferralsResource,

--- a/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
@@ -147,6 +147,8 @@ namespace CareTogether.Engines.Authorization
                         Permission.EditV1CaseRequirementExemption,
                     UpdateCustomReferralField => Permission.EditV1Case,
                     UpdateReferralComments => Permission.EditV1Case,
+                    AssignStaffToV1Case => Permission.EditV1CaseStaffAssignments,
+                    UnassignStaffFromV1Case => Permission.EditV1CaseStaffAssignments,
                     LinkReferralToCase => Permission.EditV1Case,
                     CloseReferral => Permission.CloseV1Case,
                     ReopenReferral => Permission.CloseV1Case,
@@ -236,7 +238,9 @@ namespace CareTogether.Engines.Authorization
                 organizationId,
                 locationId,
                 userContext,
-                new GlobalAuthorizationContext()
+                command is CreateV1Referral
+                    ? new GlobalAuthorizationContext()
+                    : new V1ReferralAuthorizationContext(command.ReferralId)
             );
 
             return permissions.Contains(
@@ -263,6 +267,8 @@ namespace CareTogether.Engines.Authorization
 
                     UploadV1ReferralDocument => Permission.EditV1Referral,
                     DeleteUploadedV1ReferralDocument => Permission.EditV1Referral,
+                    AssignStaffToV1Referral => Permission.EditV1ReferralStaffAssignments,
+                    UnassignStaffFromV1Referral => Permission.EditV1ReferralStaffAssignments,
 
                     _ => throw new NotImplementedException(
                         $"The command type '{command.GetType().FullName}' has not been implemented."
@@ -931,7 +937,13 @@ namespace CareTogether.Engines.Authorization
                     )
                     .ToImmutableList(),
                 History = contextPermissions.Contains(Permission.ViewV1CaseHistory)
-                    ? partneringFamilyInfo.History
+                    ? partneringFamilyInfo
+                        .History.Where(activity =>
+                            contextPermissions.Contains(Permission.ViewV1CaseStaffAssignments)
+                            || activity is not V1CaseStaffAssigned
+                                and not V1CaseStaffUnassigned
+                        )
+                        .ToImmutableList()
                     : ImmutableList<Activity>.Empty,
             };
         }
@@ -958,6 +970,11 @@ namespace CareTogether.Engines.Authorization
                 ExemptedRequirements = contextPermissions.Contains(Permission.ViewV1CaseProgress)
                     ? v1Case.ExemptedRequirements
                     : ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                StaffAssignments = contextPermissions.Contains(
+                    Permission.ViewV1CaseStaffAssignments
+                )
+                    ? v1Case.StaffAssignments
+                    : ImmutableList<StaffAssignment>.Empty,
                 MissingRequirements = contextPermissions.Contains(Permission.ViewV1CaseProgress)
                     ? v1Case.MissingRequirements
                     : ImmutableList<RequirementDefinition>.Empty,

--- a/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
@@ -937,6 +937,9 @@ namespace CareTogether.Engines.Authorization
                     )
                     .ToImmutableList(),
                 History = contextPermissions.Contains(Permission.ViewV1CaseHistory)
+                    // Existing history activities are authorized by ViewV1CaseHistory as a list.
+                    // Staff assignment activities reveal separately-permissioned staff assignment data,
+                    // so hide them from users who cannot view assignments to avoid assignee inference.
                     ? partneringFamilyInfo
                         .History.Where(activity =>
                             contextPermissions.Contains(Permission.ViewV1CaseStaffAssignments)

--- a/src/CareTogether.Core/Engines/Authorization/IAuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/IAuthorizationEngine.cs
@@ -26,6 +26,8 @@ namespace CareTogether.Engines.Authorization
     public sealed record FamilyAuthorizationContext(Guid FamilyId, Family? Family = null)
         : AuthorizationContext;
 
+    public sealed record V1ReferralAuthorizationContext(Guid ReferralId) : AuthorizationContext;
+
     public sealed record CommunityAuthorizationContext(Guid CommunityId) : AuthorizationContext;
 
     public sealed record SessionUserContext(ClaimsPrincipal User, Family? UserFamily);

--- a/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
+++ b/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
@@ -7,6 +7,7 @@ using CareTogether.Resources.Communities;
 using CareTogether.Resources.Directory;
 using CareTogether.Resources.Policies;
 using CareTogether.Resources.V1Cases;
+using CareTogether.Resources.V1Referrals;
 
 namespace CareTogether.Engines.Authorization
 {
@@ -15,6 +16,7 @@ namespace CareTogether.Engines.Authorization
         private readonly IPoliciesResource policiesResource;
         private readonly IDirectoryResource directoryResource;
         private readonly IV1CasesResource v1CasesResource;
+        private readonly IV1ReferralsResource v1ReferralsResource;
         private readonly IApprovalsResource approvalsResource;
         private readonly ICommunitiesResource communitiesResource;
 
@@ -22,6 +24,7 @@ namespace CareTogether.Engines.Authorization
             IPoliciesResource policiesResource,
             IDirectoryResource directoryResource,
             IV1CasesResource v1CasesResource,
+            IV1ReferralsResource v1ReferralsResource,
             IApprovalsResource approvalsResource,
             ICommunitiesResource communitiesResource
         )
@@ -29,6 +32,7 @@ namespace CareTogether.Engines.Authorization
             this.policiesResource = policiesResource;
             this.directoryResource = directoryResource;
             this.v1CasesResource = v1CasesResource;
+            this.v1ReferralsResource = v1ReferralsResource;
             this.approvalsResource = approvalsResource;
             this.communitiesResource = communitiesResource;
         }
@@ -100,6 +104,16 @@ namespace CareTogether.Engines.Authorization
             var targetFamilyV1Cases = v1Cases
                 .Where(v1Case => v1Case.FamilyId == targetFamily?.Id)
                 .ToImmutableList();
+            var v1ReferralAuthorizationContext =
+                context is V1ReferralAuthorizationContext vrac ? vrac : null;
+            var targetV1Referral =
+                v1ReferralAuthorizationContext == null
+                    ? null
+                    : await v1ReferralsResource.GetReferralAsync(
+                        organizationId,
+                        locationId,
+                        v1ReferralAuthorizationContext.ReferralId
+                    );
             var assignedV1Cases = v1Cases
                 .Where(v1Case =>
                     v1Case.Arrangements.Any(arrangement =>
@@ -176,6 +190,8 @@ namespace CareTogether.Engines.Authorization
                         targetFamilyV1Cases,
                         assignedV1Cases,
                         targetFamilyAssignments,
+                        targetV1Referral,
+                        userPersonId,
                         userFamilyCommunities,
                         targetFamilyCommunities,
                         userCommunityRoleAssignments,
@@ -200,6 +216,8 @@ namespace CareTogether.Engines.Authorization
             ImmutableList<Resources.V1Cases.V1CaseEntry> targetFamilyV1Cases,
             ImmutableList<Resources.V1Cases.V1CaseEntry> assignedV1Cases,
             ImmutableList<Resources.V1Cases.V1CaseEntry> targetFamilyAssignedV1Cases,
+            Resources.V1Referrals.V1Referral? targetV1Referral,
+            Guid? userPersonId,
             ImmutableList<Guid> userFamilyCommunities,
             ImmutableList<Guid> targetFamilyCommunities,
             ImmutableList<(Guid Id, string CommunityRole)> userCommunityRoleAssignments,
@@ -316,6 +334,38 @@ namespace CareTogether.Engines.Authorization
                                     c.WhenAssigneeFunctionIsIn == null
                                     || c.WhenAssigneeFunctionIsIn.Contains(iva.ArrangementFunction)
                                 )
+                            )
+                        )
+                    ),
+                AssignedStaffInV1ReferralPermissionContext c => context
+                    is V1ReferralAuthorizationContext
+                    && targetV1Referral != null
+                    && userPersonId.HasValue
+                    && (
+                        c.WhenReferralIsOpen == null
+                        || c.WhenReferralIsOpen
+                            == (targetV1Referral.Status == V1ReferralStatus.Open)
+                    )
+                    && targetV1Referral.StaffAssignments.Any(assignment =>
+                        assignment.PersonId == userPersonId.Value
+                        && (
+                            c.WhenAssignmentRoleIsIn == null
+                            || c.WhenAssignmentRoleIsIn.Contains(assignment.AssignmentRole)
+                        )
+                    ),
+                AssignedStaffInV1CasePermissionContext c => context
+                    is FamilyAuthorizationContext
+                    && userPersonId.HasValue
+                    && targetFamilyV1Cases.Any(v1Case =>
+                        (
+                            c.WhenCaseIsOpen == null
+                            || c.WhenCaseIsOpen == (v1Case.ClosedAtUtc == null)
+                        )
+                        && v1Case.StaffAssignments.Any(assignment =>
+                            assignment.PersonId == userPersonId.Value
+                            && (
+                                c.WhenAssignmentRoleIsIn == null
+                                || c.WhenAssignmentRoleIsIn.Contains(assignment.AssignmentRole)
                             )
                         )
                     ),

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
@@ -389,6 +389,12 @@ namespace CareTogether.Engines.PolicyEvaluation
         }
     }
 
+    public sealed record VolunteerFamilyApprovalCalculationResult(
+        FamilyApprovalStatus ApprovalStatus,
+        ImmutableList<Resources.CompletedRequirementInfo> CompletedFamilyRequirementsWithExpiration,
+        ImmutableDictionary<Guid, ImmutableList<Resources.CompletedRequirementInfo>> CompletedIndividualRequirementsWithExpiration
+    );
+
     public sealed record FamilyRoleVersionApprovalStatus(
         string RoleName,
         string Version,
@@ -488,7 +494,7 @@ namespace CareTogether.Engines.PolicyEvaluation
 
     public interface IPolicyEvaluationEngine
     {
-        //TODO: Merge this with the CombinedFamilyInfoFormatter logic
+        // Prefer CalculateVolunteerFamilyApprovalsAsync when starting from a VolunteerFamilyEntry.
         Task<FamilyApprovalStatus> CalculateCombinedFamilyApprovalsAsync(
             Guid organizationId,
             Guid locationId,
@@ -505,6 +511,13 @@ namespace CareTogether.Engines.PolicyEvaluation
                 ImmutableList<Resources.ExemptedRequirementInfo>
             > exemptedIndividualRequirements,
             ImmutableDictionary<Guid, ImmutableList<RoleRemoval>> individualRoleRemovals
+        );
+
+        Task<VolunteerFamilyApprovalCalculationResult> CalculateVolunteerFamilyApprovalsAsync(
+            Guid organizationId,
+            Guid locationId,
+            Family family,
+            VolunteerFamilyEntry volunteerFamily
         );
 
         Task<V1CaseStatus> CalculateV1CaseStatusAsync(

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationEngine.cs
@@ -54,6 +54,68 @@ namespace CareTogether.Engines.PolicyEvaluation
             );
         }
 
+        public async Task<VolunteerFamilyApprovalCalculationResult> CalculateVolunteerFamilyApprovalsAsync(
+            Guid organizationId,
+            Guid locationId,
+            Family family,
+            VolunteerFamilyEntry volunteerFamily
+        )
+        {
+            var policy = await policiesResource.GetCurrentPolicy(organizationId, locationId);
+
+            var applyValidity = (Resources.CompletedRequirementInfo completed) =>
+                ApplyValidityPolicyToCompletedRequirement(policy, completed);
+            var completedFamilyRequirementsWithExpiration = volunteerFamily
+                .CompletedRequirements.Select(applyValidity)
+                .ToImmutableList();
+            var completedIndividualRequirementsWithExpiration = volunteerFamily
+                .IndividualEntries.ToImmutableDictionary(
+                    entry => entry.Key,
+                    entry => entry.Value.CompletedRequirements.Select(applyValidity).ToImmutableList()
+                );
+
+            var approvalStatus = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                policy,
+                family,
+                completedFamilyRequirementsWithExpiration,
+                volunteerFamily.ExemptedRequirements,
+                volunteerFamily.RoleRemovals,
+                completedIndividualRequirementsWithExpiration,
+                volunteerFamily.IndividualEntries.ToImmutableDictionary(
+                    entry => entry.Key,
+                    entry => entry.Value.ExemptedRequirements
+                ),
+                volunteerFamily.IndividualEntries.ToImmutableDictionary(
+                    entry => entry.Key,
+                    entry => entry.Value.RoleRemovals
+                )
+            );
+
+            return new VolunteerFamilyApprovalCalculationResult(
+                approvalStatus,
+                completedFamilyRequirementsWithExpiration,
+                completedIndividualRequirementsWithExpiration
+            );
+        }
+
+        private static Resources.CompletedRequirementInfo ApplyValidityPolicyToCompletedRequirement(
+            EffectiveLocationPolicy policy,
+            Resources.CompletedRequirementInfo completed
+        )
+        {
+            return policy.ActionDefinitions.TryGetValue(
+                completed.RequirementName,
+                out var actionDefinition
+            )
+                ? completed with
+                {
+                    ExpiresAtUtc = actionDefinition.Validity.HasValue
+                        ? completed.CompletedAtUtc + actionDefinition.Validity
+                        : null,
+                }
+                : completed;
+        }
+
         internal CompletedRequirementInfo ToCompletedRequirementsForCalculation(
             Resources.CompletedRequirementInfo entry,
             TimeZoneInfo locationTimeZone

--- a/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
+++ b/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
@@ -98,7 +98,6 @@ namespace CareTogether.Managers
                 await RenderVolunteerFamilyInfoAsync(
                     organizationId,
                     locationId,
-                    locationPolicy,
                     family
                 );
             var notes = await notesResource.ListFamilyNotesAsync(
@@ -301,7 +300,6 @@ namespace CareTogether.Managers
         )> RenderVolunteerFamilyInfoAsync(
             Guid organizationId,
             Guid locationId,
-            EffectiveLocationPolicy locationPolicy,
             Family family
         )
         {
@@ -314,43 +312,14 @@ namespace CareTogether.Managers
             if (entry == null)
                 return (null, ImmutableList<UploadedDocumentInfo>.Empty);
 
-            var completedIndividualRequirements = entry.IndividualEntries.ToImmutableDictionary(
-                x => x.Key,
-                x => x.Value.CompletedRequirements
-            );
-            var exemptedIndividualRequirements = entry.IndividualEntries.ToImmutableDictionary(
-                x => x.Key,
-                x => x.Value.ExemptedRequirements
-            );
-            var removedIndividualRoles = entry.IndividualEntries.ToImmutableDictionary(
-                x => x.Key,
-                x => x.Value.RoleRemovals
-            );
-
-            // Apply default action expiration policies to completed requirements before running approval calculations.
-            var applyValidity = (Resources.CompletedRequirementInfo completed) =>
-                ApplyValidityPolicyToCompletedRequirement(locationPolicy, completed);
-            var completedFamilyRequirementsWithExpiration = entry
-                .CompletedRequirements.Select(applyValidity)
-                .ToImmutableList();
-            var completedIndividualRequirementsWithExpiration =
-                completedIndividualRequirements.ToImmutableDictionary(
-                    entry => entry.Key,
-                    entry => entry.Value.Select(applyValidity).ToImmutableList()
-                );
-
-            var combinedFamilyApprovals =
-                await policyEvaluationEngine.CalculateCombinedFamilyApprovalsAsync(
+            var approvalCalculation =
+                await policyEvaluationEngine.CalculateVolunteerFamilyApprovalsAsync(
                     organizationId,
                     locationId,
                     family,
-                    completedFamilyRequirementsWithExpiration,
-                    entry.ExemptedRequirements,
-                    entry.RoleRemovals,
-                    completedIndividualRequirementsWithExpiration,
-                    exemptedIndividualRequirements,
-                    removedIndividualRoles
+                    entry
                 );
+            var combinedFamilyApprovals = approvalCalculation.ApprovalStatus;
 
             var v1CaseEntries = (
                 await v1CasesResource.ListV1CasessAsync(organizationId, locationId)
@@ -375,7 +344,7 @@ namespace CareTogether.Managers
 
             var volunteerFamilyInfo = new VolunteerFamilyInfo(
                 combinedFamilyApprovals.FamilyRoleApprovals,
-                completedFamilyRequirementsWithExpiration,
+                approvalCalculation.CompletedFamilyRequirementsWithExpiration,
                 entry.ExemptedRequirements,
                 combinedFamilyApprovals.CurrentAvailableFamilyApplications,
                 combinedFamilyApprovals.CurrentMissingFamilyRequirements,
@@ -385,7 +354,7 @@ namespace CareTogether.Managers
                     x =>
                     {
                         entry.IndividualEntries.TryGetValue(x.Key, out var individualEntry);
-                        completedIndividualRequirementsWithExpiration.TryGetValue(
+                        approvalCalculation.CompletedIndividualRequirementsWithExpiration.TryGetValue(
                             x.Key,
                             out var completedRequirements
                         );
@@ -416,24 +385,6 @@ namespace CareTogether.Managers
             );
 
             return (volunteerFamilyInfo, entry.UploadedDocuments);
-        }
-
-        internal static Resources.CompletedRequirementInfo ApplyValidityPolicyToCompletedRequirement(
-            EffectiveLocationPolicy policy,
-            Resources.CompletedRequirementInfo completed
-        )
-        {
-            return policy.ActionDefinitions.TryGetValue(
-                completed.RequirementName,
-                out var actionDefinition
-            )
-                ? completed with
-                {
-                    ExpiresAtUtc = actionDefinition.Validity.HasValue
-                        ? completed.CompletedAtUtc + actionDefinition.Validity
-                        : null,
-                }
-                : completed;
         }
     }
 }

--- a/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
+++ b/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
@@ -261,6 +261,7 @@ namespace CareTogether.Managers
                             ToArrangement(a.Value, v1CaseStatus.IndividualArrangements[a.Key])
                         )
                         .ToImmutableList(),
+                    entry.StaffAssignments,
                     entry.Comments,
                     entry.LinkedV1ReferralIds
                 );

--- a/src/CareTogether.Core/Managers/Records/IRecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/IRecordsManager.cs
@@ -132,8 +132,8 @@ namespace CareTogether.Managers.Records
     public sealed record CommunityRecordsAggregate(CommunityInfo Community)
         : RecordsAggregate(Community.Community.Id);
 
-    public sealed record ReferralRecordsAggregate(V1Referral Referral)
-        : RecordsAggregate(Referral.ReferralId);
+    public sealed record ReferralRecordsAggregate(V1ReferralInfo Referral)
+        : RecordsAggregate(Referral.Referral.ReferralId);
 
     public interface IRecordsManager
     {

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -233,49 +233,34 @@ namespace CareTogether.Managers.Records
         {
             var userContext = await CreateSessionUserContext(user, organizationId, locationId);
 
-            var atomicCommands = GenerateAtomicCommandsForCompositeCommand(command)
-                .ToImmutableList();
+            var commandPlan = await GenerateCompositeCommandPlanAsync(
+                organizationId,
+                locationId,
+                command
+            );
 
-            foreach (var atomicCommand in atomicCommands)
+            foreach (var userCommand in commandPlan.UserCommands)
                 if (
                     !await AuthorizeCommandAsync(
                         organizationId,
                         locationId,
                         userContext,
-                        atomicCommand
+                        userCommand
                     )
                 )
                     throw new Exception("The user is not authorized to perform this command.");
 
-            foreach (var atomicCommand in atomicCommands)
-                await ExecuteCommandAsync(organizationId, locationId, user, atomicCommand);
+            foreach (var userCommand in commandPlan.UserCommands)
+                await ValidateCommandAsync(organizationId, locationId, userCommand);
 
-            var copiedStaffAssignmentCommands =
-                await GenerateReferralStaffAssignmentCopyCommandsAsync(
-                    organizationId,
-                    locationId,
-                    command
-                );
-
-            foreach (var copiedStaffAssignmentCommand in copiedStaffAssignmentCommands)
-                await v1CasesResource.ExecuteV1CaseCommandAsync(
-                    organizationId,
-                    locationId,
-                    copiedStaffAssignmentCommand,
-                    user.UserId()
-                );
+            foreach (var plannedCommand in commandPlan.AllCommands)
+                await ExecuteCommandAsync(organizationId, locationId, user, plannedCommand);
 
             return await RenderCompositeCommandResultAsync(
                 organizationId,
                 locationId,
                 userContext,
-                atomicCommands
-                    .Concat(
-                        copiedStaffAssignmentCommands.Select(command =>
-                            (AtomicRecordsCommand)new ReferralRecordsCommand(command)
-                        )
-                    )
-                    .ToImmutableList()
+                commandPlan.AllCommands
             );
         }
 
@@ -292,6 +277,7 @@ namespace CareTogether.Managers.Records
                 throw new Exception("The user is not authorized to perform this command.");
             try
             {
+                await ValidateCommandAsync(organizationId, locationId, command);
                 await ExecuteCommandAsync(organizationId, locationId, user, command);
 
                 return await RenderCommandResultAsync(
@@ -480,6 +466,31 @@ namespace CareTogether.Managers.Records
                 referralId,
                 documentId
             );
+        }
+
+        private sealed record CompositeCommandPlan(
+            ImmutableList<AtomicRecordsCommand> UserCommands,
+            ImmutableList<AtomicRecordsCommand> DerivedCommands
+        )
+        {
+            public ImmutableList<AtomicRecordsCommand> AllCommands =>
+                UserCommands.Concat(DerivedCommands).ToImmutableList();
+        }
+
+        private async Task<CompositeCommandPlan> GenerateCompositeCommandPlanAsync(
+            Guid organizationId,
+            Guid locationId,
+            CompositeRecordsCommand command
+        )
+        {
+            var userCommands = GenerateAtomicCommandsForCompositeCommand(command).ToImmutableList();
+            var derivedCommands = await GenerateDerivedAtomicCommandsForCompositeCommandAsync(
+                organizationId,
+                locationId,
+                command
+            );
+
+            return new CompositeCommandPlan(userCommands, derivedCommands);
         }
 
         private IEnumerable<AtomicRecordsCommand> GenerateAtomicCommandsForCompositeCommand(
@@ -684,6 +695,24 @@ namespace CareTogether.Managers.Records
             }
         }
 
+        private async Task<ImmutableList<AtomicRecordsCommand>> GenerateDerivedAtomicCommandsForCompositeCommandAsync(
+            Guid organizationId,
+            Guid locationId,
+            CompositeRecordsCommand command
+        )
+        {
+            var copiedStaffAssignmentCommands =
+                await GenerateReferralStaffAssignmentCopyCommandsAsync(
+                    organizationId,
+                    locationId,
+                    command
+                );
+
+            return copiedStaffAssignmentCommands
+                .Select(command => (AtomicRecordsCommand)new ReferralRecordsCommand(command))
+                .ToImmutableList();
+        }
+
         private async Task<ImmutableList<V1CaseCommand>> GenerateReferralStaffAssignmentCopyCommandsAsync(
             Guid organizationId,
             Guid locationId,
@@ -860,7 +889,6 @@ namespace CareTogether.Managers.Records
                     );
                     return;
                 case ReferralRecordsCommand c:
-                    await ValidateStaffAssignmentCommandAsync(organizationId, locationId, c.Command);
                     await v1CasesResource.ExecuteV1CaseCommandAsync(
                         organizationId,
                         locationId,
@@ -869,7 +897,6 @@ namespace CareTogether.Managers.Records
                     );
                     return;
                 case V1ReferralRecordsCommand c:
-                    await ValidateStaffAssignmentCommandAsync(organizationId, locationId, c.Command);
                     await v1ReferralsResource.ExecuteV1ReferralCommandAsync(
                         organizationId,
                         locationId,
@@ -915,6 +942,26 @@ namespace CareTogether.Managers.Records
                     );
             }
         }
+
+        private Task ValidateCommandAsync(
+            Guid organizationId,
+            Guid locationId,
+            AtomicRecordsCommand command
+        ) =>
+            command switch
+            {
+                ReferralRecordsCommand c => ValidateStaffAssignmentCommandAsync(
+                    organizationId,
+                    locationId,
+                    c.Command
+                ),
+                V1ReferralRecordsCommand c => ValidateStaffAssignmentCommandAsync(
+                    organizationId,
+                    locationId,
+                    c.Command
+                ),
+                _ => Task.CompletedTask,
+            };
 
         private async Task ValidateStaffAssignmentCommandAsync(
             Guid organizationId,

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -703,14 +703,28 @@ namespace CareTogether.Managers.Records
             CompositeRecordsCommand command
         )
         {
-            var copiedStaffAssignmentCommands =
-                await GenerateReferralStaffAssignmentCopyCommandsAsync(
-                    organizationId,
-                    locationId,
-                    command
-                );
+            var derivedV1CaseCommands = command switch
+            {
+                LinkReferralToCaseAndAcceptCommand c =>
+                    await GenerateReferralStaffAssignmentCopyCommandsAsync(
+                        organizationId,
+                        locationId,
+                        c.FamilyId,
+                        c.CaseId,
+                        c.ReferralId
+                    ),
+                OpenCaseForReferralAndAcceptCommand c =>
+                    await GenerateReferralStaffAssignmentCopyCommandsAsync(
+                        organizationId,
+                        locationId,
+                        c.FamilyId,
+                        c.CaseId,
+                        c.ReferralId
+                    ),
+                _ => ImmutableList<V1CaseCommand>.Empty,
+            };
 
-            return copiedStaffAssignmentCommands
+            return derivedV1CaseCommands
                 .Select(command => (AtomicRecordsCommand)new ReferralRecordsCommand(command))
                 .ToImmutableList();
         }
@@ -718,31 +732,15 @@ namespace CareTogether.Managers.Records
         private async Task<ImmutableList<V1CaseCommand>> GenerateReferralStaffAssignmentCopyCommandsAsync(
             Guid organizationId,
             Guid locationId,
-            CompositeRecordsCommand command
+            Guid familyId,
+            Guid caseId,
+            Guid referralId
         )
         {
-            var copyTarget = command switch
-            {
-                LinkReferralToCaseAndAcceptCommand c => (
-                    c.FamilyId,
-                    c.CaseId,
-                    c.ReferralId
-                ),
-                OpenCaseForReferralAndAcceptCommand c => (
-                    c.FamilyId,
-                    c.CaseId,
-                    c.ReferralId
-                ),
-                _ => ((Guid FamilyId, Guid CaseId, Guid ReferralId)?)null,
-            };
-
-            if (copyTarget == null)
-                return ImmutableList<V1CaseCommand>.Empty;
-
             var referral = await v1ReferralsResource.GetReferralAsync(
                 organizationId,
                 locationId,
-                copyTarget.Value.ReferralId
+                referralId
             );
             if (referral == null)
                 return ImmutableList<V1CaseCommand>.Empty;
@@ -761,8 +759,8 @@ namespace CareTogether.Managers.Records
                 )
                 .Select(assignment =>
                     (V1CaseCommand)new AssignStaffToV1Case(
-                        copyTarget.Value.FamilyId,
-                        copyTarget.Value.CaseId,
+                        familyId,
+                        caseId,
                         assignment.PersonId,
                         assignment.AssignmentRole
                     )

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -1077,31 +1077,14 @@ namespace CareTogether.Managers.Records
             if (volunteerFamily == null)
                 return false;
 
-            var locationPolicy = await policiesResource.GetCurrentPolicy(
-                organizationId,
-                locationId
-            );
-            var combinedApprovals =
-                await policyEvaluationEngine.CalculateCombinedFamilyApprovalsAsync(
+            var approvalCalculation =
+                await policyEvaluationEngine.CalculateVolunteerFamilyApprovalsAsync(
                     organizationId,
                     locationId,
                     family,
-                    volunteerFamily.CompletedRequirements,
-                    volunteerFamily.ExemptedRequirements,
-                    volunteerFamily.RoleRemovals,
-                    volunteerFamily.IndividualEntries.ToImmutableDictionary(
-                        entry => entry.Key,
-                        entry => entry.Value.CompletedRequirements
-                    ),
-                    volunteerFamily.IndividualEntries.ToImmutableDictionary(
-                        entry => entry.Key,
-                        entry => entry.Value.ExemptedRequirements
-                    ),
-                    volunteerFamily.IndividualEntries.ToImmutableDictionary(
-                        entry => entry.Key,
-                        entry => entry.Value.RoleRemovals
-                    )
+                    volunteerFamily
                 );
+            var combinedApprovals = approvalCalculation.ApprovalStatus;
 
             var hasEligibleIndividualRole =
                 combinedApprovals.IndividualApprovals.TryGetValue(

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -952,28 +952,27 @@ namespace CareTogether.Managers.Records
         ) =>
             command switch
             {
-                ReferralRecordsCommand c => ValidateStaffAssignmentCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command
-                ),
-                V1ReferralRecordsCommand c => ValidateStaffAssignmentCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command
-                ),
+                ReferralRecordsCommand { Command: AssignStaffToV1Case assignStaff } =>
+                    ValidateStaffAssignmentCommandAsync(
+                        organizationId,
+                        locationId,
+                        assignStaff
+                    ),
+                V1ReferralRecordsCommand { Command: AssignStaffToV1Referral assignStaff } =>
+                    ValidateStaffAssignmentCommandAsync(
+                        organizationId,
+                        locationId,
+                        assignStaff
+                    ),
                 _ => Task.CompletedTask,
             };
 
         private async Task ValidateStaffAssignmentCommandAsync(
             Guid organizationId,
             Guid locationId,
-            V1ReferralCommand command
+            AssignStaffToV1Referral assignStaff
         )
         {
-            if (command is not AssignStaffToV1Referral assignStaff)
-                return;
-
             var locationPolicy = await policiesResource.GetCurrentPolicy(
                 organizationId,
                 locationId
@@ -1004,12 +1003,9 @@ namespace CareTogether.Managers.Records
         private async Task ValidateStaffAssignmentCommandAsync(
             Guid organizationId,
             Guid locationId,
-            V1CaseCommand command
+            AssignStaffToV1Case assignStaff
         )
         {
-            if (command is not AssignStaffToV1Case assignStaff)
-                return;
-
             var locationPolicy = await policiesResource.GetCurrentPolicy(
                 organizationId,
                 locationId

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -6,6 +6,8 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using CareTogether.Engines.Authorization;
 using CareTogether.Engines.PolicyEvaluation;
+using CareTogether.Resources;
+using CareTogether.Resources.Accounts;
 using CareTogether.Resources.Approvals;
 using CareTogether.Resources.Communities;
 using CareTogether.Resources.Directory;
@@ -26,6 +28,7 @@ namespace CareTogether.Managers.Records
         private readonly IPolicyEvaluationEngine policyEvaluationEngine;
         private readonly IUserAccessCalculation userAccessCalculation;
         private readonly IDirectoryResource directoryResource;
+        private readonly IAccountsResource accountsResource;
         private readonly IApprovalsResource approvalsResource;
         private readonly IV1CasesResource v1CasesResource;
         private readonly IV1ReferralsResource v1ReferralsResource;
@@ -42,6 +45,7 @@ namespace CareTogether.Managers.Records
             IPolicyEvaluationEngine policyEvaluationEngine,
             IUserAccessCalculation userAccessCalculation,
             IDirectoryResource directoryResource,
+            IAccountsResource accountsResource,
             IApprovalsResource approvalsResource,
             IV1CasesResource v1CasesResource,
             IV1ReferralsResource v1ReferralsResource,
@@ -56,6 +60,7 @@ namespace CareTogether.Managers.Records
             this.policyEvaluationEngine = policyEvaluationEngine;
             this.userAccessCalculation = userAccessCalculation;
             this.directoryResource = directoryResource;
+            this.accountsResource = accountsResource;
             this.approvalsResource = approvalsResource;
             this.v1CasesResource = v1CasesResource;
             this.v1ReferralsResource = v1ReferralsResource;
@@ -156,27 +161,29 @@ namespace CareTogether.Managers.Records
                 locationId
             );
 
-            var canViewReferrals = await authorizationEngine.AuthorizeV1ReferralReadAsync(
-                organizationId,
-                locationId,
-                userContext
-            );
+            var renderedReferrals = (
+                await referrals
+                    .Select(async referral =>
+                    {
+                        var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
+                            organizationId,
+                            locationId,
+                            userContext,
+                            new V1ReferralAuthorizationContext(referral.ReferralId)
+                        );
+                        if (!permissions.Contains(Permission.ViewV1Referral))
+                            return null;
 
-            var renderedReferrals = canViewReferrals
-                ? (
-                    await referrals
-                        .Select(async referral =>
-                        {
-                            var renderedReferral = await RenderReferralAsync(
-                                organizationId,
-                                locationId,
-                                referral
-                            );
-                            return (RecordsAggregate)new ReferralRecordsAggregate(renderedReferral);
-                        })
-                        .WhenAll()
-                ).ToImmutableList()
-                : ImmutableList<RecordsAggregate>.Empty;
+                        var renderedReferral = await RenderReferralAsync(
+                            organizationId,
+                            locationId,
+                            userContext,
+                            referral
+                        );
+                        return (RecordsAggregate)new ReferralRecordsAggregate(renderedReferral);
+                    })
+                    .WhenAll()
+            ).WhereNotNull().ToImmutableList();
 
             var visibleCommunities = (
                 await communities
@@ -243,11 +250,32 @@ namespace CareTogether.Managers.Records
             foreach (var atomicCommand in atomicCommands)
                 await ExecuteCommandAsync(organizationId, locationId, user, atomicCommand);
 
+            var copiedStaffAssignmentCommands =
+                await GenerateReferralStaffAssignmentCopyCommandsAsync(
+                    organizationId,
+                    locationId,
+                    command
+                );
+
+            foreach (var copiedStaffAssignmentCommand in copiedStaffAssignmentCommands)
+                await v1CasesResource.ExecuteV1CaseCommandAsync(
+                    organizationId,
+                    locationId,
+                    copiedStaffAssignmentCommand,
+                    user.UserId()
+                );
+
             return await RenderCompositeCommandResultAsync(
                 organizationId,
                 locationId,
                 userContext,
                 atomicCommands
+                    .Concat(
+                        copiedStaffAssignmentCommands.Select(command =>
+                            (AtomicRecordsCommand)new ReferralRecordsCommand(command)
+                        )
+                    )
+                    .ToImmutableList()
             );
         }
 
@@ -656,6 +684,61 @@ namespace CareTogether.Managers.Records
             }
         }
 
+        private async Task<ImmutableList<V1CaseCommand>> GenerateReferralStaffAssignmentCopyCommandsAsync(
+            Guid organizationId,
+            Guid locationId,
+            CompositeRecordsCommand command
+        )
+        {
+            var copyTarget = command switch
+            {
+                LinkReferralToCaseAndAcceptCommand c => (
+                    c.FamilyId,
+                    c.CaseId,
+                    c.ReferralId
+                ),
+                OpenCaseForReferralAndAcceptCommand c => (
+                    c.FamilyId,
+                    c.CaseId,
+                    c.ReferralId
+                ),
+                _ => ((Guid FamilyId, Guid CaseId, Guid ReferralId)?)null,
+            };
+
+            if (copyTarget == null)
+                return ImmutableList<V1CaseCommand>.Empty;
+
+            var referral = await v1ReferralsResource.GetReferralAsync(
+                organizationId,
+                locationId,
+                copyTarget.Value.ReferralId
+            );
+            if (referral == null)
+                return ImmutableList<V1CaseCommand>.Empty;
+
+            var locationPolicy = await policiesResource.GetCurrentPolicy(
+                organizationId,
+                locationId
+            );
+            var caseStaffAssignmentRoles = locationPolicy
+                .ReferralPolicy.StaffAssignmentPolicies.Select(policy => policy.AssignmentRole)
+                .ToImmutableHashSet();
+
+            return referral
+                .StaffAssignments.Where(assignment =>
+                    caseStaffAssignmentRoles.Contains(assignment.AssignmentRole)
+                )
+                .Select(assignment =>
+                    (V1CaseCommand)new AssignStaffToV1Case(
+                        copyTarget.Value.FamilyId,
+                        copyTarget.Value.CaseId,
+                        assignment.PersonId,
+                        assignment.AssignmentRole
+                    )
+                )
+                .ToImmutableList();
+        }
+
         private Task<bool> AuthorizeCommandAsync(
             Guid organizationId,
             Guid locationId,
@@ -735,81 +818,267 @@ namespace CareTogether.Managers.Records
                 ),
             };
 
-        private Task ExecuteCommandAsync(
+        private async Task ExecuteCommandAsync(
             Guid organizationId,
             Guid locationId,
             ClaimsPrincipal user,
             AtomicRecordsCommand command
-        ) =>
-            command switch
+        )
+        {
+            switch (command)
             {
-                FamilyRecordsCommand c => directoryResource.ExecuteFamilyCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command,
-                    user.UserId()
-                ),
-                PersonRecordsCommand c => directoryResource.ExecutePersonCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command,
-                    user.UserId()
-                ),
-                FamilyApprovalRecordsCommand c =>
-                    approvalsResource.ExecuteVolunteerFamilyCommandAsync(
+                case FamilyRecordsCommand c:
+                    await directoryResource.ExecuteFamilyCommandAsync(
                         organizationId,
                         locationId,
                         c.Command,
                         user.UserId()
-                    ),
-                IndividualApprovalRecordsCommand c =>
-                    approvalsResource.ExecuteVolunteerCommandAsync(
+                    );
+                    return;
+                case PersonRecordsCommand c:
+                    await directoryResource.ExecutePersonCommandAsync(
                         organizationId,
                         locationId,
                         c.Command,
                         user.UserId()
-                    ),
-                ReferralRecordsCommand c => v1CasesResource.ExecuteV1CaseCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command,
-                    user.UserId()
-                ),
-                V1ReferralRecordsCommand c => v1ReferralsResource.ExecuteV1ReferralCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command,
-                    user.UserId()
-                ),
-                ArrangementRecordsCommand c => v1CasesResource.ExecuteArrangementsCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command,
-                    user.UserId()
-                ),
-                NoteRecordsCommand c => notesResource.ExecuteNoteCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command,
-                    user.UserId()
-                ),
-                CommunityRecordsCommand c => communitiesResource.ExecuteCommunityCommandAsync(
-                    organizationId,
-                    locationId,
-                    c.Command,
-                    user.UserId()
-                ),
-                V1ReferralNoteRecordsCommand c =>
-                    v1ReferralNotesResource.ExecuteReferralNoteCommandAsync(
+                    );
+                    return;
+                case FamilyApprovalRecordsCommand c:
+                    await approvalsResource.ExecuteVolunteerFamilyCommandAsync(
                         organizationId,
                         locationId,
                         c.Command,
                         user.UserId()
+                    );
+                    return;
+                case IndividualApprovalRecordsCommand c:
+                    await approvalsResource.ExecuteVolunteerCommandAsync(
+                        organizationId,
+                        locationId,
+                        c.Command,
+                        user.UserId()
+                    );
+                    return;
+                case ReferralRecordsCommand c:
+                    await ValidateStaffAssignmentCommandAsync(organizationId, locationId, c.Command);
+                    await v1CasesResource.ExecuteV1CaseCommandAsync(
+                        organizationId,
+                        locationId,
+                        c.Command,
+                        user.UserId()
+                    );
+                    return;
+                case V1ReferralRecordsCommand c:
+                    await ValidateStaffAssignmentCommandAsync(organizationId, locationId, c.Command);
+                    await v1ReferralsResource.ExecuteV1ReferralCommandAsync(
+                        organizationId,
+                        locationId,
+                        c.Command,
+                        user.UserId()
+                    );
+                    return;
+                case ArrangementRecordsCommand c:
+                    await v1CasesResource.ExecuteArrangementsCommandAsync(
+                        organizationId,
+                        locationId,
+                        c.Command,
+                        user.UserId()
+                    );
+                    return;
+                case NoteRecordsCommand c:
+                    await notesResource.ExecuteNoteCommandAsync(
+                        organizationId,
+                        locationId,
+                        c.Command,
+                        user.UserId()
+                    );
+                    return;
+                case CommunityRecordsCommand c:
+                    await communitiesResource.ExecuteCommunityCommandAsync(
+                        organizationId,
+                        locationId,
+                        c.Command,
+                        user.UserId()
+                    );
+                    return;
+                case V1ReferralNoteRecordsCommand c:
+                    await v1ReferralNotesResource.ExecuteReferralNoteCommandAsync(
+                        organizationId,
+                        locationId,
+                        c.Command,
+                        user.UserId()
+                    );
+                    return;
+                default:
+                    throw new NotImplementedException(
+                        $"The command type '{command.GetType().FullName}' has not been implemented."
+                    );
+            }
+        }
+
+        private async Task ValidateStaffAssignmentCommandAsync(
+            Guid organizationId,
+            Guid locationId,
+            V1ReferralCommand command
+        )
+        {
+            if (command is not AssignStaffToV1Referral assignStaff)
+                return;
+
+            var locationPolicy = await policiesResource.GetCurrentPolicy(
+                organizationId,
+                locationId
+            );
+            var assignmentPolicy = locationPolicy
+                .V1ReferralPolicy.StaffAssignmentPolicies.SingleOrDefault(policy =>
+                    policy.AssignmentRole == assignStaff.AssignmentRole
+                );
+
+            if (assignmentPolicy == null)
+                throw new InvalidOperationException(
+                    "The staff assignment role is not configured for referrals."
+                );
+
+            if (
+                !await IsEligibleStaffAssigneeAsync(
+                    organizationId,
+                    locationId,
+                    assignStaff.PersonId,
+                    assignmentPolicy.Eligibility
+                )
+            )
+                throw new InvalidOperationException(
+                    "The selected person is not eligible for this staff assignment role."
+                );
+        }
+
+        private async Task ValidateStaffAssignmentCommandAsync(
+            Guid organizationId,
+            Guid locationId,
+            V1CaseCommand command
+        )
+        {
+            if (command is not AssignStaffToV1Case assignStaff)
+                return;
+
+            var locationPolicy = await policiesResource.GetCurrentPolicy(
+                organizationId,
+                locationId
+            );
+            var assignmentPolicy = locationPolicy
+                .ReferralPolicy.StaffAssignmentPolicies.SingleOrDefault(policy =>
+                    policy.AssignmentRole == assignStaff.AssignmentRole
+                );
+
+            if (assignmentPolicy == null)
+                throw new InvalidOperationException(
+                    "The staff assignment role is not configured for cases."
+                );
+
+            if (
+                !await IsEligibleStaffAssigneeAsync(
+                    organizationId,
+                    locationId,
+                    assignStaff.PersonId,
+                    assignmentPolicy.Eligibility
+                )
+            )
+                throw new InvalidOperationException(
+                    "The selected person is not eligible for this staff assignment role."
+                );
+        }
+
+        private async Task<bool> IsEligibleStaffAssigneeAsync(
+            Guid organizationId,
+            Guid locationId,
+            Guid personId,
+            StaffAssignmentEligibility eligibility
+        )
+        {
+            var person = (await directoryResource.ListPeopleAsync(organizationId, locationId))
+                .SingleOrDefault(person => person.Id == personId);
+
+            if (person == null || !person.Active)
+                return false;
+
+            var locationRoles =
+                await accountsResource.TryGetPersonRolesAsync(organizationId, locationId, personId)
+                ?? ImmutableList<string>.Empty;
+            if (locationRoles.Intersect(eligibility.EligibleLocationRoles).Any())
+                return true;
+
+            if (eligibility.EligiblePeople.Contains(personId))
+                return true;
+
+            if (
+                eligibility.EligibleIndividualVolunteerRoles.IsEmpty
+                && eligibility.EligibleVolunteerFamilyRoles.IsEmpty
+            )
+                return false;
+
+            var family = await directoryResource.FindPersonFamilyAsync(
+                organizationId,
+                locationId,
+                personId
+            );
+            if (family == null || !family.Active)
+                return false;
+
+            var volunteerFamily = await approvalsResource.TryGetVolunteerFamilyAsync(
+                organizationId,
+                locationId,
+                family.Id
+            );
+            if (volunteerFamily == null)
+                return false;
+
+            var locationPolicy = await policiesResource.GetCurrentPolicy(
+                organizationId,
+                locationId
+            );
+            var combinedApprovals =
+                await policyEvaluationEngine.CalculateCombinedFamilyApprovalsAsync(
+                    organizationId,
+                    locationId,
+                    family,
+                    volunteerFamily.CompletedRequirements,
+                    volunteerFamily.ExemptedRequirements,
+                    volunteerFamily.RoleRemovals,
+                    volunteerFamily.IndividualEntries.ToImmutableDictionary(
+                        entry => entry.Key,
+                        entry => entry.Value.CompletedRequirements
                     ),
-                _ => throw new NotImplementedException(
-                    $"The command type '{command.GetType().FullName}' has not been implemented."
-                ),
-            };
+                    volunteerFamily.IndividualEntries.ToImmutableDictionary(
+                        entry => entry.Key,
+                        entry => entry.Value.ExemptedRequirements
+                    ),
+                    volunteerFamily.IndividualEntries.ToImmutableDictionary(
+                        entry => entry.Key,
+                        entry => entry.Value.RoleRemovals
+                    )
+                );
+
+            var hasEligibleIndividualRole =
+                combinedApprovals.IndividualApprovals.TryGetValue(
+                    personId,
+                    out var individualApproval
+                )
+                && individualApproval.ApprovalStatusByRole.Any(role =>
+                    eligibility.EligibleIndividualVolunteerRoles.Contains(role.Key)
+                    && IsApprovedOrOnboarded(role.Value.CurrentStatus)
+                );
+
+            if (hasEligibleIndividualRole)
+                return true;
+
+            return combinedApprovals.FamilyRoleApprovals.Any(role =>
+                eligibility.EligibleVolunteerFamilyRoles.Contains(role.Key)
+                && IsApprovedOrOnboarded(role.Value.CurrentStatus)
+            );
+        }
+
+        private static bool IsApprovedOrOnboarded(RoleApprovalStatus? status) =>
+            status is RoleApprovalStatus.Approved or RoleApprovalStatus.Onboarded;
 
         private async Task<ImmutableList<RecordsAggregate>> RenderCommandResultAsync(
             Guid organizationId,
@@ -839,20 +1108,21 @@ namespace CareTogether.Managers.Records
                 var renderedReferral = await RenderReferralAsync(
                     organizationId,
                     locationId,
+                    userContext,
                     referral
                 );
 
                 var results = ImmutableList.CreateBuilder<RecordsAggregate>();
                 results.Add(new ReferralRecordsAggregate(renderedReferral));
 
-                if (renderedReferral.FamilyId.HasValue)
+                if (renderedReferral.Referral.FamilyId.HasValue)
                 {
                     var familyResult =
                         await combinedFamilyInfoFormatter.RenderCombinedFamilyInfoAsync(
                             organizationId,
                             locationPolicy,
                             locationId,
-                            renderedReferral.FamilyId.Value,
+                            renderedReferral.Referral.FamilyId.Value,
                             null,
                             userContext
                         );
@@ -880,6 +1150,7 @@ namespace CareTogether.Managers.Records
                 var renderedReferral = await RenderReferralAsync(
                     organizationId,
                     locationId,
+                    userContext,
                     referral
                 );
 
@@ -1006,9 +1277,10 @@ namespace CareTogether.Managers.Records
                 ),
             };
 
-        private async Task<V1Referral> RenderReferralAsync(
+        private async Task<V1ReferralInfo> RenderReferralAsync(
             Guid organizationId,
             Guid locationId,
+            SessionUserContext userContext,
             V1Referral referral
         )
         {
@@ -1024,10 +1296,34 @@ namespace CareTogether.Managers.Records
                 referral.ReferralId
             );
 
-            return referral with
+            var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
+                organizationId,
+                locationId,
+                userContext,
+                new V1ReferralAuthorizationContext(referral.ReferralId)
+            );
+
+            var canViewStaffAssignments = permissions.Contains(
+                Permission.ViewV1ReferralStaffAssignments
+            );
+
+            var disclosedReferral = referral with
             {
                 Notes = notes,
+                StaffAssignments = canViewStaffAssignments
+                    ? referral.StaffAssignments
+                    : ImmutableList<StaffAssignment>.Empty,
+                History = canViewStaffAssignments
+                    ? referral.History
+                    : referral
+                        .History.Where(activity =>
+                            activity is not V1ReferralStaffAssigned
+                                and not V1ReferralStaffUnassigned
+                        )
+                        .ToImmutableList(),
             };
+
+            return new V1ReferralInfo(disclosedReferral, permissions);
         }
 
         private async Task<V1Referral> PopulateMissingReferralIntakeRequirementsAsync(

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -239,6 +239,8 @@ namespace CareTogether.Managers.Records
                 command
             );
 
+            // User commands are the requested workflow steps and must pass authorization.
+            // Derived commands are workflow side effects covered by the authorized user commands.
             foreach (var userCommand in commandPlan.UserCommands)
                 if (
                     !await AuthorizeCommandAsync(

--- a/src/CareTogether.Core/Managers/SharedContracts.cs
+++ b/src/CareTogether.Core/Managers/SharedContracts.cs
@@ -9,6 +9,7 @@ using CareTogether.Resources.Directory;
 using CareTogether.Resources.Notes;
 using CareTogether.Resources.Policies;
 using CareTogether.Resources.V1Cases;
+using CareTogether.Resources.V1Referrals;
 
 namespace CareTogether.Managers
 {
@@ -31,6 +32,11 @@ namespace CareTogether.Managers
         ImmutableList<Activity> History
     );
 
+    public sealed record V1ReferralInfo(
+        V1Referral Referral,
+        ImmutableList<Permission> UserPermissions
+    );
+
     public sealed record V1Case(
         Guid Id,
         DateTime OpenedAtUtc,
@@ -42,6 +48,7 @@ namespace CareTogether.Managers
         ImmutableList<CompletedCustomFieldInfo> CompletedCustomFields,
         ImmutableList<string> MissingCustomFields,
         ImmutableList<Arrangement> Arrangements,
+        ImmutableList<StaffAssignment> StaffAssignments,
         string? Comments,
         ImmutableList<Guid> LinkedV1ReferralIds
     );

--- a/src/CareTogether.Core/Permission.cs
+++ b/src/CareTogether.Core/Permission.cs
@@ -68,6 +68,8 @@
         ViewV1Referral = 264,
         EditV1ReferralRequirementCompletion = 265,
         EditV1ReferralRequirementExemption = 266,
+        ViewV1ReferralStaffAssignments = 267,
+        EditV1ReferralStaffAssignments = 268,
 
         // ---- V1Cases ---- //
 
@@ -80,6 +82,8 @@
         EditV1CaseRequirementCompletion = 306, // Requires UploadFamilyDocuments
         EditV1CaseRequirementExemption = 307,
         ViewV1CaseHistory = 308,
+        ViewV1CaseStaffAssignments = 309,
+        EditV1CaseStaffAssignments = 310,
 
         CreateArrangement = 350,
         EditArrangement = 351,

--- a/src/CareTogether.Core/Resources/Policies/IPoliciesResource.cs
+++ b/src/CareTogether.Core/Resources/Policies/IPoliciesResource.cs
@@ -68,6 +68,16 @@ namespace CareTogether.Resources.Policies
         ImmutableList<string>? WhenAssigneeFunctionIsIn
     ) : PermissionContext();
 
+    public sealed record AssignedStaffInV1ReferralPermissionContext(
+        bool? WhenReferralIsOpen,
+        ImmutableList<string>? WhenAssignmentRoleIsIn
+    ) : PermissionContext();
+
+    public sealed record AssignedStaffInV1CasePermissionContext(
+        bool? WhenCaseIsOpen,
+        ImmutableList<string>? WhenAssignmentRoleIsIn
+    ) : PermissionContext();
+
     public sealed record CommunityMemberPermissionContext(
         ImmutableList<string>? WhenOwnCommunityRoleIsIn
     ) : PermissionContext();
@@ -99,7 +109,11 @@ namespace CareTogether.Resources.Policies
         ImmutableList<CustomField> CustomFamilyFields,
         V1CasePolicy ReferralPolicy,
         VolunteerPolicy VolunteerPolicy
-    );
+    )
+    {
+        public V1ReferralPolicy V1ReferralPolicy { get; init; } =
+            new(ImmutableList<StaffAssignmentPolicy>.Empty);
+    };
 
     public enum DocumentLinkRequirement
     {
@@ -145,6 +159,9 @@ namespace CareTogether.Resources.Policies
         ImmutableList<RequirementDefinition>? IntakeRequirements = null
     )
     {
+        public ImmutableList<StaffAssignmentPolicy> StaffAssignmentPolicies { get; init; } =
+            ImmutableList<StaffAssignmentPolicy>.Empty;
+
         public ImmutableList<RequirementDefinition> IntakeRequirements_PRE_MIGRATION =
             RequiredIntakeActionNames
                 .Select(requirementName => new RequirementDefinition(requirementName, true))
@@ -152,7 +169,21 @@ namespace CareTogether.Resources.Policies
                 .ToImmutableList();
     };
 
-    //TODO: Include referral close reasons
+    public sealed record V1ReferralPolicy(
+        ImmutableList<StaffAssignmentPolicy> StaffAssignmentPolicies
+    );
+
+    public sealed record StaffAssignmentPolicy(
+        string AssignmentRole,
+        StaffAssignmentEligibility Eligibility
+    );
+
+    public sealed record StaffAssignmentEligibility(
+        ImmutableList<string> EligibleLocationRoles,
+        ImmutableList<string> EligibleIndividualVolunteerRoles,
+        ImmutableList<string> EligibleVolunteerFamilyRoles,
+        ImmutableList<Guid> EligiblePeople
+    );
 
     public sealed record CustomField(
         string Name,

--- a/src/CareTogether.Core/Resources/Referrals/IReferralsResource.cs
+++ b/src/CareTogether.Core/Resources/Referrals/IReferralsResource.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using CareTogether.Resources;
 using CareTogether.Resources.Policies;
 using JsonPolymorph;
 
@@ -17,6 +18,7 @@ namespace CareTogether.Resources.V1Cases
         ImmutableList<ExemptedRequirementInfo> ExemptedRequirements,
         ImmutableDictionary<string, CompletedCustomFieldInfo> CompletedCustomFields,
         ImmutableDictionary<Guid, ArrangementEntry> Arrangements,
+        ImmutableList<StaffAssignment> StaffAssignments,
         ImmutableList<Activity> History,
         string? Comments
     );
@@ -144,6 +146,20 @@ namespace CareTogether.Resources.V1Cases
 
     public sealed record UpdateReferralComments(Guid FamilyId, Guid ReferralId, string? Comments)
         : V1CaseCommand(FamilyId, ReferralId);
+
+    public sealed record AssignStaffToV1Case(
+        Guid FamilyId,
+        Guid ReferralId,
+        Guid PersonId,
+        string AssignmentRole
+    ) : V1CaseCommand(FamilyId, ReferralId);
+
+    public sealed record UnassignStaffFromV1Case(
+        Guid FamilyId,
+        Guid ReferralId,
+        Guid PersonId,
+        string AssignmentRole
+    ) : V1CaseCommand(FamilyId, ReferralId);
 
     public sealed record CloseReferral(
         Guid FamilyId,

--- a/src/CareTogether.Core/Resources/Referrals/ReferralModel.cs
+++ b/src/CareTogether.Core/Resources/Referrals/ReferralModel.cs
@@ -59,6 +59,20 @@ namespace CareTogether.Resources.V1Cases
         Guid? NoteId
     ) : Activity(UserId, AuditTimestampUtc, ChangedAtUtc, null, NoteId);
 
+    public sealed record V1CaseStaffAssigned(
+        Guid UserId,
+        DateTime AuditTimestampUtc,
+        Guid PersonId,
+        string AssignmentRole
+    ) : Activity(UserId, AuditTimestampUtc, AuditTimestampUtc, null, null);
+
+    public sealed record V1CaseStaffUnassigned(
+        Guid UserId,
+        DateTime AuditTimestampUtc,
+        Guid PersonId,
+        string AssignmentRole
+    ) : Activity(UserId, AuditTimestampUtc, AuditTimestampUtc, null, null);
+
     public sealed class V1CaseModel
     {
         private ImmutableDictionary<Guid, V1CaseEntry> v1Cases = ImmutableDictionary<
@@ -101,6 +115,7 @@ namespace CareTogether.Resources.V1Cases
                         ImmutableList<ExemptedRequirementInfo>.Empty,
                         ImmutableDictionary<string, CompletedCustomFieldInfo>.Empty,
                         ImmutableDictionary<Guid, ArrangementEntry>.Empty,
+                        ImmutableList<StaffAssignment>.Empty,
                         ImmutableList<Activity>.Empty,
                         Comments: null
                     ),
@@ -195,6 +210,13 @@ namespace CareTogether.Resources.V1Cases
                             null
                         ),
                         LinkReferralToCase c => (LinkReferralToCaseEntry(v1CaseEntry, c), null),
+                        AssignStaffToV1Case c => AssignStaff(v1CaseEntry, c, userId, timestampUtc),
+                        UnassignStaffFromV1Case c => UnassignStaff(
+                            v1CaseEntry,
+                            c,
+                            userId,
+                            timestampUtc
+                        ),
                         CloseReferral c => (
                             v1CaseEntry with
                             {
@@ -859,6 +881,74 @@ namespace CareTogether.Resources.V1Cases
                     LastKnownSequenceNumber++;
                     v1Cases = v1Cases.SetItem(v1CaseEntryToUpsert.Id, v1CaseEntryToUpsert);
                 }
+            );
+        }
+
+        private static (V1CaseEntry V1CaseEntry, Activity? Activity) AssignStaff(
+            V1CaseEntry v1CaseEntry,
+            AssignStaffToV1Case command,
+            Guid userId,
+            DateTime timestampUtc
+        )
+        {
+            if (
+                v1CaseEntry.StaffAssignments.Any(assignment =>
+                    assignment.PersonId == command.PersonId
+                    && assignment.AssignmentRole == command.AssignmentRole
+                )
+            )
+                return (v1CaseEntry, null);
+
+            return (
+                v1CaseEntry with
+                {
+                    StaffAssignments = v1CaseEntry.StaffAssignments.Add(
+                        new StaffAssignment(
+                            command.PersonId,
+                            command.AssignmentRole,
+                            timestampUtc,
+                            userId
+                        )
+                    ),
+                },
+                new V1CaseStaffAssigned(
+                    userId,
+                    timestampUtc,
+                    command.PersonId,
+                    command.AssignmentRole
+                )
+            );
+        }
+
+        private static (V1CaseEntry V1CaseEntry, Activity? Activity) UnassignStaff(
+            V1CaseEntry v1CaseEntry,
+            UnassignStaffFromV1Case command,
+            Guid userId,
+            DateTime timestampUtc
+        )
+        {
+            if (
+                !v1CaseEntry.StaffAssignments.Any(assignment =>
+                    assignment.PersonId == command.PersonId
+                    && assignment.AssignmentRole == command.AssignmentRole
+                )
+            )
+                return (v1CaseEntry, null);
+
+            return (
+                v1CaseEntry with
+                {
+                    StaffAssignments = v1CaseEntry.StaffAssignments.RemoveAll(assignment =>
+                        assignment.PersonId == command.PersonId
+                        && assignment.AssignmentRole == command.AssignmentRole
+                    ),
+                },
+                new V1CaseStaffUnassigned(
+                    userId,
+                    timestampUtc,
+                    command.PersonId,
+                    command.AssignmentRole
+                )
             );
         }
 

--- a/src/CareTogether.Core/Resources/SharedContracts.cs
+++ b/src/CareTogether.Core/Resources/SharedContracts.cs
@@ -31,6 +31,13 @@ namespace CareTogether.Resources
         string UploadedFileName
     );
 
+    public sealed record StaffAssignment(
+        Guid PersonId,
+        string AssignmentRole,
+        DateTime AssignedAtUtc,
+        Guid AssignedByUserId
+    );
+
     public sealed record CompletedCustomFieldInfo(
         Guid UserId,
         DateTime TimestampUtc,

--- a/src/CareTogether.Core/Resources/V1Referrals/IV1ReferralsResource.cs
+++ b/src/CareTogether.Core/Resources/V1Referrals/IV1ReferralsResource.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using CareTogether.Resources;
 using CareTogether.Resources.Policies;
 using CareTogether.Resources.V1ReferralNotes;
 using JsonPolymorph;
@@ -22,6 +23,7 @@ namespace CareTogether.Resources.V1Referrals
         ImmutableList<ExemptedRequirementInfo> ExemptedRequirements,
         ImmutableList<UploadedDocumentInfo> UploadedDocuments,
         ImmutableList<Guid> DeletedDocuments,
+        ImmutableList<StaffAssignment> StaffAssignments,
         ImmutableList<Activity> History,
         ImmutableList<V1ReferralNoteEntry> Notes
     )
@@ -108,6 +110,18 @@ namespace CareTogether.Resources.V1Referrals
 
     public sealed record DeleteUploadedV1ReferralDocument(Guid ReferralId, Guid UploadedDocumentId)
         : V1ReferralCommand(ReferralId);
+
+    public sealed record AssignStaffToV1Referral(
+        Guid ReferralId,
+        Guid PersonId,
+        string AssignmentRole
+    ) : V1ReferralCommand(ReferralId);
+
+    public sealed record UnassignStaffFromV1Referral(
+        Guid ReferralId,
+        Guid PersonId,
+        string AssignmentRole
+    ) : V1ReferralCommand(ReferralId);
 
     public interface IV1ReferralsResource
     {

--- a/src/CareTogether.Core/Resources/V1Referrals/V1ReferralModel.cs
+++ b/src/CareTogether.Core/Resources/V1Referrals/V1ReferralModel.cs
@@ -46,6 +46,20 @@ namespace CareTogether.Resources.V1Referrals
         Guid? NoteId
     ) : Activity(UserId, AuditTimestampUtc, CompletedAtUtc, UploadedDocumentId, NoteId);
 
+    public sealed record V1ReferralStaffAssigned(
+        Guid UserId,
+        DateTime AuditTimestampUtc,
+        Guid PersonId,
+        string AssignmentRole
+    ) : Activity(UserId, AuditTimestampUtc, AuditTimestampUtc, null, null);
+
+    public sealed record V1ReferralStaffUnassigned(
+        Guid UserId,
+        DateTime AuditTimestampUtc,
+        Guid PersonId,
+        string AssignmentRole
+    ) : Activity(UserId, AuditTimestampUtc, AuditTimestampUtc, null, null);
+
     public sealed class V1ReferralModel
     {
         private ImmutableDictionary<Guid, V1Referral> referrals = ImmutableDictionary<
@@ -129,6 +143,7 @@ namespace CareTogether.Resources.V1Referrals
                             ExemptedRequirements: ImmutableList<ExemptedRequirementInfo>.Empty,
                             UploadedDocuments: ImmutableList<UploadedDocumentInfo>.Empty,
                             DeletedDocuments: ImmutableList<Guid>.Empty,
+                            StaffAssignments: ImmutableList<StaffAssignment>.Empty,
                             History: ImmutableList<Activity>.Empty,
                             Notes: ImmutableList<V1ReferralNoteEntry>.Empty
                         ),
@@ -287,10 +302,90 @@ namespace CareTogether.Resources.V1Referrals
                     },
                     null
                 ),
+                AssignStaffToV1Referral c => AssignStaff(
+                    EnsureExists(referral),
+                    c,
+                    actorUserId,
+                    occurredAtUtc
+                ),
+                UnassignStaffFromV1Referral c => UnassignStaff(
+                    EnsureExists(referral),
+                    c,
+                    actorUserId,
+                    occurredAtUtc
+                ),
                 _ => throw new NotImplementedException(
                     $"The command type '{command.GetType().FullName}' has not been implemented."
                 ),
             };
+        }
+
+        private static (V1Referral Referral, Activity? Activity) AssignStaff(
+            V1Referral referral,
+            AssignStaffToV1Referral command,
+            Guid actorUserId,
+            DateTime occurredAtUtc
+        )
+        {
+            if (
+                referral.StaffAssignments.Any(assignment =>
+                    assignment.PersonId == command.PersonId
+                    && assignment.AssignmentRole == command.AssignmentRole
+                )
+            )
+                return (referral, null);
+
+            return (
+                referral with
+                {
+                    StaffAssignments = referral.StaffAssignments.Add(
+                        new StaffAssignment(
+                            command.PersonId,
+                            command.AssignmentRole,
+                            occurredAtUtc,
+                            actorUserId
+                        )
+                    ),
+                },
+                new V1ReferralStaffAssigned(
+                    actorUserId,
+                    occurredAtUtc,
+                    command.PersonId,
+                    command.AssignmentRole
+                )
+            );
+        }
+
+        private static (V1Referral Referral, Activity? Activity) UnassignStaff(
+            V1Referral referral,
+            UnassignStaffFromV1Referral command,
+            Guid actorUserId,
+            DateTime occurredAtUtc
+        )
+        {
+            if (
+                !referral.StaffAssignments.Any(assignment =>
+                    assignment.PersonId == command.PersonId
+                    && assignment.AssignmentRole == command.AssignmentRole
+                )
+            )
+                return (referral, null);
+
+            return (
+                referral with
+                {
+                    StaffAssignments = referral.StaffAssignments.RemoveAll(assignment =>
+                        assignment.PersonId == command.PersonId
+                        && assignment.AssignmentRole == command.AssignmentRole
+                    ),
+                },
+                new V1ReferralStaffUnassigned(
+                    actorUserId,
+                    occurredAtUtc,
+                    command.PersonId,
+                    command.AssignmentRole
+                )
+            );
         }
 
         private static V1Referral AddActivity(V1Referral referral, Activity? activity) =>

--- a/src/caretogether-pwa/src/GeneratedClient.ts
+++ b/src/caretogether-pwa/src/GeneratedClient.ts
@@ -1815,6 +1815,16 @@ export abstract class PermissionContext implements IPermissionContext {
             result.init(data);
             return result;
         }
+        if (data["discriminator"] === "AssignedStaffInV1CasePermissionContext") {
+            let result = new AssignedStaffInV1CasePermissionContext();
+            result.init(data);
+            return result;
+        }
+        if (data["discriminator"] === "AssignedStaffInV1ReferralPermissionContext") {
+            let result = new AssignedStaffInV1ReferralPermissionContext();
+            result.init(data);
+            return result;
+        }
         if (data["discriminator"] === "CommunityCoMemberFamiliesAssignedFunctionsInReferralCoAssignedFamiliesPermissionContext") {
             let result = new CommunityCoMemberFamiliesAssignedFunctionsInReferralCoAssignedFamiliesPermissionContext();
             result.init(data);
@@ -2021,6 +2031,98 @@ export class AssignedFunctionsInReferralPartneringFamilyPermissionContext extend
 export interface IAssignedFunctionsInReferralPartneringFamilyPermissionContext extends IPermissionContext {
     whenReferralIsOpen?: boolean | undefined;
     whenOwnFunctionIsIn?: string[] | undefined;
+}
+
+export class AssignedStaffInV1CasePermissionContext extends PermissionContext implements IAssignedStaffInV1CasePermissionContext {
+    whenCaseIsOpen?: boolean | undefined;
+    whenAssignmentRoleIsIn?: string[] | undefined;
+
+    constructor(data?: IAssignedStaffInV1CasePermissionContext) {
+        super(data);
+        this._discriminator = "AssignedStaffInV1CasePermissionContext";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.whenCaseIsOpen = _data["whenCaseIsOpen"];
+            if (Array.isArray(_data["whenAssignmentRoleIsIn"])) {
+                this.whenAssignmentRoleIsIn = [] as any;
+                for (let item of _data["whenAssignmentRoleIsIn"])
+                    this.whenAssignmentRoleIsIn!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): AssignedStaffInV1CasePermissionContext {
+        data = typeof data === 'object' ? data : {};
+        let result = new AssignedStaffInV1CasePermissionContext();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["whenCaseIsOpen"] = this.whenCaseIsOpen;
+        if (Array.isArray(this.whenAssignmentRoleIsIn)) {
+            data["whenAssignmentRoleIsIn"] = [];
+            for (let item of this.whenAssignmentRoleIsIn)
+                data["whenAssignmentRoleIsIn"].push(item);
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IAssignedStaffInV1CasePermissionContext extends IPermissionContext {
+    whenCaseIsOpen?: boolean | undefined;
+    whenAssignmentRoleIsIn?: string[] | undefined;
+}
+
+export class AssignedStaffInV1ReferralPermissionContext extends PermissionContext implements IAssignedStaffInV1ReferralPermissionContext {
+    whenReferralIsOpen?: boolean | undefined;
+    whenAssignmentRoleIsIn?: string[] | undefined;
+
+    constructor(data?: IAssignedStaffInV1ReferralPermissionContext) {
+        super(data);
+        this._discriminator = "AssignedStaffInV1ReferralPermissionContext";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.whenReferralIsOpen = _data["whenReferralIsOpen"];
+            if (Array.isArray(_data["whenAssignmentRoleIsIn"])) {
+                this.whenAssignmentRoleIsIn = [] as any;
+                for (let item of _data["whenAssignmentRoleIsIn"])
+                    this.whenAssignmentRoleIsIn!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): AssignedStaffInV1ReferralPermissionContext {
+        data = typeof data === 'object' ? data : {};
+        let result = new AssignedStaffInV1ReferralPermissionContext();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["whenReferralIsOpen"] = this.whenReferralIsOpen;
+        if (Array.isArray(this.whenAssignmentRoleIsIn)) {
+            data["whenAssignmentRoleIsIn"] = [];
+            for (let item of this.whenAssignmentRoleIsIn)
+                data["whenAssignmentRoleIsIn"].push(item);
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IAssignedStaffInV1ReferralPermissionContext extends IPermissionContext {
+    whenReferralIsOpen?: boolean | undefined;
+    whenAssignmentRoleIsIn?: string[] | undefined;
 }
 
 export class CommunityCoMemberFamiliesAssignedFunctionsInReferralCoAssignedFamiliesPermissionContext extends PermissionContext implements ICommunityCoMemberFamiliesAssignedFunctionsInReferralCoAssignedFamiliesPermissionContext {
@@ -2340,6 +2442,8 @@ export enum Permission {
     ViewV1Referral = 264,
     EditV1ReferralRequirementCompletion = 265,
     EditV1ReferralRequirementExemption = 266,
+    ViewV1ReferralStaffAssignments = 267,
+    EditV1ReferralStaffAssignments = 268,
     CreateV1Case = 300,
     EditV1Case = 301,
     CloseV1Case = 302,
@@ -2349,6 +2453,8 @@ export enum Permission {
     EditV1CaseRequirementCompletion = 306,
     EditV1CaseRequirementExemption = 307,
     ViewV1CaseHistory = 308,
+    ViewV1CaseStaffAssignments = 309,
+    EditV1CaseStaffAssignments = 310,
     CreateArrangement = 350,
     EditArrangement = 351,
     ViewAssignments = 352,
@@ -2420,6 +2526,7 @@ export class EffectiveLocationPolicy implements IEffectiveLocationPolicy {
     customFamilyFields!: CustomField[];
     referralPolicy!: V1CasePolicy;
     volunteerPolicy!: VolunteerPolicy;
+    v1ReferralPolicy!: V1ReferralPolicy;
 
     constructor(data?: IEffectiveLocationPolicy) {
         if (data) {
@@ -2433,6 +2540,7 @@ export class EffectiveLocationPolicy implements IEffectiveLocationPolicy {
             this.customFamilyFields = [];
             this.referralPolicy = new V1CasePolicy();
             this.volunteerPolicy = new VolunteerPolicy();
+            this.v1ReferralPolicy = new V1ReferralPolicy();
         }
     }
 
@@ -2452,6 +2560,7 @@ export class EffectiveLocationPolicy implements IEffectiveLocationPolicy {
             }
             this.referralPolicy = _data["referralPolicy"] ? V1CasePolicy.fromJS(_data["referralPolicy"]) : new V1CasePolicy();
             this.volunteerPolicy = _data["volunteerPolicy"] ? VolunteerPolicy.fromJS(_data["volunteerPolicy"]) : new VolunteerPolicy();
+            this.v1ReferralPolicy = _data["v1ReferralPolicy"] ? V1ReferralPolicy.fromJS(_data["v1ReferralPolicy"]) : new V1ReferralPolicy();
         }
     }
 
@@ -2478,6 +2587,7 @@ export class EffectiveLocationPolicy implements IEffectiveLocationPolicy {
         }
         data["referralPolicy"] = this.referralPolicy ? this.referralPolicy.toJSON() : <any>undefined;
         data["volunteerPolicy"] = this.volunteerPolicy ? this.volunteerPolicy.toJSON() : <any>undefined;
+        data["v1ReferralPolicy"] = this.v1ReferralPolicy ? this.v1ReferralPolicy.toJSON() : <any>undefined;
         return data;
     }
 }
@@ -2487,6 +2597,7 @@ export interface IEffectiveLocationPolicy {
     customFamilyFields: CustomField[];
     referralPolicy: V1CasePolicy;
     volunteerPolicy: VolunteerPolicy;
+    v1ReferralPolicy: V1ReferralPolicy;
 }
 
 export class ActionRequirement implements IActionRequirement {
@@ -2645,6 +2756,7 @@ export class V1CasePolicy implements IV1CasePolicy {
     arrangementPolicies!: ArrangementPolicy[];
     functionPolicies?: FunctionPolicy[] | undefined;
     intakeRequirements?: RequirementDefinition[] | undefined;
+    staffAssignmentPolicies!: StaffAssignmentPolicy[];
 
     constructor(data?: IV1CasePolicy) {
         if (data) {
@@ -2658,6 +2770,7 @@ export class V1CasePolicy implements IV1CasePolicy {
             this.requiredIntakeActionNames = [];
             this.customFields = [];
             this.arrangementPolicies = [];
+            this.staffAssignmentPolicies = [];
         }
     }
 
@@ -2692,6 +2805,11 @@ export class V1CasePolicy implements IV1CasePolicy {
                 this.intakeRequirements = [] as any;
                 for (let item of _data["intakeRequirements"])
                     this.intakeRequirements!.push(RequirementDefinition.fromJS(item));
+            }
+            if (Array.isArray(_data["staffAssignmentPolicies"])) {
+                this.staffAssignmentPolicies = [] as any;
+                for (let item of _data["staffAssignmentPolicies"])
+                    this.staffAssignmentPolicies!.push(StaffAssignmentPolicy.fromJS(item));
             }
         }
     }
@@ -2735,6 +2853,11 @@ export class V1CasePolicy implements IV1CasePolicy {
             for (let item of this.intakeRequirements)
                 data["intakeRequirements"].push(item.toJSON());
         }
+        if (Array.isArray(this.staffAssignmentPolicies)) {
+            data["staffAssignmentPolicies"] = [];
+            for (let item of this.staffAssignmentPolicies)
+                data["staffAssignmentPolicies"].push(item.toJSON());
+        }
         return data;
     }
 }
@@ -2746,6 +2869,7 @@ export interface IV1CasePolicy {
     arrangementPolicies: ArrangementPolicy[];
     functionPolicies?: FunctionPolicy[] | undefined;
     intakeRequirements?: RequirementDefinition[] | undefined;
+    staffAssignmentPolicies: StaffAssignmentPolicy[];
 }
 
 export class RequirementDefinition implements IRequirementDefinition {
@@ -3674,6 +3798,135 @@ export interface IFunctionEligibility {
     eligiblePeople: string[];
 }
 
+export class StaffAssignmentPolicy implements IStaffAssignmentPolicy {
+    assignmentRole!: string;
+    eligibility!: StaffAssignmentEligibility;
+
+    constructor(data?: IStaffAssignmentPolicy) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        if (!data) {
+            this.eligibility = new StaffAssignmentEligibility();
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.assignmentRole = _data["assignmentRole"];
+            this.eligibility = _data["eligibility"] ? StaffAssignmentEligibility.fromJS(_data["eligibility"]) : new StaffAssignmentEligibility();
+        }
+    }
+
+    static fromJS(data: any): StaffAssignmentPolicy {
+        data = typeof data === 'object' ? data : {};
+        let result = new StaffAssignmentPolicy();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["assignmentRole"] = this.assignmentRole;
+        data["eligibility"] = this.eligibility ? this.eligibility.toJSON() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IStaffAssignmentPolicy {
+    assignmentRole: string;
+    eligibility: StaffAssignmentEligibility;
+}
+
+export class StaffAssignmentEligibility implements IStaffAssignmentEligibility {
+    eligibleLocationRoles!: string[];
+    eligibleIndividualVolunteerRoles!: string[];
+    eligibleVolunteerFamilyRoles!: string[];
+    eligiblePeople!: string[];
+
+    constructor(data?: IStaffAssignmentEligibility) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        if (!data) {
+            this.eligibleLocationRoles = [];
+            this.eligibleIndividualVolunteerRoles = [];
+            this.eligibleVolunteerFamilyRoles = [];
+            this.eligiblePeople = [];
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["eligibleLocationRoles"])) {
+                this.eligibleLocationRoles = [] as any;
+                for (let item of _data["eligibleLocationRoles"])
+                    this.eligibleLocationRoles!.push(item);
+            }
+            if (Array.isArray(_data["eligibleIndividualVolunteerRoles"])) {
+                this.eligibleIndividualVolunteerRoles = [] as any;
+                for (let item of _data["eligibleIndividualVolunteerRoles"])
+                    this.eligibleIndividualVolunteerRoles!.push(item);
+            }
+            if (Array.isArray(_data["eligibleVolunteerFamilyRoles"])) {
+                this.eligibleVolunteerFamilyRoles = [] as any;
+                for (let item of _data["eligibleVolunteerFamilyRoles"])
+                    this.eligibleVolunteerFamilyRoles!.push(item);
+            }
+            if (Array.isArray(_data["eligiblePeople"])) {
+                this.eligiblePeople = [] as any;
+                for (let item of _data["eligiblePeople"])
+                    this.eligiblePeople!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): StaffAssignmentEligibility {
+        data = typeof data === 'object' ? data : {};
+        let result = new StaffAssignmentEligibility();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.eligibleLocationRoles)) {
+            data["eligibleLocationRoles"] = [];
+            for (let item of this.eligibleLocationRoles)
+                data["eligibleLocationRoles"].push(item);
+        }
+        if (Array.isArray(this.eligibleIndividualVolunteerRoles)) {
+            data["eligibleIndividualVolunteerRoles"] = [];
+            for (let item of this.eligibleIndividualVolunteerRoles)
+                data["eligibleIndividualVolunteerRoles"].push(item);
+        }
+        if (Array.isArray(this.eligibleVolunteerFamilyRoles)) {
+            data["eligibleVolunteerFamilyRoles"] = [];
+            for (let item of this.eligibleVolunteerFamilyRoles)
+                data["eligibleVolunteerFamilyRoles"].push(item);
+        }
+        if (Array.isArray(this.eligiblePeople)) {
+            data["eligiblePeople"] = [];
+            for (let item of this.eligiblePeople)
+                data["eligiblePeople"].push(item);
+        }
+        return data;
+    }
+}
+
+export interface IStaffAssignmentEligibility {
+    eligibleLocationRoles: string[];
+    eligibleIndividualVolunteerRoles: string[];
+    eligibleVolunteerFamilyRoles: string[];
+    eligiblePeople: string[];
+}
+
 export class VolunteerPolicy implements IVolunteerPolicy {
     volunteerRoles!: { [key: string]: VolunteerRolePolicy; };
     volunteerFamilyRoles!: { [key: string]: VolunteerFamilyRolePolicy; };
@@ -4048,6 +4301,53 @@ export enum VolunteerFamilyRequirementScope {
     OncePerFamily = 0,
     AllAdultsInTheFamily = 1,
     AllParticipatingAdultsInTheFamily = 2,
+}
+
+export class V1ReferralPolicy implements IV1ReferralPolicy {
+    staffAssignmentPolicies!: StaffAssignmentPolicy[];
+
+    constructor(data?: IV1ReferralPolicy) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        if (!data) {
+            this.staffAssignmentPolicies = [];
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["staffAssignmentPolicies"])) {
+                this.staffAssignmentPolicies = [] as any;
+                for (let item of _data["staffAssignmentPolicies"])
+                    this.staffAssignmentPolicies!.push(StaffAssignmentPolicy.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): V1ReferralPolicy {
+        data = typeof data === 'object' ? data : {};
+        let result = new V1ReferralPolicy();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.staffAssignmentPolicies)) {
+            data["staffAssignmentPolicies"] = [];
+            for (let item of this.staffAssignmentPolicies)
+                data["staffAssignmentPolicies"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+export interface IV1ReferralPolicy {
+    staffAssignmentPolicies: StaffAssignmentPolicy[];
 }
 
 export class CurrentFeatureFlags implements ICurrentFeatureFlags {
@@ -5377,6 +5677,16 @@ export abstract class Activity implements IActivity {
             result.init(data);
             return result;
         }
+        if (data["discriminator"] === "V1CaseStaffAssigned") {
+            let result = new V1CaseStaffAssigned();
+            result.init(data);
+            return result;
+        }
+        if (data["discriminator"] === "V1CaseStaffUnassigned") {
+            let result = new V1CaseStaffUnassigned();
+            result.init(data);
+            return result;
+        }
         if (data["discriminator"] === "V1ReferralAccepted") {
             let result = new V1ReferralAccepted();
             result.init(data);
@@ -5394,6 +5704,16 @@ export abstract class Activity implements IActivity {
         }
         if (data["discriminator"] === "V1ReferralRequirementCompleted") {
             let result = new V1ReferralRequirementCompleted();
+            result.init(data);
+            return result;
+        }
+        if (data["discriminator"] === "V1ReferralStaffAssigned") {
+            let result = new V1ReferralStaffAssigned();
+            result.init(data);
+            return result;
+        }
+        if (data["discriminator"] === "V1ReferralStaffUnassigned") {
+            let result = new V1ReferralStaffUnassigned();
             result.init(data);
             return result;
         }
@@ -5590,6 +5910,82 @@ export interface IReferralRequirementCompleted extends IActivity {
     completedAtUtc: Date;
 }
 
+export class V1CaseStaffAssigned extends Activity implements IV1CaseStaffAssigned {
+    personId!: string;
+    assignmentRole!: string;
+
+    constructor(data?: IV1CaseStaffAssigned) {
+        super(data);
+        this._discriminator = "V1CaseStaffAssigned";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+        }
+    }
+
+    static fromJS(data: any): V1CaseStaffAssigned {
+        data = typeof data === 'object' ? data : {};
+        let result = new V1CaseStaffAssigned();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IV1CaseStaffAssigned extends IActivity {
+    personId: string;
+    assignmentRole: string;
+}
+
+export class V1CaseStaffUnassigned extends Activity implements IV1CaseStaffUnassigned {
+    personId!: string;
+    assignmentRole!: string;
+
+    constructor(data?: IV1CaseStaffUnassigned) {
+        super(data);
+        this._discriminator = "V1CaseStaffUnassigned";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+        }
+    }
+
+    static fromJS(data: any): V1CaseStaffUnassigned {
+        data = typeof data === 'object' ? data : {};
+        let result = new V1CaseStaffUnassigned();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IV1CaseStaffUnassigned extends IActivity {
+    personId: string;
+    assignmentRole: string;
+}
+
 export class V1ReferralAccepted extends Activity implements IV1ReferralAccepted {
     acceptedAtUtc!: Date;
 
@@ -5734,6 +6130,82 @@ export interface IV1ReferralRequirementCompleted extends IActivity {
     completedAtUtc: Date;
 }
 
+export class V1ReferralStaffAssigned extends Activity implements IV1ReferralStaffAssigned {
+    personId!: string;
+    assignmentRole!: string;
+
+    constructor(data?: IV1ReferralStaffAssigned) {
+        super(data);
+        this._discriminator = "V1ReferralStaffAssigned";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+        }
+    }
+
+    static fromJS(data: any): V1ReferralStaffAssigned {
+        data = typeof data === 'object' ? data : {};
+        let result = new V1ReferralStaffAssigned();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IV1ReferralStaffAssigned extends IActivity {
+    personId: string;
+    assignmentRole: string;
+}
+
+export class V1ReferralStaffUnassigned extends Activity implements IV1ReferralStaffUnassigned {
+    personId!: string;
+    assignmentRole!: string;
+
+    constructor(data?: IV1ReferralStaffUnassigned) {
+        super(data);
+        this._discriminator = "V1ReferralStaffUnassigned";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+        }
+    }
+
+    static fromJS(data: any): V1ReferralStaffUnassigned {
+        data = typeof data === 'object' ? data : {};
+        let result = new V1ReferralStaffUnassigned();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IV1ReferralStaffUnassigned extends IActivity {
+    personId: string;
+    assignmentRole: string;
+}
+
 export class UserInfo implements IUserInfo {
     userId?: string | undefined;
     personId!: string;
@@ -5864,6 +6336,7 @@ export class V1Case implements IV1Case {
     completedCustomFields!: CompletedCustomFieldInfo[];
     missingCustomFields!: string[];
     arrangements!: Arrangement[];
+    staffAssignments!: StaffAssignment[];
     comments?: string | undefined;
     linkedV1ReferralIds!: string[];
 
@@ -5881,6 +6354,7 @@ export class V1Case implements IV1Case {
             this.completedCustomFields = [];
             this.missingCustomFields = [];
             this.arrangements = [];
+            this.staffAssignments = [];
             this.linkedV1ReferralIds = [];
         }
     }
@@ -5920,6 +6394,11 @@ export class V1Case implements IV1Case {
                 this.arrangements = [] as any;
                 for (let item of _data["arrangements"])
                     this.arrangements!.push(Arrangement.fromJS(item));
+            }
+            if (Array.isArray(_data["staffAssignments"])) {
+                this.staffAssignments = [] as any;
+                for (let item of _data["staffAssignments"])
+                    this.staffAssignments!.push(StaffAssignment.fromJS(item));
             }
             this.comments = _data["comments"];
             if (Array.isArray(_data["linkedV1ReferralIds"])) {
@@ -5973,6 +6452,11 @@ export class V1Case implements IV1Case {
             for (let item of this.arrangements)
                 data["arrangements"].push(item.toJSON());
         }
+        if (Array.isArray(this.staffAssignments)) {
+            data["staffAssignments"] = [];
+            for (let item of this.staffAssignments)
+                data["staffAssignments"].push(item.toJSON());
+        }
         data["comments"] = this.comments;
         if (Array.isArray(this.linkedV1ReferralIds)) {
             data["linkedV1ReferralIds"] = [];
@@ -5994,6 +6478,7 @@ export interface IV1Case {
     completedCustomFields: CompletedCustomFieldInfo[];
     missingCustomFields: string[];
     arrangements: Arrangement[];
+    staffAssignments: StaffAssignment[];
     comments?: string | undefined;
     linkedV1ReferralIds: string[];
 }
@@ -6585,6 +7070,54 @@ export interface IChildLocationHistoryEntry {
     childLocationReceivingAdultId: string;
     plan: ChildLocationPlan;
     noteId?: string | undefined;
+}
+
+export class StaffAssignment implements IStaffAssignment {
+    personId!: string;
+    assignmentRole!: string;
+    assignedAtUtc!: Date;
+    assignedByUserId!: string;
+
+    constructor(data?: IStaffAssignment) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+            this.assignedAtUtc = _data["assignedAtUtc"] ? new Date(_data["assignedAtUtc"].toString()) : <any>undefined;
+            this.assignedByUserId = _data["assignedByUserId"];
+        }
+    }
+
+    static fromJS(data: any): StaffAssignment {
+        data = typeof data === 'object' ? data : {};
+        let result = new StaffAssignment();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        data["assignedAtUtc"] = this.assignedAtUtc ? this.assignedAtUtc.toISOString() : <any>undefined;
+        data["assignedByUserId"] = this.assignedByUserId;
+        return data;
+    }
+}
+
+export interface IStaffAssignment {
+    personId: string;
+    assignmentRole: string;
+    assignedAtUtc: Date;
+    assignedByUserId: string;
 }
 
 export class VolunteerFamilyInfo implements IVolunteerFamilyInfo {
@@ -7953,12 +8486,12 @@ export enum NoteStatus {
 }
 
 export class ReferralRecordsAggregate extends RecordsAggregate implements IReferralRecordsAggregate {
-    referral!: V1Referral;
+    referral!: V1ReferralInfo;
 
     constructor(data?: IReferralRecordsAggregate) {
         super(data);
         if (!data) {
-            this.referral = new V1Referral();
+            this.referral = new V1ReferralInfo();
         }
         this._discriminator = "ReferralRecordsAggregate";
     }
@@ -7966,7 +8499,7 @@ export class ReferralRecordsAggregate extends RecordsAggregate implements IRefer
     init(_data?: any) {
         super.init(_data);
         if (_data) {
-            this.referral = _data["referral"] ? V1Referral.fromJS(_data["referral"]) : new V1Referral();
+            this.referral = _data["referral"] ? V1ReferralInfo.fromJS(_data["referral"]) : new V1ReferralInfo();
         }
     }
 
@@ -7986,7 +8519,59 @@ export class ReferralRecordsAggregate extends RecordsAggregate implements IRefer
 }
 
 export interface IReferralRecordsAggregate extends IRecordsAggregate {
+    referral: V1ReferralInfo;
+}
+
+export class V1ReferralInfo implements IV1ReferralInfo {
+    referral!: V1Referral;
+    userPermissions!: Permission[];
+
+    constructor(data?: IV1ReferralInfo) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        if (!data) {
+            this.referral = new V1Referral();
+            this.userPermissions = [];
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.referral = _data["referral"] ? V1Referral.fromJS(_data["referral"]) : new V1Referral();
+            if (Array.isArray(_data["userPermissions"])) {
+                this.userPermissions = [] as any;
+                for (let item of _data["userPermissions"])
+                    this.userPermissions!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): V1ReferralInfo {
+        data = typeof data === 'object' ? data : {};
+        let result = new V1ReferralInfo();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["referral"] = this.referral ? this.referral.toJSON() : <any>undefined;
+        if (Array.isArray(this.userPermissions)) {
+            data["userPermissions"] = [];
+            for (let item of this.userPermissions)
+                data["userPermissions"].push(item);
+        }
+        return data;
+    }
+}
+
+export interface IV1ReferralInfo {
     referral: V1Referral;
+    userPermissions: Permission[];
 }
 
 export class V1Referral implements IV1Referral {
@@ -8004,6 +8589,7 @@ export class V1Referral implements IV1Referral {
     exemptedRequirements!: ExemptedRequirementInfo[];
     uploadedDocuments!: UploadedDocumentInfo[];
     deletedDocuments!: string[];
+    staffAssignments!: StaffAssignment[];
     history!: Activity[];
     notes!: V1ReferralNoteEntry[];
     missingIntakeRequirements!: RequirementDefinition[];
@@ -8021,6 +8607,7 @@ export class V1Referral implements IV1Referral {
             this.exemptedRequirements = [];
             this.uploadedDocuments = [];
             this.deletedDocuments = [];
+            this.staffAssignments = [];
             this.history = [];
             this.notes = [];
             this.missingIntakeRequirements = [];
@@ -8064,6 +8651,11 @@ export class V1Referral implements IV1Referral {
                 this.deletedDocuments = [] as any;
                 for (let item of _data["deletedDocuments"])
                     this.deletedDocuments!.push(item);
+            }
+            if (Array.isArray(_data["staffAssignments"])) {
+                this.staffAssignments = [] as any;
+                for (let item of _data["staffAssignments"])
+                    this.staffAssignments!.push(StaffAssignment.fromJS(item));
             }
             if (Array.isArray(_data["history"])) {
                 this.history = [] as any;
@@ -8128,6 +8720,11 @@ export class V1Referral implements IV1Referral {
             for (let item of this.deletedDocuments)
                 data["deletedDocuments"].push(item);
         }
+        if (Array.isArray(this.staffAssignments)) {
+            data["staffAssignments"] = [];
+            for (let item of this.staffAssignments)
+                data["staffAssignments"].push(item.toJSON());
+        }
         if (Array.isArray(this.history)) {
             data["history"] = [];
             for (let item of this.history)
@@ -8162,6 +8759,7 @@ export interface IV1Referral {
     exemptedRequirements: ExemptedRequirementInfo[];
     uploadedDocuments: UploadedDocumentInfo[];
     deletedDocuments: string[];
+    staffAssignments: StaffAssignment[];
     history: Activity[];
     notes: V1ReferralNoteEntry[];
     missingIntakeRequirements: RequirementDefinition[];
@@ -13227,6 +13825,11 @@ export abstract class V1CaseCommand implements IV1CaseCommand {
 
     static fromJS(data: any): V1CaseCommand {
         data = typeof data === 'object' ? data : {};
+        if (data["discriminator"] === "AssignStaffToV1Case") {
+            let result = new AssignStaffToV1Case();
+            result.init(data);
+            return result;
+        }
         if (data["discriminator"] === "CloseReferral") {
             let result = new CloseReferral();
             result.init(data);
@@ -13262,6 +13865,11 @@ export abstract class V1CaseCommand implements IV1CaseCommand {
             result.init(data);
             return result;
         }
+        if (data["discriminator"] === "UnassignStaffFromV1Case") {
+            let result = new UnassignStaffFromV1Case();
+            result.init(data);
+            return result;
+        }
         if (data["discriminator"] === "UnexemptReferralRequirement") {
             let result = new UnexemptReferralRequirement();
             result.init(data);
@@ -13292,6 +13900,44 @@ export abstract class V1CaseCommand implements IV1CaseCommand {
 export interface IV1CaseCommand {
     familyId: string;
     referralId: string;
+}
+
+export class AssignStaffToV1Case extends V1CaseCommand implements IAssignStaffToV1Case {
+    personId!: string;
+    assignmentRole!: string;
+
+    constructor(data?: IAssignStaffToV1Case) {
+        super(data);
+        this._discriminator = "AssignStaffToV1Case";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+        }
+    }
+
+    static fromJS(data: any): AssignStaffToV1Case {
+        data = typeof data === 'object' ? data : {};
+        let result = new AssignStaffToV1Case();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IAssignStaffToV1Case extends IV1CaseCommand {
+    personId: string;
+    assignmentRole: string;
 }
 
 export class CloseReferral extends V1CaseCommand implements ICloseReferral {
@@ -13562,6 +14208,44 @@ export class ReopenReferral extends V1CaseCommand implements IReopenReferral {
 
 export interface IReopenReferral extends IV1CaseCommand {
     reopenedAtUtc: Date;
+}
+
+export class UnassignStaffFromV1Case extends V1CaseCommand implements IUnassignStaffFromV1Case {
+    personId!: string;
+    assignmentRole!: string;
+
+    constructor(data?: IUnassignStaffFromV1Case) {
+        super(data);
+        this._discriminator = "UnassignStaffFromV1Case";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+        }
+    }
+
+    static fromJS(data: any): UnassignStaffFromV1Case {
+        data = typeof data === 'object' ? data : {};
+        let result = new UnassignStaffFromV1Case();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IUnassignStaffFromV1Case extends IV1CaseCommand {
+    personId: string;
+    assignmentRole: string;
 }
 
 export class UnexemptReferralRequirement extends V1CaseCommand implements IUnexemptReferralRequirement {
@@ -14029,6 +14713,11 @@ export abstract class V1ReferralCommand implements IV1ReferralCommand {
             result.init(data);
             return result;
         }
+        if (data["discriminator"] === "AssignStaffToV1Referral") {
+            let result = new AssignStaffToV1Referral();
+            result.init(data);
+            return result;
+        }
         if (data["discriminator"] === "CloseV1Referral") {
             let result = new CloseV1Referral();
             result.init(data);
@@ -14061,6 +14750,11 @@ export abstract class V1ReferralCommand implements IV1ReferralCommand {
         }
         if (data["discriminator"] === "ReopenV1Referral") {
             let result = new ReopenV1Referral();
+            result.init(data);
+            return result;
+        }
+        if (data["discriminator"] === "UnassignStaffFromV1Referral") {
+            let result = new UnassignStaffFromV1Referral();
             result.init(data);
             return result;
         }
@@ -14136,6 +14830,44 @@ export class AcceptV1Referral extends V1ReferralCommand implements IAcceptV1Refe
 
 export interface IAcceptV1Referral extends IV1ReferralCommand {
     acceptedAtUtc: Date;
+}
+
+export class AssignStaffToV1Referral extends V1ReferralCommand implements IAssignStaffToV1Referral {
+    personId!: string;
+    assignmentRole!: string;
+
+    constructor(data?: IAssignStaffToV1Referral) {
+        super(data);
+        this._discriminator = "AssignStaffToV1Referral";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+        }
+    }
+
+    static fromJS(data: any): AssignStaffToV1Referral {
+        data = typeof data === 'object' ? data : {};
+        let result = new AssignStaffToV1Referral();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IAssignStaffToV1Referral extends IV1ReferralCommand {
+    personId: string;
+    assignmentRole: string;
 }
 
 export class CloseV1Referral extends V1ReferralCommand implements ICloseV1Referral {
@@ -14418,6 +15150,44 @@ export class ReopenV1Referral extends V1ReferralCommand implements IReopenV1Refe
 
 export interface IReopenV1Referral extends IV1ReferralCommand {
     reopenedAtUtc: Date;
+}
+
+export class UnassignStaffFromV1Referral extends V1ReferralCommand implements IUnassignStaffFromV1Referral {
+    personId!: string;
+    assignmentRole!: string;
+
+    constructor(data?: IUnassignStaffFromV1Referral) {
+        super(data);
+        this._discriminator = "UnassignStaffFromV1Referral";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.personId = _data["personId"];
+            this.assignmentRole = _data["assignmentRole"];
+        }
+    }
+
+    static fromJS(data: any): UnassignStaffFromV1Referral {
+        data = typeof data === 'object' ? data : {};
+        let result = new UnassignStaffFromV1Referral();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["personId"] = this.personId;
+        data["assignmentRole"] = this.assignmentRole;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IUnassignStaffFromV1Referral extends IV1ReferralCommand {
+    personId: string;
+    assignmentRole: string;
 }
 
 export class UnexemptReferralRequirement2 extends V1ReferralCommand implements IUnexemptReferralRequirement2 {

--- a/src/caretogether-pwa/src/Model/Data.tsx
+++ b/src/caretogether-pwa/src/Model/Data.tsx
@@ -256,6 +256,9 @@ export const visibleReferralsQuery = selector({
 
     return visibleAggregates
       .filter((aggregate) => aggregate instanceof ReferralRecordsAggregate)
-      .map((aggregate) => (aggregate as ReferralRecordsAggregate).referral!);
+      .map(
+        (aggregate) =>
+          (aggregate as ReferralRecordsAggregate).referral!.referral!
+      );
   },
 });

--- a/swagger.json
+++ b/swagger.json
@@ -1521,6 +1521,8 @@
             "AllVolunteerFamiliesPermissionContext": "#/components/schemas/AllVolunteerFamiliesPermissionContext",
             "AssignedFunctionsInReferralCoAssigneeFamiliesPermissionContext": "#/components/schemas/AssignedFunctionsInReferralCoAssigneeFamiliesPermissionContext",
             "AssignedFunctionsInReferralPartneringFamilyPermissionContext": "#/components/schemas/AssignedFunctionsInReferralPartneringFamilyPermissionContext",
+            "AssignedStaffInV1CasePermissionContext": "#/components/schemas/AssignedStaffInV1CasePermissionContext",
+            "AssignedStaffInV1ReferralPermissionContext": "#/components/schemas/AssignedStaffInV1ReferralPermissionContext",
             "CommunityCoMemberFamiliesAssignedFunctionsInReferralCoAssignedFamiliesPermissionContext": "#/components/schemas/CommunityCoMemberFamiliesAssignedFunctionsInReferralCoAssignedFamiliesPermissionContext",
             "CommunityCoMemberFamiliesAssignedFunctionsInReferralPartneringFamilyPermissionContext": "#/components/schemas/CommunityCoMemberFamiliesAssignedFunctionsInReferralPartneringFamilyPermissionContext",
             "CommunityCoMemberFamiliesPermissionContext": "#/components/schemas/CommunityCoMemberFamiliesPermissionContext",
@@ -1608,6 +1610,54 @@
                 "nullable": true
               },
               "whenOwnFunctionIsIn": {
+                "type": "array",
+                "nullable": true,
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "AssignedStaffInV1CasePermissionContext": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PermissionContext"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "whenCaseIsOpen": {
+                "type": "boolean",
+                "nullable": true
+              },
+              "whenAssignmentRoleIsIn": {
+                "type": "array",
+                "nullable": true,
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "AssignedStaffInV1ReferralPermissionContext": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PermissionContext"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "whenReferralIsOpen": {
+                "type": "boolean",
+                "nullable": true
+              },
+              "whenAssignmentRoleIsIn": {
                 "type": "array",
                 "nullable": true,
                 "items": {
@@ -1794,6 +1844,8 @@
           "ViewV1Referral",
           "EditV1ReferralRequirementCompletion",
           "EditV1ReferralRequirementExemption",
+          "ViewV1ReferralStaffAssignments",
+          "EditV1ReferralStaffAssignments",
           "CreateV1Case",
           "EditV1Case",
           "CloseV1Case",
@@ -1803,6 +1855,8 @@
           "EditV1CaseRequirementCompletion",
           "EditV1CaseRequirementExemption",
           "ViewV1CaseHistory",
+          "ViewV1CaseStaffAssignments",
+          "EditV1CaseStaffAssignments",
           "CreateArrangement",
           "EditArrangement",
           "ViewAssignments",
@@ -1872,6 +1926,8 @@
           264,
           265,
           266,
+          267,
+          268,
           300,
           301,
           302,
@@ -1881,6 +1937,8 @@
           306,
           307,
           308,
+          309,
+          310,
           350,
           351,
           352,
@@ -1928,7 +1986,8 @@
           "actionDefinitions",
           "customFamilyFields",
           "referralPolicy",
-          "volunteerPolicy"
+          "volunteerPolicy",
+          "v1ReferralPolicy"
         ],
         "properties": {
           "actionDefinitions": {
@@ -1948,6 +2007,9 @@
           },
           "volunteerPolicy": {
             "$ref": "#/components/schemas/VolunteerPolicy"
+          },
+          "v1ReferralPolicy": {
+            "$ref": "#/components/schemas/V1ReferralPolicy"
           }
         }
       },
@@ -2084,7 +2146,8 @@
           "intakeRequirements_PRE_MIGRATION",
           "requiredIntakeActionNames",
           "customFields",
-          "arrangementPolicies"
+          "arrangementPolicies",
+          "staffAssignmentPolicies"
         ],
         "properties": {
           "intakeRequirements_PRE_MIGRATION": {
@@ -2123,6 +2186,12 @@
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/RequirementDefinition"
+            }
+          },
+          "staffAssignmentPolicies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StaffAssignmentPolicy"
             }
           }
         }
@@ -2593,6 +2662,59 @@
           }
         }
       },
+      "StaffAssignmentPolicy": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "assignmentRole",
+          "eligibility"
+        ],
+        "properties": {
+          "assignmentRole": {
+            "type": "string"
+          },
+          "eligibility": {
+            "$ref": "#/components/schemas/StaffAssignmentEligibility"
+          }
+        }
+      },
+      "StaffAssignmentEligibility": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "eligibleLocationRoles",
+          "eligibleIndividualVolunteerRoles",
+          "eligibleVolunteerFamilyRoles",
+          "eligiblePeople"
+        ],
+        "properties": {
+          "eligibleLocationRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "eligibleIndividualVolunteerRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "eligibleVolunteerFamilyRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "eligiblePeople": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "guid"
+            }
+          }
+        }
+      },
       "VolunteerPolicy": {
         "type": "object",
         "additionalProperties": false,
@@ -2764,6 +2886,21 @@
           1,
           2
         ]
+      },
+      "V1ReferralPolicy": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "staffAssignmentPolicies"
+        ],
+        "properties": {
+          "staffAssignmentPolicies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StaffAssignmentPolicy"
+            }
+          }
+        }
       },
       "CurrentFeatureFlags": {
         "type": "object",
@@ -3504,10 +3641,14 @@
             "ChildLocationChanged": "#/components/schemas/ChildLocationChanged",
             "ReferralOpened": "#/components/schemas/ReferralOpened",
             "ReferralRequirementCompleted": "#/components/schemas/ReferralRequirementCompleted",
+            "V1CaseStaffAssigned": "#/components/schemas/V1CaseStaffAssigned",
+            "V1CaseStaffUnassigned": "#/components/schemas/V1CaseStaffUnassigned",
             "V1ReferralAccepted": "#/components/schemas/V1ReferralAccepted",
             "V1ReferralClosed": "#/components/schemas/V1ReferralClosed",
             "V1ReferralOpened": "#/components/schemas/V1ReferralOpened",
-            "V1ReferralRequirementCompleted": "#/components/schemas/V1ReferralRequirementCompleted"
+            "V1ReferralRequirementCompleted": "#/components/schemas/V1ReferralRequirementCompleted",
+            "V1ReferralStaffAssigned": "#/components/schemas/V1ReferralStaffAssigned",
+            "V1ReferralStaffUnassigned": "#/components/schemas/V1ReferralStaffUnassigned"
           }
         },
         "x-abstract": true,
@@ -3672,6 +3813,54 @@
           }
         ]
       },
+      "V1CaseStaffAssigned": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Activity"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "personId",
+              "assignmentRole"
+            ],
+            "properties": {
+              "personId": {
+                "type": "string",
+                "format": "guid"
+              },
+              "assignmentRole": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "V1CaseStaffUnassigned": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Activity"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "personId",
+              "assignmentRole"
+            ],
+            "properties": {
+              "personId": {
+                "type": "string",
+                "format": "guid"
+              },
+              "assignmentRole": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
       "V1ReferralAccepted": {
         "allOf": [
           {
@@ -3760,6 +3949,54 @@
           }
         ]
       },
+      "V1ReferralStaffAssigned": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Activity"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "personId",
+              "assignmentRole"
+            ],
+            "properties": {
+              "personId": {
+                "type": "string",
+                "format": "guid"
+              },
+              "assignmentRole": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "V1ReferralStaffUnassigned": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Activity"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "personId",
+              "assignmentRole"
+            ],
+            "properties": {
+              "personId": {
+                "type": "string",
+                "format": "guid"
+              },
+              "assignmentRole": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
       "UserInfo": {
         "type": "object",
         "additionalProperties": false,
@@ -3827,6 +4064,7 @@
           "completedCustomFields",
           "missingCustomFields",
           "arrangements",
+          "staffAssignments",
           "linkedV1ReferralIds"
         ],
         "properties": {
@@ -3885,6 +4123,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Arrangement"
+            }
+          },
+          "staffAssignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StaffAssignment"
             }
           },
           "comments": {
@@ -4288,6 +4532,33 @@
             "type": "string",
             "format": "guid",
             "nullable": true
+          }
+        }
+      },
+      "StaffAssignment": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "personId",
+          "assignmentRole",
+          "assignedAtUtc",
+          "assignedByUserId"
+        ],
+        "properties": {
+          "personId": {
+            "type": "string",
+            "format": "guid"
+          },
+          "assignmentRole": {
+            "type": "string"
+          },
+          "assignedAtUtc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "assignedByUserId": {
+            "type": "string",
+            "format": "guid"
           }
         }
       },
@@ -5058,11 +5329,30 @@
             ],
             "properties": {
               "referral": {
-                "$ref": "#/components/schemas/V1Referral"
+                "$ref": "#/components/schemas/V1ReferralInfo"
               }
             }
           }
         ]
+      },
+      "V1ReferralInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "referral",
+          "userPermissions"
+        ],
+        "properties": {
+          "referral": {
+            "$ref": "#/components/schemas/V1Referral"
+          },
+          "userPermissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Permission"
+            }
+          }
+        }
       },
       "V1Referral": {
         "type": "object",
@@ -5077,6 +5367,7 @@
           "exemptedRequirements",
           "uploadedDocuments",
           "deletedDocuments",
+          "staffAssignments",
           "history",
           "notes",
           "missingIntakeRequirements"
@@ -5148,6 +5439,12 @@
             "items": {
               "type": "string",
               "format": "guid"
+            }
+          },
+          "staffAssignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StaffAssignment"
             }
           },
           "history": {
@@ -8173,6 +8470,7 @@
         "discriminator": {
           "propertyName": "discriminator",
           "mapping": {
+            "AssignStaffToV1Case": "#/components/schemas/AssignStaffToV1Case",
             "CloseReferral": "#/components/schemas/CloseReferral",
             "CompleteReferralRequirement": "#/components/schemas/CompleteReferralRequirement",
             "CreateReferral": "#/components/schemas/CreateReferral",
@@ -8180,6 +8478,7 @@
             "LinkReferralToCase": "#/components/schemas/LinkReferralToCase",
             "MarkReferralRequirementIncomplete": "#/components/schemas/MarkReferralRequirementIncomplete",
             "ReopenReferral": "#/components/schemas/ReopenReferral",
+            "UnassignStaffFromV1Case": "#/components/schemas/UnassignStaffFromV1Case",
             "UnexemptReferralRequirement": "#/components/schemas/UnexemptReferralRequirement",
             "UpdateCustomReferralField": "#/components/schemas/UpdateCustomReferralField",
             "UpdateReferralComments": "#/components/schemas/UpdateReferralComments"
@@ -8205,6 +8504,30 @@
             "type": "string"
           }
         }
+      },
+      "AssignStaffToV1Case": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/V1CaseCommand"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "personId",
+              "assignmentRole"
+            ],
+            "properties": {
+              "personId": {
+                "type": "string",
+                "format": "guid"
+              },
+              "assignmentRole": {
+                "type": "string"
+              }
+            }
+          }
+        ]
       },
       "CloseReferral": {
         "allOf": [
@@ -8376,6 +8699,30 @@
               "reopenedAtUtc": {
                 "type": "string",
                 "format": "date-time"
+              }
+            }
+          }
+        ]
+      },
+      "UnassignStaffFromV1Case": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/V1CaseCommand"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "personId",
+              "assignmentRole"
+            ],
+            "properties": {
+              "personId": {
+                "type": "string",
+                "format": "guid"
+              },
+              "assignmentRole": {
+                "type": "string"
               }
             }
           }
@@ -8633,6 +8980,7 @@
           "propertyName": "discriminator",
           "mapping": {
             "AcceptV1Referral": "#/components/schemas/AcceptV1Referral",
+            "AssignStaffToV1Referral": "#/components/schemas/AssignStaffToV1Referral",
             "CloseV1Referral": "#/components/schemas/CloseV1Referral",
             "CompleteReferralRequirement": "#/components/schemas/CompleteReferralRequirement2",
             "CreateV1Referral": "#/components/schemas/CreateV1Referral",
@@ -8640,6 +8988,7 @@
             "ExemptReferralRequirement": "#/components/schemas/ExemptReferralRequirement2",
             "MarkReferralRequirementIncomplete": "#/components/schemas/MarkReferralRequirementIncomplete2",
             "ReopenV1Referral": "#/components/schemas/ReopenV1Referral",
+            "UnassignStaffFromV1Referral": "#/components/schemas/UnassignStaffFromV1Referral",
             "UnexemptReferralRequirement": "#/components/schemas/UnexemptReferralRequirement2",
             "UpdateCustomV1ReferralField": "#/components/schemas/UpdateCustomV1ReferralField",
             "UpdateV1ReferralDetails": "#/components/schemas/UpdateV1ReferralDetails",
@@ -8678,6 +9027,30 @@
               "acceptedAtUtc": {
                 "type": "string",
                 "format": "date-time"
+              }
+            }
+          }
+        ]
+      },
+      "AssignStaffToV1Referral": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/V1ReferralCommand"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "personId",
+              "assignmentRole"
+            ],
+            "properties": {
+              "personId": {
+                "type": "string",
+                "format": "guid"
+              },
+              "assignmentRole": {
+                "type": "string"
               }
             }
           }
@@ -8866,6 +9239,30 @@
               "reopenedAtUtc": {
                 "type": "string",
                 "format": "date-time"
+              }
+            }
+          }
+        ]
+      },
+      "UnassignStaffFromV1Referral": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/V1ReferralCommand"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "personId",
+              "assignmentRole"
+            ],
+            "properties": {
+              "personId": {
+                "type": "string",
+                "format": "guid"
+              },
+              "assignmentRole": {
+                "type": "string"
               }
             }
           }

--- a/test/CareTogether.Core.Test/AuthorizationEngineTests/AuthorizeUserAccess.cs
+++ b/test/CareTogether.Core.Test/AuthorizationEngineTests/AuthorizeUserAccess.cs
@@ -12,6 +12,7 @@ using CareTogether.Resources.Goals;
 using CareTogether.Resources.Notes;
 using CareTogether.Resources.Policies;
 using CareTogether.Resources.V1Cases;
+using CareTogether.Resources.V1Referrals;
 using CareTogether.TestData;
 using CareTogether.Utilities.FileStore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -60,6 +61,7 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
             var directoryEventLog = new MemoryEventLog<DirectoryEvent>();
             var goalsEventLog = new MemoryEventLog<GoalCommandExecutedEvent>();
             var v1CasesEventLog = new MemoryEventLog<V1CaseEvent>();
+            var v1ReferralsEventLog = new MemoryEventLog<V1ReferralEvent>();
             var approvalsEventLog = new MemoryEventLog<ApprovalEvent>();
             var notesEventLog = new MemoryEventLog<NotesEvent>();
             var communitiesEventLog = new MemoryEventLog<CommunityCommandExecutedEvent>();
@@ -92,6 +94,10 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
                 personAccessEventLog
             );
             var v1CasesResource = new V1CasesResource(v1CasesEventLog);
+            var v1ReferralsResource = new V1ReferralsResource(
+                v1ReferralsEventLog,
+                Mock.Of<IFileStore>()
+            );
             var approvalsResource = new ApprovalsResource(approvalsEventLog);
             var communitiesResource = new CommunitiesResource(
                 communitiesEventLog,
@@ -102,6 +108,7 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
                 policiesResource,
                 directoryResource,
                 v1CasesResource,
+                v1ReferralsResource,
                 approvalsResource,
                 communitiesResource
             );

--- a/test/CareTogether.Core.Test/AuthorizationEngineTests/AuthorizeV1ReferralCommandAsync.cs
+++ b/test/CareTogether.Core.Test/AuthorizationEngineTests/AuthorizeV1ReferralCommandAsync.cs
@@ -80,6 +80,16 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
                     ReferralId,
                     "Intake Form"
                 ),
+                nameof(AssignStaffToV1Referral) => new AssignStaffToV1Referral(
+                    ReferralId,
+                    Guid.NewGuid(),
+                    "Intake Coordinator"
+                ),
+                nameof(UnassignStaffFromV1Referral) => new UnassignStaffFromV1Referral(
+                    ReferralId,
+                    Guid.NewGuid(),
+                    "Intake Coordinator"
+                ),
                 _ => throw new ArgumentOutOfRangeException(nameof(commandName), commandName, null),
             };
 
@@ -143,6 +153,25 @@ namespace CareTogether.Core.Test.AuthorizationEngineTests
             );
 
             Assert.IsFalse(response);
+        }
+
+        [DataTestMethod]
+        [DataRow(nameof(AssignStaffToV1Referral))]
+        [DataRow(nameof(UnassignStaffFromV1Referral))]
+        public async Task ReferralStaffAssignmentCommandsRequireReferralStaffAssignmentEditPermission(
+            string commandName
+        )
+        {
+            var dut = CreateAuthorizationEngine(Permission.EditV1ReferralStaffAssignments);
+
+            var response = await dut.AuthorizeV1ReferralCommandAsync(
+                OrganizationId,
+                LocationId,
+                UserContext(),
+                CommandFor(commandName)
+            );
+
+            Assert.IsTrue(response);
         }
     }
 }

--- a/test/CareTogether.Core.Test/AuthorizationEngineTests/StaffAssignmentPermissionContextTests.cs
+++ b/test/CareTogether.Core.Test/AuthorizationEngineTests/StaffAssignmentPermissionContextTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Immutable;
+using CareTogether.Engines.Authorization;
+using CareTogether.Resources;
+using CareTogether.Resources.Communities;
+using CareTogether.Resources.Directory;
+using CareTogether.Resources.Policies;
+using CareTogether.Resources.V1Cases;
+using CareTogether.Resources.V1Referrals;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CareTogether.Core.Test.AuthorizationEngineTests
+{
+    [TestClass]
+    public sealed class StaffAssignmentPermissionContextTests
+    {
+        private static readonly Guid PersonId = Guid.Parse(
+            "11111111-1111-1111-1111-111111111111"
+        );
+        private static readonly Guid ReferralId = Guid.Parse(
+            "22222222-2222-2222-2222-222222222222"
+        );
+        private static readonly Guid FamilyId = Guid.Parse(
+            "33333333-3333-3333-3333-333333333333"
+        );
+
+        [TestMethod]
+        public void AssignedStaffInV1ReferralMatchesOpenReferralAndRole()
+        {
+            var permissionSet = new ContextualPermissionSet(
+                new AssignedStaffInV1ReferralPermissionContext(
+                    WhenReferralIsOpen: true,
+                    WhenAssignmentRoleIsIn: ["Intake Coordinator"]
+                ),
+                [Permission.ViewV1Referral]
+            );
+
+            var result = UserAccessCalculation.IsPermissionSetApplicable(
+                permissionSet,
+                new V1ReferralAuthorizationContext(ReferralId),
+                userFamily: null,
+                targetFamily: null,
+                targetFamilyIsVolunteerFamily: false,
+                userFamilyV1Cases: [],
+                targetFamilyV1Cases: [],
+                assignedV1Cases: [],
+                targetFamilyAssignedV1Cases: [],
+                targetV1Referral: Referral(V1ReferralStatus.Open),
+                userPersonId: PersonId,
+                userFamilyCommunities: [],
+                targetFamilyCommunities: [],
+                userCommunityRoleAssignments: [],
+                communities: []
+            );
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void AssignedStaffInV1ReferralOpenFilterRequiresExactlyOpenStatus()
+        {
+            var permissionSet = new ContextualPermissionSet(
+                new AssignedStaffInV1ReferralPermissionContext(
+                    WhenReferralIsOpen: true,
+                    WhenAssignmentRoleIsIn: null
+                ),
+                [Permission.ViewV1Referral]
+            );
+
+            var result = UserAccessCalculation.IsPermissionSetApplicable(
+                permissionSet,
+                new V1ReferralAuthorizationContext(ReferralId),
+                userFamily: null,
+                targetFamily: null,
+                targetFamilyIsVolunteerFamily: false,
+                userFamilyV1Cases: [],
+                targetFamilyV1Cases: [],
+                assignedV1Cases: [],
+                targetFamilyAssignedV1Cases: [],
+                targetV1Referral: Referral(V1ReferralStatus.Accepted),
+                userPersonId: PersonId,
+                userFamilyCommunities: [],
+                targetFamilyCommunities: [],
+                userCommunityRoleAssignments: [],
+                communities: []
+            );
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void AssignedStaffInV1CaseMatchesOpenCaseAndRoleThroughFamilyContext()
+        {
+            var permissionSet = new ContextualPermissionSet(
+                new AssignedStaffInV1CasePermissionContext(
+                    WhenCaseIsOpen: true,
+                    WhenAssignmentRoleIsIn: ["Case Manager"]
+                ),
+                [Permission.ViewV1CaseProgress]
+            );
+
+            var result = UserAccessCalculation.IsPermissionSetApplicable(
+                permissionSet,
+                new FamilyAuthorizationContext(FamilyId),
+                userFamily: null,
+                targetFamily: Family(),
+                targetFamilyIsVolunteerFamily: false,
+                userFamilyV1Cases: [],
+                targetFamilyV1Cases: [V1Case(closedAtUtc: null)],
+                assignedV1Cases: [],
+                targetFamilyAssignedV1Cases: [],
+                targetV1Referral: null,
+                userPersonId: PersonId,
+                userFamilyCommunities: [],
+                targetFamilyCommunities: [],
+                userCommunityRoleAssignments: [],
+                communities: []
+            );
+
+            Assert.IsTrue(result);
+        }
+
+        private static V1Referral Referral(V1ReferralStatus status) =>
+            new(
+                ReferralId,
+                FamilyId,
+                DateTime.UtcNow,
+                "Referral",
+                status,
+                Comment: null,
+                AcceptedAtUtc: null,
+                ClosedAtUtc: null,
+                CloseReason: null,
+                CompletedCustomFields: ImmutableDictionary<
+                    string,
+                    CompletedCustomFieldInfo
+                >.Empty,
+                CompletedRequirements: [],
+                ExemptedRequirements: [],
+                UploadedDocuments: [],
+                DeletedDocuments: [],
+                StaffAssignments:
+                [
+                    new StaffAssignment(PersonId, "Intake Coordinator", DateTime.UtcNow, PersonId),
+                ],
+                History: [],
+                Notes: []
+            );
+
+        private static V1CaseEntry V1Case(DateTime? closedAtUtc) =>
+            new(
+                ReferralId,
+                FamilyId,
+                LinkedV1ReferralIds: [],
+                OpenedAtUtc: DateTime.UtcNow,
+                ClosedAtUtc: closedAtUtc,
+                CloseReason: null,
+                CompletedRequirements: [],
+                ExemptedRequirements: [],
+                CompletedCustomFields: ImmutableDictionary<string, CompletedCustomFieldInfo>.Empty,
+                Arrangements: ImmutableDictionary<Guid, ArrangementEntry>.Empty,
+                StaffAssignments:
+                [
+                    new StaffAssignment(PersonId, "Case Manager", DateTime.UtcNow, PersonId),
+                ],
+                History: [],
+                Comments: null
+            );
+
+        private static Family Family() =>
+            new(
+                FamilyId,
+                Active: true,
+                PrimaryFamilyContactPersonId: PersonId,
+                Adults: [],
+                Children: [],
+                CustodialRelationships: [],
+                UploadedDocuments: [],
+                DeletedDocuments: [],
+                CompletedCustomFields: [],
+                History: [],
+                IsTestFamily: false
+            );
+    }
+}

--- a/test/CareTogether.Core.Test/StaffAssignmentResourceTests.cs
+++ b/test/CareTogether.Core.Test/StaffAssignmentResourceTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Linq;
+using CareTogether.Resources.V1Cases;
+using CareTogether.Resources.V1Referrals;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CareTogether.Core.Test
+{
+    [TestClass]
+    public sealed class StaffAssignmentResourceTests
+    {
+        private static readonly Guid UserId = Guid.Parse(
+            "11111111-1111-1111-1111-111111111111"
+        );
+        private static readonly Guid FamilyId = Guid.Parse(
+            "22222222-2222-2222-2222-222222222222"
+        );
+        private static readonly Guid RecordId = Guid.Parse(
+            "33333333-3333-3333-3333-333333333333"
+        );
+        private static readonly Guid PersonId = Guid.Parse(
+            "44444444-4444-4444-4444-444444444444"
+        );
+
+        [TestMethod]
+        public void V1ReferralStaffAssignmentsAreActiveStateAndIdempotent()
+        {
+            var model = new V1ReferralModel();
+            Commit(
+                model.ExecuteReferralCommand(
+                    new CreateV1Referral(RecordId, null, DateTime.UtcNow, "Referral", null),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+
+            Commit(
+                model.ExecuteReferralCommand(
+                    new AssignStaffToV1Referral(RecordId, PersonId, "Intake Coordinator"),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+            Commit(
+                model.ExecuteReferralCommand(
+                    new AssignStaffToV1Referral(RecordId, PersonId, "Intake Coordinator"),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+
+            var referral = model.GetReferral(RecordId)!;
+            Assert.AreEqual(1, referral.StaffAssignments.Count);
+            Assert.AreEqual(
+                1,
+                referral.History.OfType<V1ReferralStaffAssigned>().Count()
+            );
+
+            Commit(
+                model.ExecuteReferralCommand(
+                    new UnassignStaffFromV1Referral(RecordId, PersonId, "Intake Coordinator"),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+            Commit(
+                model.ExecuteReferralCommand(
+                    new UnassignStaffFromV1Referral(RecordId, PersonId, "Intake Coordinator"),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+
+            referral = model.GetReferral(RecordId)!;
+            Assert.AreEqual(0, referral.StaffAssignments.Count);
+            Assert.AreEqual(
+                1,
+                referral.History.OfType<V1ReferralStaffUnassigned>().Count()
+            );
+        }
+
+        [TestMethod]
+        public void V1CaseStaffAssignmentsAreActiveStateAndIdempotent()
+        {
+            var model = new V1CaseModel();
+            Commit(
+                model.ExecuteV1CaseCommand(
+                    new CreateReferral(FamilyId, RecordId, DateTime.UtcNow),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+
+            Commit(
+                model.ExecuteV1CaseCommand(
+                    new AssignStaffToV1Case(FamilyId, RecordId, PersonId, "Case Manager"),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+            Commit(
+                model.ExecuteV1CaseCommand(
+                    new AssignStaffToV1Case(FamilyId, RecordId, PersonId, "Case Manager"),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+
+            var v1Case = model.GetV1CaseEntry(RecordId);
+            Assert.AreEqual(1, v1Case.StaffAssignments.Count);
+            Assert.AreEqual(1, v1Case.History.OfType<V1CaseStaffAssigned>().Count());
+
+            Commit(
+                model.ExecuteV1CaseCommand(
+                    new UnassignStaffFromV1Case(FamilyId, RecordId, PersonId, "Case Manager"),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+            Commit(
+                model.ExecuteV1CaseCommand(
+                    new UnassignStaffFromV1Case(FamilyId, RecordId, PersonId, "Case Manager"),
+                    UserId,
+                    DateTime.UtcNow
+                )
+            );
+
+            v1Case = model.GetV1CaseEntry(RecordId);
+            Assert.AreEqual(0, v1Case.StaffAssignments.Count);
+            Assert.AreEqual(1, v1Case.History.OfType<V1CaseStaffUnassigned>().Count());
+        }
+
+        private static void Commit<TEvent, TState>(
+            (TEvent Event, long SequenceNumber, TState State, Action OnCommit) result
+        ) => result.OnCommit();
+
+        private static void Commit<TState>(
+            (
+                V1ReferralCommandExecuted Event,
+                long SequenceNumber,
+                TState Referral,
+                Action OnCommit
+            ) result
+        ) => result.OnCommit();
+
+        private static void Commit<TState>(
+            (ReferralCommandExecuted Event, long SequenceNumber, TState V1CaseEntry, Action OnCommit)
+                result
+        ) => result.OnCommit();
+    }
+}

--- a/test/CareTogether.TestData/TestDataProvider.cs
+++ b/test/CareTogether.TestData/TestDataProvider.cs
@@ -3207,7 +3207,21 @@ namespace CareTogether.TestData
                         new RequirementDefinition("Intake Coordinator Screening Call", true),
                         new RequirementDefinition("Intake Form", true),
                     ]
-                ),
+                )
+                {
+                    StaffAssignmentPolicies =
+                    [
+                        new StaffAssignmentPolicy(
+                            "Case Manager",
+                            new StaffAssignmentEligibility(
+                                EligibleLocationRoles: [SystemConstants.ORGANIZATION_ADMINISTRATOR],
+                                EligibleIndividualVolunteerRoles: [],
+                                EligibleVolunteerFamilyRoles: [],
+                                EligiblePeople: []
+                            )
+                        ),
+                    ],
+                },
                 new VolunteerPolicy(
                     new Dictionary<string, VolunteerRolePolicy>
                     {
@@ -3374,7 +3388,22 @@ namespace CareTogether.TestData
                         ),
                     }.ToImmutableDictionary()
                 )
-            );
+            )
+            {
+                V1ReferralPolicy = new V1ReferralPolicy(
+                    [
+                        new StaffAssignmentPolicy(
+                            "Intake Coordinator",
+                            new StaffAssignmentEligibility(
+                                EligibleLocationRoles: [SystemConstants.ORGANIZATION_ADMINISTRATOR],
+                                EligibleIndividualVolunteerRoles: [],
+                                EligibleVolunteerFamilyRoles: [],
+                                EligiblePeople: []
+                            )
+                        ),
+                    ]
+                ),
+            };
 
             await policiesStore.UpsertAsync(guid1, guid2, "policy", policy);
             await policiesStore.UpsertAsync(guid1, guid3, "policy", policy);


### PR DESCRIPTION
## Summary
- add backend contracts, resource state, commands, permissions, and policy models for assigning staff to V1 referrals and V1 cases
- add assigned-staff authorization contexts, per-referral listing/disclosure, manager-side eligibility validation, and referral-to-case assignment copy on accept/link
- add focused backend tests, minimal test policy data, generated client/swagger updates, and the saved split implementation plan

## Verification
- dotnet build CareTogetherCMS.sln --no-restore -nologo
- dotnet test test/CareTogether.Core.Test/CareTogether.Core.Test.csproj --no-build -nologo
- npm run type-check
- git diff --check

## Known follow-ups
- referral document valet authorization remains on the existing broader/global path
- referral note command authorization remains on the existing broader/global path
- operational UI and role-editor support are planned for PR 2