### PR TITLE
Fix arrangement section text overlap

### DIFF
--- a/src/caretogether-pwa/src/Families/FamilyScreen.tsx
+++ b/src/caretogether-pwa/src/Families/FamilyScreen.tsx
@@ -1168,7 +1168,7 @@ export function FamilyScreen() {
               <Typography
                 className="ph-unmask"
                 variant="h3"
-                style={{ marginBottom: 0 }}
+                sx={{ mb: 1 }}
               >
                 Family Members
               </Typography>

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementsSection/ArrangementsSection.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementsSection/ArrangementsSection.tsx
@@ -52,21 +52,24 @@ export function ArrangementsSection({
   useScrollToArrangement(arrangementRefs);
 
   return (
-    <Grid item xs={12}>
-      <div
-        style={{
-          display: `flex`,
-          justifyContent: `space-between`,
-          maxWidth: `100%`,
-          flexWrap: `wrap`,
+    <Grid item xs={12} sx={{ mb: 3 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          maxWidth: '100%',
+          flexWrap: 'wrap',
+          gap: 2,
+          mb: 2,
         }}
       >
-        <div
-          style={{
-            display: `flex`,
-            justifyContent: `flex-start`,
-            maxWidth: `100%`,
-            flexWrap: `wrap`,
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-start',
+            maxWidth: '100%',
+            flexWrap: 'wrap',
           }}
         >
           <Box
@@ -98,15 +101,17 @@ export function ArrangementsSection({
               <ToggleButton value="Cancelled">Cancelled</ToggleButton>
             </ToggleButtonGroup>
           </Box>
-        </div>
+        </Box>
         {permissions(Permission.CreateArrangement) && (
           <Box
             sx={{
               textAlign: 'center',
-              display: `flex`,
-              flexDirection: `row`,
-              maxWidth: `100%`,
-              flexWrap: `wrap`,
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'flex-end',
+              maxWidth: '100%',
+              flexWrap: 'wrap',
+              gap: 1,
             }}
           >
             {v1Case &&
@@ -120,7 +125,6 @@ export function ArrangementsSection({
                       }
                       variant="contained"
                       size="small"
-                      sx={{ margin: 1 }}
                       startIcon={<AddCircleIcon />}
                     >
                       {arrangementPolicy.arrangementType}
@@ -130,25 +134,27 @@ export function ArrangementsSection({
               )}
           </Box>
         )}
-      </div>
-      <Masonry columns={isDesktop ? (isWideScreen ? 3 : 2) : 1} spacing={2}>
-        {filteredArrangements.map((arrangement) => (
-          <div
-            key={arrangement.id}
-            ref={(el) => {
-              if (arrangement.id) {
-                arrangementRefs.current[arrangement.id] = el;
-              }
-            }}
-          >
-            <ArrangementCard
-              partneringFamily={family}
-              v1CaseId={v1Case.id!}
-              arrangement={arrangement}
-            />
-          </div>
-        ))}
-      </Masonry>
+      </Box>
+      {filteredArrangements.length > 0 && (
+        <Masonry columns={isDesktop ? (isWideScreen ? 3 : 2) : 1} spacing={2}>
+          {filteredArrangements.map((arrangement) => (
+            <div
+              key={arrangement.id}
+              ref={(el) => {
+                if (arrangement.id) {
+                  arrangementRefs.current[arrangement.id] = el;
+                }
+              }}
+            >
+              <ArrangementCard
+                partneringFamily={family}
+                v1CaseId={v1Case.id!}
+                arrangement={arrangement}
+              />
+            </div>
+          ))}
+        </Masonry>
+      )}
 
       {createArrangementDialogParameter && (
         <CreateArrangementDialog


### PR DESCRIPTION
The problem was that the Family Members section was starting too close to the Arrangements action buttons when there were no arrangement cards, which made the text look overlapped, fixed it by adding proper bottom spacing to the Arrangements section, using a proper flex gap for the buttons, and skipping the empty arrangement grid when there are no arrangements.




<img width="1902" height="833" alt="Screenshot (1030)" src="https://github.com/user-attachments/assets/a70af92d-36f5-4b3c-912e-a89c8271afca" />

<img width="1898" height="888" alt="Screenshot (1031)" src="https://github.com/user-attachments/assets/8725186c-d788-4102-bf22-2428c3662a33" />
