### PR TITLE
Show volunteer assignments in referral and case lists

### DIFF
--- a/src/caretogether-pwa/src/Families/FamilyScreen.tsx
+++ b/src/caretogether-pwa/src/Families/FamilyScreen.tsx
@@ -1000,36 +1000,6 @@ export function FamilyScreen() {
                 </Grid>
               )}
             </Grid>
-
-            {volunteerAssignmentsEnabled &&
-              permissions(Permission.ViewV1CaseVolunteerAssignments) &&
-              selectedV1Case && (
-                <Grid item md={12} sx={{ mt: 2 }}>
-                  <VolunteerAssignmentsSection
-                    assignments={selectedV1Case.assignedIndividualVolunteers ?? []}
-                    policies={
-                      policy.referralPolicy?.volunteerAssignmentPolicies ?? []
-                    }
-                    canEdit={permissions(Permission.EditV1CaseVolunteerAssignments)}
-                    onAssign={(personId, assignmentRole) =>
-                      v1CasesModel.assignIndividualVolunteerToV1Case(
-                        familyId,
-                        selectedV1Case.id,
-                        personId,
-                        assignmentRole
-                      )
-                    }
-                    onUnassign={(personId, assignmentRole) =>
-                      v1CasesModel.unassignIndividualVolunteerFromV1Case(
-                        familyId,
-                        selectedV1Case.id,
-                        personId,
-                        assignmentRole
-                      )
-                    }
-                  />
-                </Grid>
-              )}
           </Grid>
 
           <Grid container spacing={0}>
@@ -1183,6 +1153,41 @@ export function FamilyScreen() {
                 </Grid>
               </>
             )}
+
+            {volunteerAssignmentsEnabled &&
+              permissions(Permission.ViewV1CaseVolunteerAssignments) &&
+              selectedV1Case && (
+                <Grid item xs={12} md={6} sx={{ mb: 2 }}>
+                  <VolunteerAssignmentsSection
+                    assignments={
+                      selectedV1Case.assignedIndividualVolunteers ?? []
+                    }
+                    policies={
+                      policy.referralPolicy?.volunteerAssignmentPolicies ?? []
+                    }
+                    canEdit={permissions(
+                      Permission.EditV1CaseVolunteerAssignments
+                    )}
+                    onAssign={(personId, assignmentRole) =>
+                      v1CasesModel.assignIndividualVolunteerToV1Case(
+                        familyId,
+                        selectedV1Case.id,
+                        personId,
+                        assignmentRole
+                      )
+                    }
+                    onUnassign={(personId, assignmentRole) =>
+                      v1CasesModel.unassignIndividualVolunteerFromV1Case(
+                        familyId,
+                        selectedV1Case.id,
+                        personId,
+                        assignmentRole
+                      )
+                    }
+                  />
+                </Grid>
+              )}
+
             {permissions(Permission.ViewFamilyDocumentMetadata) && (
               <Grid item xs={12} lg={8} xl={5} mb={2}>
                 <Typography

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
@@ -357,6 +357,7 @@ function PartneringFamilies() {
             </Button>
           )}
           <ToggleButtonGroup
+            sx={{ marginLeft: 'auto' }}
             value={arrangementsFilter}
             exclusive
             onChange={(_, value) => setArrangementsFilter(value)}

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
@@ -35,6 +35,7 @@ import { useLocalStorage } from '../Hooks/useLocalStorage';
 import { policyData } from '../Model/ConfigurationModel';
 import { SearchBar } from '../Shell/SearchBar';
 import { filterFamiliesByText } from '../Families/FamilyUtils';
+import { usePersonAndFamilyLookup } from '../Model/DirectoryModel';
 import { useAllPartneringFamiliesPermissions } from '../Model/SessionModel';
 import { useScreenTitle } from '../Shell/ShellScreenTitle';
 import { useLoadable } from '../Hooks/useLoadable';
@@ -59,6 +60,13 @@ import {
 } from './PartneringFamilies/sortPartneringFamilies';
 import { useSidePanel } from '../Hooks/useSidePanel';
 import { PartneringFamilyCustomFieldFiltersSidePanel } from './PartneringFamilies/PartneringFamilyCustomFieldFiltersSidePanel';
+import { VOLUNTEER_ASSIGNMENTS_FEATURE_FLAG } from '../featureFlags';
+import {
+  AssignmentFilterSelectionsByRole,
+  assignmentRolesForColumns,
+  matchesAssignmentFilters,
+} from '../VolunteerAssignments/assignmentRoleColumns';
+import { AssignmentRoleFilters } from '../VolunteerAssignments/AssignmentRoleFilters';
 
 const PARTNERING_FAMILIES_SORT_STORAGE_KEY = 'partnering-families-sortMode';
 
@@ -72,6 +80,7 @@ function isSetupOrActiveArrangementPhase(phase: ArrangementPhase | undefined) {
 
 function PartneringFamilies() {
   const appNavigate = useAppNavigate();
+  const personAndFamilyLookup = usePersonAndFamilyLookup();
   const {
     SidePanel: CustomFieldFiltersSidePanel,
     openSidePanel: openCustomFieldFiltersSidePanel,
@@ -146,6 +155,28 @@ function PartneringFamilies() {
   const activeCustomFieldFilterCount = Object.values(
     selectedCustomFieldValuesByField
   ).filter((selectedValues) => selectedValues.length > 0).length;
+  const [assignmentFilters, setAssignmentFilters] =
+    useState<AssignmentFilterSelectionsByRole>({});
+
+  const permissions = useAllPartneringFamiliesPermissions();
+  const volunteerAssignmentsEnabled = useFeatureFlagEnabled(
+    VOLUNTEER_ASSIGNMENTS_FEATURE_FLAG
+  );
+  const canViewVolunteerAssignments =
+    volunteerAssignmentsEnabled === true &&
+    permissions(Permission.ViewV1CaseVolunteerAssignments);
+  const assignmentRoles = canViewVolunteerAssignments
+    ? assignmentRolesForColumns(
+        loadablePolicy?.referralPolicy?.volunteerAssignmentPolicies?.map(
+          (assignmentPolicy) => assignmentPolicy.assignmentRole
+        ) ?? [],
+        partneringFamilies.flatMap(
+          (family) =>
+            family.partneringFamilyInfo?.openV1Case
+              ?.assignedIndividualVolunteers ?? []
+        )
+      )
+    : [];
 
   useScrollMemory();
 
@@ -204,6 +235,15 @@ function PartneringFamilies() {
               : countyFilter.includes(county);
           })
           .filter((family) => {
+            if (!canViewVolunteerAssignments) return true;
+
+            return matchesAssignmentFilters(
+              family.partneringFamilyInfo?.openV1Case
+                ?.assignedIndividualVolunteers ?? [],
+              assignmentFilters
+            );
+          })
+          .filter((family) => {
             const familyId = family.family?.id;
             const openCase = family.partneringFamilyInfo?.openV1Case;
             const arrangements = openCase?.arrangements ?? [];
@@ -246,7 +286,9 @@ function PartneringFamilies() {
         openReferralByFamily
       ),
     [
+      assignmentFilters,
       arrangementsFilter,
+      canViewVolunteerAssignments,
       countyFilter,
       filteredPartneringFamilies,
       openReferralByFamily,
@@ -259,6 +301,7 @@ function PartneringFamilies() {
   React.useEffect(() => {
     forceCheck();
   }, [
+    assignmentFilters,
     arrangementsFilter,
     filterText,
     selectedCustomFieldValuesByField,
@@ -272,8 +315,6 @@ function PartneringFamilies() {
   const updateTestFamilyFlagEnabled = useFeatureFlagEnabled(
     'updateTestFamilyFlag'
   );
-
-  const permissions = useAllPartneringFamiliesPermissions();
 
   const canCreateFamily =
     permissions(Permission.EditFamilyInfo) &&
@@ -359,6 +400,22 @@ function PartneringFamilies() {
             families={partneringFamilies}
             value={countyFilter}
             onChange={setCountyFilter}
+          />
+          <AssignmentRoleFilters
+            assignmentRoles={assignmentRoles}
+            assignments={partneringFamilies.flatMap(
+              (family) =>
+                family.partneringFamilyInfo?.openV1Case
+                  ?.assignedIndividualVolunteers ?? []
+            )}
+            selectedValuesByRole={assignmentFilters}
+            onChange={(assignmentRole, selectedValues) =>
+              setAssignmentFilters((current) => ({
+                ...current,
+                [assignmentRole]: selectedValues,
+              }))
+            }
+            personLookup={(personId) => personAndFamilyLookup(personId).person}
           />
           {customFieldCount > 0 && (
             <FormControl
@@ -465,6 +522,9 @@ function PartneringFamilies() {
                 <TableCell>Client Family</TableCell>
                 <TableCell>Case Status</TableCell>
                 <TableCell>County</TableCell>
+                {assignmentRoles.map((assignmentRole) => (
+                  <TableCell key={assignmentRole}>{assignmentRole}</TableCell>
+                ))}
                 {referralCustomFields.map((field) => (
                   <TableCell
                     key={field.name}
@@ -502,6 +562,10 @@ function PartneringFamilies() {
                     appNavigate.family(familyId, v1CaseId, arrangementId)
                   }
                   openFamily={openFamily}
+                  assignmentRoles={assignmentRoles}
+                  assignmentPersonLookup={(personId) =>
+                    personAndFamilyLookup(personId).person
+                  }
                   referralCustomFields={referralCustomFields}
                   arrangementStatusSummary={arrangementStatusSummary}
                   updateTestFamilyFlagEnabled={updateTestFamilyFlagEnabled}

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
@@ -401,22 +401,26 @@ function PartneringFamilies() {
             value={countyFilter}
             onChange={setCountyFilter}
           />
-          <AssignmentRoleFilters
-            assignmentRoles={assignmentRoles}
-            assignments={partneringFamilies.flatMap(
-              (family) =>
-                family.partneringFamilyInfo?.openV1Case
-                  ?.assignedIndividualVolunteers ?? []
-            )}
-            selectedValuesByRole={assignmentFilters}
-            onChange={(assignmentRole, selectedValues) =>
-              setAssignmentFilters((current) => ({
-                ...current,
-                [assignmentRole]: selectedValues,
-              }))
-            }
-            personLookup={(personId) => personAndFamilyLookup(personId).person}
-          />
+          {canViewVolunteerAssignments && (
+            <AssignmentRoleFilters
+              assignmentRoles={assignmentRoles}
+              assignments={partneringFamilies.flatMap(
+                (family) =>
+                  family.partneringFamilyInfo?.openV1Case
+                    ?.assignedIndividualVolunteers ?? []
+              )}
+              selectedValuesByRole={assignmentFilters}
+              onChange={(assignmentRole, selectedValues) =>
+                setAssignmentFilters((current) => ({
+                  ...current,
+                  [assignmentRole]: selectedValues,
+                }))
+              }
+              personLookup={(personId) =>
+                personAndFamilyLookup(personId).person
+              }
+            />
+          )}
           {customFieldCount > 0 && (
             <FormControl
               sx={{
@@ -522,9 +526,10 @@ function PartneringFamilies() {
                 <TableCell>Client Family</TableCell>
                 <TableCell>Case Status</TableCell>
                 <TableCell>County</TableCell>
-                {assignmentRoles.map((assignmentRole) => (
-                  <TableCell key={assignmentRole}>{assignmentRole}</TableCell>
-                ))}
+                {canViewVolunteerAssignments &&
+                  assignmentRoles.map((assignmentRole) => (
+                    <TableCell key={assignmentRole}>{assignmentRole}</TableCell>
+                  ))}
                 {referralCustomFields.map((field) => (
                   <TableCell
                     key={field.name}
@@ -562,7 +567,9 @@ function PartneringFamilies() {
                     appNavigate.family(familyId, v1CaseId, arrangementId)
                   }
                   openFamily={openFamily}
-                  assignmentRoles={assignmentRoles}
+                  assignmentRoles={
+                    canViewVolunteerAssignments ? assignmentRoles : []
+                  }
                   assignmentPersonLookup={(personId) =>
                     personAndFamilyLookup(personId).person
                   }

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies/PartneringFamilyTableItem.tsx
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies/PartneringFamilyTableItem.tsx
@@ -15,6 +15,7 @@ import { ArrangementCard } from '../Arrangements/ArrangementCard';
 import { matchingArrangements } from './arrangementHelpers';
 import { PartneringFamilyTableItemProps } from './types';
 import { getFamilyCounty } from '../../Utilities/getFamilyCounty';
+import { assignmentNamesForRole } from '../../VolunteerAssignments/assignmentRoleColumns';
 
 function getPartneringFamilyRowGroupHeight(
   expandedView: boolean,
@@ -32,6 +33,7 @@ function PartneringFamilyPlaceholderRow(
     PartneringFamilyTableItemProps,
     | 'arrangementTypes'
     | 'arrangementsFilter'
+    | 'assignmentRoles'
     | 'expandedView'
     | 'partneringFamily'
     | 'referralCustomFields'
@@ -42,6 +44,7 @@ function PartneringFamilyPlaceholderRow(
   const {
     arrangementTypes,
     arrangementsFilter,
+    assignmentRoles,
     expandedView,
     partneringFamily,
     referralCustomFields,
@@ -56,7 +59,8 @@ function PartneringFamilyPlaceholderRow(
     arrangementCount
   );
   const columnCount =
-    2 +
+    3 +
+    assignmentRoles.length +
     referralCustomFields.length +
     (expandedView ? 0 : arrangementTypes.length);
 
@@ -87,6 +91,8 @@ function PartneringFamilyTableRows(props: PartneringFamilyTableItemProps) {
     expandedView,
     openArrangement,
     openFamily,
+    assignmentRoles,
+    assignmentPersonLookup,
     referralCustomFields,
     arrangementStatusSummary,
     updateTestFamilyFlagEnabled,
@@ -107,6 +113,7 @@ function PartneringFamilyTableRows(props: PartneringFamilyTableItemProps) {
     arrangementsFilter
   );
   const openV1Case = partneringFamily.partneringFamilyInfo?.openV1Case;
+  const assignments = openV1Case?.assignedIndividualVolunteers ?? [];
   const closedV1Cases =
     partneringFamily.partneringFamilyInfo?.closedV1Cases ?? [];
   const latestClosedV1Case =
@@ -151,6 +158,41 @@ function PartneringFamilyTableRows(props: PartneringFamilyTableItemProps) {
         </TableCell>
         <TableCell>{caseStatusText}</TableCell>
         <TableCell>{getFamilyCounty(partneringFamily)}</TableCell>
+        {assignmentRoles.map((assignmentRole) => (
+          <TableCell key={assignmentRole}>
+            {assignmentNamesForRole(
+              assignments,
+              assignmentRole,
+              assignmentPersonLookup
+            )}
+          </TableCell>
+        ))}
+        {referralCustomFields.map((field) => {
+          const completedFields =
+            partneringFamily.partneringFamilyInfo?.openV1Case
+              ?.completedCustomFields ?? [];
+
+          const matchingField = completedFields.find(
+            (customField: CompletedCustomFieldInfo) =>
+              customField.customFieldName === field.name
+          );
+
+          const fieldValue = matchingField?.value;
+          const displayValue =
+            fieldValue === true
+              ? 'Yes'
+              : fieldValue === false
+                ? 'No'
+                : fieldValue === undefined || fieldValue === null
+                  ? ''
+                  : fieldValue.toString();
+
+          return (
+            <TableCell key={field.name} sx={{ textAlign: 'center' }}>
+              {displayValue}
+            </TableCell>
+          );
+        })}
         {!expandedView ? (
           arrangementTypes.map((arrangementType) => (
             <TableCell key={arrangementType}>
@@ -196,32 +238,6 @@ function PartneringFamilyTableRows(props: PartneringFamilyTableItemProps) {
         ) : (
           <></>
         )}
-        {referralCustomFields.map((field) => {
-          const completedFields =
-            partneringFamily.partneringFamilyInfo?.openV1Case
-              ?.completedCustomFields ?? [];
-
-          const matchingField = completedFields.find(
-            (customField: CompletedCustomFieldInfo) =>
-              customField.customFieldName === field.name
-          );
-
-          const fieldValue = matchingField?.value;
-          const displayValue =
-            fieldValue === true
-              ? 'Yes'
-              : fieldValue === false
-                ? 'No'
-                : fieldValue === undefined || fieldValue === null
-                  ? ''
-                  : fieldValue.toString();
-
-          return (
-            <TableCell key={field.name} sx={{ textAlign: 'center' }}>
-              {displayValue}
-            </TableCell>
-          );
-        })}
       </TableRow>
       {expandedView ? (
         <TableRow onClick={() => openFamily(familyId)}>
@@ -236,7 +252,9 @@ function PartneringFamilyTableRows(props: PartneringFamilyTableItemProps) {
             </Box>
           </TableCell>
 
-          <TableCell colSpan={2 + referralCustomFields.length}>
+          <TableCell
+            colSpan={2 + assignmentRoles.length + referralCustomFields.length}
+          >
             <Grid container spacing={2}>
               {arrangementEntries.map((arrangementEntry) => (
                 <Grid item key={arrangementEntry.arrangement.id}>

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies/types.ts
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies/types.ts
@@ -1,4 +1,10 @@
-import { ArrangementPhase, CombinedFamilyInfo, CustomField, PartneringFamilyInfo } from '../../GeneratedClient';
+import {
+  ArrangementPhase,
+  CombinedFamilyInfo,
+  CustomField,
+  PartneringFamilyInfo,
+  Person,
+} from '../../GeneratedClient';
 import { ReactNode } from 'react';
 
 type ArrangementsFilter =
@@ -19,6 +25,8 @@ type PartneringFamilyTableItemProps = {
     arrangementId: string
   ) => void;
   openFamily: (familyId: string) => void;
+  assignmentRoles: string[];
+  assignmentPersonLookup: (personId: string) => Person | undefined;
   referralCustomFields: CustomField[];
   arrangementStatusSummary: (
     partneringFamilyInfo: PartneringFamilyInfo,

--- a/src/caretogether-pwa/src/V1Referrals/ReferralRow.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/ReferralRow.tsx
@@ -11,10 +11,12 @@ export interface ReferralRowModel {
   clientFamilyName: string | null;
   county: string | null;
   comments?: string;
+  assignmentNamesByRole: Record<string, string>;
 }
 
 interface ReferralRowProps {
   referral: ReferralRowModel;
+  assignmentRoles: string[];
   expanded: boolean;
 }
 
@@ -23,7 +25,11 @@ function formatDate(date?: Date) {
   return date.toLocaleDateString();
 }
 
-export function ReferralRow({ referral, expanded }: ReferralRowProps) {
+export function ReferralRow({
+  referral,
+  assignmentRoles,
+  expanded,
+}: ReferralRowProps) {
   const appNavigate = useAppNavigate();
 
   const comments = referral.comments ?? '';
@@ -65,6 +71,11 @@ export function ReferralRow({ referral, expanded }: ReferralRowProps) {
         <TableCell>{referral.clientFamilyName ?? ''}</TableCell>
 
         <TableCell>{referral.county ?? ''}</TableCell>
+        {assignmentRoles.map((assignmentRole) => (
+          <TableCell key={assignmentRole}>
+            {referral.assignmentNamesByRole[assignmentRole] ?? ''}
+          </TableCell>
+        ))}
       </TableRow>
 
       {expanded && comments && (
@@ -72,7 +83,7 @@ export function ReferralRow({ referral, expanded }: ReferralRowProps) {
           sx={{ cursor: 'pointer' }}
           onClick={() => appNavigate.referral(referral.id)}
         >
-          <TableCell colSpan={4} sx={{ pl: 3 }}>
+          <TableCell colSpan={4 + assignmentRoles.length} sx={{ pl: 3 }}>
             <Box sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word' }}>
               {preview}
             </Box>

--- a/src/caretogether-pwa/src/V1Referrals/ReferralsFilters.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/ReferralsFilters.tsx
@@ -8,13 +8,19 @@ import {
 } from '@mui/material';
 import { MouseEvent } from 'react';
 import { SearchBar } from '../Shell/SearchBar';
-import { CombinedFamilyInfo } from '../GeneratedClient';
+import {
+  AssignedIndividualVolunteer,
+  CombinedFamilyInfo,
+  Person,
+} from '../GeneratedClient';
 import { CountyFilter } from '../V1Referrals/CountyFilter';
 import {
   Add as AddIcon,
   UnfoldLess as UnfoldLessIcon,
   UnfoldMore as UnfoldMoreIcon,
 } from '@mui/icons-material';
+import { AssignmentRoleFilters } from '../VolunteerAssignments/AssignmentRoleFilters';
+import { AssignmentFilterSelectionsByRole } from '../VolunteerAssignments/assignmentRoleColumns';
 
 export type ReferralStatusFilter = 'ALL' | 'OPEN' | 'ACCEPTED' | 'CLOSED';
 
@@ -35,6 +41,15 @@ interface ReferralsFiltersProps {
   setCountyFilter: (value: (string | null)[]) => void;
 
   familiesForCountyFilter: CombinedFamilyInfo[];
+
+  assignmentRoles: string[];
+  assignmentsForAssignmentFilter: AssignedIndividualVolunteer[];
+  assignmentFilters: AssignmentFilterSelectionsByRole;
+  setAssignmentFilter: (
+    assignmentRole: string,
+    selectedValues: (string | null)[]
+  ) => void;
+  assignmentPersonLookup: (personId: string) => Person | undefined;
 }
 
 export function ReferralsFilters({
@@ -49,6 +64,11 @@ export function ReferralsFilters({
   countyFilter,
   setCountyFilter,
   familiesForCountyFilter,
+  assignmentRoles,
+  assignmentsForAssignmentFilter,
+  assignmentFilters,
+  setAssignmentFilter,
+  assignmentPersonLookup,
 }: ReferralsFiltersProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -63,7 +83,10 @@ export function ReferralsFilters({
   };
 
   return (
-    <Stack direction="row" sx={{ mt: 2, mb: 2 }}>
+    <Stack
+      direction="row"
+      sx={{ mt: 2, mb: 2, flexWrap: 'wrap', alignItems: 'center', gap: 1 }}
+    >
       {canAddNewReferral && (
         <Button
           variant="contained"
@@ -79,7 +102,7 @@ export function ReferralsFilters({
         exclusive
         onChange={(_, value) => value && setStatusFilter(value)}
         size={isMobile ? 'medium' : 'small'}
-        sx={{ ml: 'auto', mr: 2 }}
+        sx={{ ml: 'auto' }}
       >
         <ToggleButton value="ALL">ALL</ToggleButton>
         <ToggleButton value="OPEN">OPEN</ToggleButton>
@@ -91,6 +114,14 @@ export function ReferralsFilters({
         families={familiesForCountyFilter}
         value={countyFilter}
         onChange={setCountyFilter}
+      />
+
+      <AssignmentRoleFilters
+        assignmentRoles={assignmentRoles}
+        assignments={assignmentsForAssignmentFilter}
+        selectedValuesByRole={assignmentFilters}
+        onChange={setAssignmentFilter}
+        personLookup={assignmentPersonLookup}
       />
 
       <SearchBar value={filterText} onChange={setFilterText} />

--- a/src/caretogether-pwa/src/V1Referrals/V1Referrals.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/V1Referrals.tsx
@@ -17,7 +17,10 @@ import { ReferralRow } from './ReferralRow';
 import { ReferralsFilters } from './ReferralsFilters';
 import { AddNewReferralDrawer } from './AddNewReferralDrawer';
 import { ReferralDetailsPage } from './ReferralDetailsPage';
-import { useFamilyLookup } from '../Model/DirectoryModel';
+import {
+  useFamilyLookup,
+  usePersonAndFamilyLookup,
+} from '../Model/DirectoryModel';
 import { familyNameString } from '../Families/FamilyName';
 import { currentLocationQuery, visibleReferralsQuery } from '../Model/Data';
 import { Permission, V1ReferralStatus } from '../GeneratedClient';
@@ -27,6 +30,15 @@ import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react';
 import { useAppNavigate } from '../Hooks/useAppNavigate';
 import { ProgressBackdrop } from '../Shell/ProgressBackdrop';
 import { useGlobalPermissions } from '../Model/SessionModel';
+import { policyData } from '../Model/ConfigurationModel';
+import { useLoadable } from '../Hooks/useLoadable';
+import { VOLUNTEER_ASSIGNMENTS_FEATURE_FLAG } from '../featureFlags';
+import {
+  AssignmentFilterSelectionsByRole,
+  assignmentNamesForRole,
+  assignmentRolesForColumns,
+  matchesAssignmentFilters,
+} from '../VolunteerAssignments/assignmentRoleColumns';
 
 const REFERRALS_FEATURE_FLAG = 'referrals';
 
@@ -95,22 +107,43 @@ export function V1Referrals() {
 function V1ReferralsContent() {
   const referralsLoadable = useRecoilValueLoadable(visibleReferralsQuery);
   const familyLookup = useFamilyLookup();
+  const personAndFamilyLookup = usePersonAndFamilyLookup();
   const permissions = useGlobalPermissions();
+  const policy = useLoadable(policyData);
+  const volunteerAssignmentsEnabled = useFeatureFlagEnabled(
+    VOLUNTEER_ASSIGNMENTS_FEATURE_FLAG
+  );
 
   const [filterText, setFilterText] = useState('');
   const [statusFilter, setStatusFilter] = useState<ReferralStatusFilter>('ALL');
   const [expandedView, setExpandedView] = useState(true);
   const [openNewReferral, setOpenNewReferral] = useState(false);
   const [countyFilter, setCountyFilter] = useState<(string | null)[]>([]);
+  const [assignmentFilters, setAssignmentFilters] =
+    useState<AssignmentFilterSelectionsByRole>({});
 
   const referrals =
     referralsLoadable.state === 'hasValue'
       ? referralsLoadable.contents.map((referralInfo) => referralInfo.referral)
       : [];
+  const canViewVolunteerAssignments =
+    volunteerAssignmentsEnabled === true &&
+    permissions(Permission.ViewV1ReferralVolunteerAssignments);
+  const assignmentRoles = canViewVolunteerAssignments
+    ? assignmentRolesForColumns(
+        policy?.v1ReferralPolicy?.volunteerAssignmentPolicies?.map(
+          (assignmentPolicy) => assignmentPolicy.assignmentRole
+        ) ?? [],
+        referrals.flatMap(
+          (referral) => referral.assignedIndividualVolunteers ?? []
+        )
+      )
+    : [];
 
   const rows = referrals
     .map((r) => {
       const family = r.familyId ? familyLookup(r.familyId) : null;
+      const assignments = r.assignedIndividualVolunteers ?? [];
 
       return {
         id: r.referralId,
@@ -122,6 +155,19 @@ function V1ReferralsContent() {
         clientFamilyName: family ? familyNameString(family) : null,
         county: family ? getFamilyCounty(family) : null,
         comments: r.comment ?? '',
+        matchesAssignmentFilters:
+          !canViewVolunteerAssignments ||
+          matchesAssignmentFilters(assignments, assignmentFilters),
+        assignmentNamesByRole: Object.fromEntries(
+          assignmentRoles.map((assignmentRole) => [
+            assignmentRole,
+            assignmentNamesForRole(
+              assignments,
+              assignmentRole,
+              (personId) => personAndFamilyLookup(personId).person
+            ),
+          ])
+        ),
       };
     })
     .sort((a, b) => {
@@ -149,7 +195,12 @@ function V1ReferralsContent() {
           ? countyFilter.includes(null)
           : countyFilter.includes(r.county);
 
-    return matchesText && matchesStatus && matchesCounty;
+    return (
+      matchesText &&
+      matchesStatus &&
+      matchesCounty &&
+      r.matchesAssignmentFilters
+    );
   });
 
   return (
@@ -170,6 +221,20 @@ function V1ReferralsContent() {
                 setStatusFilter={setStatusFilter}
                 countyFilter={countyFilter}
                 setCountyFilter={setCountyFilter}
+                assignmentRoles={assignmentRoles}
+                assignmentsForAssignmentFilter={referrals.flatMap(
+                  (referral) => referral.assignedIndividualVolunteers ?? []
+                )}
+                assignmentFilters={assignmentFilters}
+                setAssignmentFilter={(assignmentRole, selectedValues) =>
+                  setAssignmentFilters((current) => ({
+                    ...current,
+                    [assignmentRole]: selectedValues,
+                  }))
+                }
+                assignmentPersonLookup={(personId) =>
+                  personAndFamilyLookup(personId).person
+                }
                 familiesForCountyFilter={referrals
                   .map((r) => (r.familyId ? familyLookup(r.familyId) : null))
                   .filter(
@@ -188,6 +253,11 @@ function V1ReferralsContent() {
                       <TableCell>Status</TableCell>
                       <TableCell>Client Family</TableCell>
                       <TableCell>County</TableCell>
+                      {assignmentRoles.map((assignmentRole) => (
+                        <TableCell key={assignmentRole}>
+                          {assignmentRole}
+                        </TableCell>
+                      ))}
                     </TableRow>
                   </TableHead>
 
@@ -196,6 +266,7 @@ function V1ReferralsContent() {
                       <ReferralRow
                         key={ref.id}
                         referral={ref}
+                        assignmentRoles={assignmentRoles}
                         expanded={expandedView}
                       />
                     ))}

--- a/src/caretogether-pwa/src/V1Referrals/V1Referrals.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/V1Referrals.tsx
@@ -221,10 +221,17 @@ function V1ReferralsContent() {
                 setStatusFilter={setStatusFilter}
                 countyFilter={countyFilter}
                 setCountyFilter={setCountyFilter}
-                assignmentRoles={assignmentRoles}
-                assignmentsForAssignmentFilter={referrals.flatMap(
-                  (referral) => referral.assignedIndividualVolunteers ?? []
-                )}
+                assignmentRoles={
+                  canViewVolunteerAssignments ? assignmentRoles : []
+                }
+                assignmentsForAssignmentFilter={
+                  canViewVolunteerAssignments
+                    ? referrals.flatMap(
+                        (referral) =>
+                          referral.assignedIndividualVolunteers ?? []
+                      )
+                    : []
+                }
                 assignmentFilters={assignmentFilters}
                 setAssignmentFilter={(assignmentRole, selectedValues) =>
                   setAssignmentFilters((current) => ({
@@ -253,11 +260,12 @@ function V1ReferralsContent() {
                       <TableCell>Status</TableCell>
                       <TableCell>Client Family</TableCell>
                       <TableCell>County</TableCell>
-                      {assignmentRoles.map((assignmentRole) => (
-                        <TableCell key={assignmentRole}>
-                          {assignmentRole}
-                        </TableCell>
-                      ))}
+                      {canViewVolunteerAssignments &&
+                        assignmentRoles.map((assignmentRole) => (
+                          <TableCell key={assignmentRole}>
+                            {assignmentRole}
+                          </TableCell>
+                        ))}
                     </TableRow>
                   </TableHead>
 
@@ -266,7 +274,9 @@ function V1ReferralsContent() {
                       <ReferralRow
                         key={ref.id}
                         referral={ref}
-                        assignmentRoles={assignmentRoles}
+                        assignmentRoles={
+                          canViewVolunteerAssignments ? assignmentRoles : []
+                        }
                         expanded={expandedView}
                       />
                     ))}

--- a/src/caretogether-pwa/src/VolunteerAssignments/AssignmentRoleFilters.tsx
+++ b/src/caretogether-pwa/src/VolunteerAssignments/AssignmentRoleFilters.tsx
@@ -1,0 +1,91 @@
+import { AssignedIndividualVolunteer, Person } from '../GeneratedClient';
+import { CustomFieldsFilterSelect } from '../Generic/CustomFieldsFilter/CustomFieldsFilterSelect';
+import {
+  CustomFieldFilterOption,
+  CustomFieldFilterValue,
+} from '../Generic/CustomFieldsFilter/types';
+import { personNameString } from '../Families/PersonName';
+import { AssignmentFilterSelectionsByRole } from './assignmentRoleColumns';
+
+type AssignmentRoleFiltersProps = {
+  assignmentRoles: string[];
+  assignments: AssignedIndividualVolunteer[];
+  selectedValuesByRole: AssignmentFilterSelectionsByRole;
+  onChange: (assignmentRole: string, selectedValues: (string | null)[]) => void;
+  personLookup: (personId: string) => Person | undefined;
+};
+
+function assignmentFilterOptions(
+  assignmentRole: string,
+  assignments: AssignedIndividualVolunteer[],
+  selectedValues: (string | null)[],
+  personLookup: (personId: string) => Person | undefined
+) {
+  const assignedPersonIds = Array.from(
+    new Set(
+      assignments
+        .filter((assignment) => assignment.assignmentRole === assignmentRole)
+        .map((assignment) => assignment.personId)
+    )
+  );
+
+  const selectedSet = new Set<string | null>(selectedValues);
+  const personOptions: CustomFieldFilterOption[] = assignedPersonIds
+    .map((personId) => ({
+      key: personNameString(personLookup(personId)),
+      value: personId,
+      selected: selectedSet.has(personId),
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  return [
+    {
+      key: 'Unassigned',
+      value: null,
+      selected: selectedSet.has(null),
+    },
+    ...personOptions,
+  ];
+}
+
+function assignmentFilterValues(
+  selectedValues: CustomFieldFilterValue[]
+): (string | null)[] {
+  return selectedValues.filter(
+    (value): value is string | null =>
+      typeof value === 'string' || value === null
+  );
+}
+
+export function AssignmentRoleFilters({
+  assignmentRoles,
+  assignments,
+  selectedValuesByRole,
+  onChange,
+  personLookup,
+}: AssignmentRoleFiltersProps) {
+  return (
+    <>
+      {assignmentRoles.map((assignmentRole) => {
+        const selectedValues = selectedValuesByRole[assignmentRole] ?? [];
+
+        return (
+          <CustomFieldsFilterSelect
+            key={assignmentRole}
+            label={assignmentRole}
+            options={assignmentFilterOptions(
+              assignmentRole,
+              assignments,
+              selectedValues,
+              personLookup
+            )}
+            selectedValues={selectedValues}
+            onChange={(selectedValues) =>
+              onChange(assignmentRole, assignmentFilterValues(selectedValues))
+            }
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/src/caretogether-pwa/src/VolunteerAssignments/assignmentRoleColumns.ts
+++ b/src/caretogether-pwa/src/VolunteerAssignments/assignmentRoleColumns.ts
@@ -1,0 +1,56 @@
+import { AssignedIndividualVolunteer, Person } from '../GeneratedClient';
+import { personNameString } from '../Families/PersonName';
+
+export function assignmentRolesForColumns(
+  policyRoles: (string | undefined)[],
+  assignments: AssignedIndividualVolunteer[]
+) {
+  const configuredRoles = policyRoles.filter((role): role is string =>
+    Boolean(role)
+  );
+  const assignedRoles = assignments
+    .map((assignment) => assignment.assignmentRole)
+    .filter((role) => role && !configuredRoles.includes(role));
+
+  return Array.from(new Set(configuredRoles.concat(assignedRoles)));
+}
+
+export function assignmentNamesForRole(
+  assignments: AssignedIndividualVolunteer[],
+  assignmentRole: string,
+  personLookup: (personId: string) => Person | undefined
+) {
+  return assignments
+    .filter((assignment) => assignment.assignmentRole === assignmentRole)
+    .map((assignment) => personNameString(personLookup(assignment.personId)))
+    .sort((a, b) => a.localeCompare(b))
+    .join(', ');
+}
+
+export type AssignmentFilterSelectionsByRole = Record<
+  string,
+  (string | null)[]
+>;
+
+export function matchesAssignmentFilters(
+  assignments: AssignedIndividualVolunteer[],
+  selectedValuesByRole: AssignmentFilterSelectionsByRole
+) {
+  return Object.entries(selectedValuesByRole).every(
+    ([assignmentRole, selectedValues]) => {
+      if (selectedValues.length === 0) return true;
+
+      const assignedPersonIds = assignments
+        .filter((assignment) => assignment.assignmentRole === assignmentRole)
+        .map((assignment) => assignment.personId);
+
+      if (assignedPersonIds.length === 0) {
+        return selectedValues.includes(null);
+      }
+
+      return assignedPersonIds.some((personId) =>
+        selectedValues.includes(personId)
+      );
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add assignment role columns to referral and client/case lists
- add assignment role filters with assigned volunteer and unassigned options
- share assignment role column/filter helpers across both list screens
