### PR TITLE
 Fix referral closing timeline

### DIFF
--- a/src/caretogether-pwa/src/Activities/ActivityTimeline.tsx
+++ b/src/caretogether-pwa/src/Activities/ActivityTimeline.tsx
@@ -94,6 +94,20 @@ const composeNoteType = (activity: Activity): string | null => {
   return null;
 };
 
+const shouldShowTimelineTime = (item: MergedTimelineItem) => {
+  if (item.kind !== 'family-activity') return false;
+
+  return item.activity instanceof ChildLocationChanged;
+};
+
+const formatTimelineTimestamp = (item: MergedTimelineItem) => {
+  if (shouldShowTimelineTime(item)) {
+    return format(item.timestamp, 'M/d/yy h:mm a');
+  }
+
+  return format(item.timestamp, 'M/d/yy');
+};
+
 function embedNotesInActivities(notes: Note[], activities: Activity[]) {
   // We only want to show each note once, on the most recent activity entry that is
   // linked to that particular note. The following stateful code works by pulling from the
@@ -576,7 +590,7 @@ export function ActivityTimeline({
               >
                 <Box sx={{ color: 'text.disabled', margin: 0, padding: 0 }}>
                   <span className="ph-unmask" style={{ marginRight: 16 }}>
-                    {format(item.timestamp, 'M/d/yy h:mm a')}
+                    {formatTimelineTimestamp(item)}
                   </span>
                   {item.userId ? (
                     <PersonName person={userLookup(item.userId)} />

--- a/src/caretogether-pwa/src/V1Referrals/CloseV1ReferralDrawer.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/CloseV1ReferralDrawer.tsx
@@ -28,18 +28,38 @@ function isSameLocalDate(left: Date, right: Date) {
   );
 }
 
-function withCurrentLocalTimeIfToday(date: Date, now = new Date()) {
-  if (!isSameLocalDate(date, now)) return date;
+function isSameLocalTime(left: Date, right: Date) {
+  return (
+    left.getHours() === right.getHours() &&
+    left.getMinutes() === right.getMinutes() &&
+    left.getSeconds() === right.getSeconds() &&
+    left.getMilliseconds() === right.getMilliseconds()
+  );
+}
 
-  const dateWithCurrentTime = new Date(date);
-  dateWithCurrentTime.setHours(
-    now.getHours(),
-    now.getMinutes(),
-    now.getSeconds(),
-    now.getMilliseconds()
+function withLocalTime(date: Date, time: Date) {
+  const dateWithTime = new Date(date);
+  dateWithTime.setHours(
+    time.getHours(),
+    time.getMinutes(),
+    time.getSeconds(),
+    time.getMilliseconds()
   );
 
-  return dateWithCurrentTime;
+  return dateWithTime;
+}
+
+function atStartOfLocalDay(date: Date) {
+  const dateAtStartOfDay = new Date(date);
+  dateAtStartOfDay.setHours(0, 0, 0, 0);
+
+  return dateAtStartOfDay;
+}
+
+function defaultCloseDateTimeForDate(date: Date, now = new Date()) {
+  return isSameLocalDate(date, now)
+    ? withLocalTime(date, now)
+    : atStartOfLocalDay(date);
 }
 
 export function CloseV1ReferralDrawer({
@@ -54,20 +74,52 @@ export function CloseV1ReferralDrawer({
     closedAtLocal: Date | null;
   }>({
     reason: null,
-    closedAtLocal: null,
+    closedAtLocal: new Date(),
   });
+  const [timeWasEdited, setTimeWasEdited] = useState(false);
 
   const [dateError, setDateError] = useState(false);
   const { reason, closedAtLocal } = fields;
 
   const canSave = reason !== null && closedAtLocal !== null && !dateError;
 
+  function updateClosedAtLocal(date: Date | null) {
+    if (date === null) {
+      setFields({ ...fields, closedAtLocal: null });
+      setTimeWasEdited(false);
+      return;
+    }
+
+    if (!closedAtLocal) {
+      setFields({
+        ...fields,
+        closedAtLocal: defaultCloseDateTimeForDate(date),
+      });
+      return;
+    }
+
+    const dateChanged = !isSameLocalDate(date, closedAtLocal);
+    const timeChanged = !isSameLocalTime(date, closedAtLocal);
+
+    if (!dateChanged && timeChanged) {
+      setTimeWasEdited(true);
+      setFields({ ...fields, closedAtLocal: date });
+      return;
+    }
+
+    if (dateChanged && !timeWasEdited) {
+      setFields({
+        ...fields,
+        closedAtLocal: defaultCloseDateTimeForDate(date),
+      });
+      return;
+    }
+
+    setFields({ ...fields, closedAtLocal: date });
+  }
+
   async function save() {
-    await closeReferral(
-      referralId,
-      reason!,
-      withCurrentLocalTimeIfToday(closedAtLocal!)
-    );
+    await closeReferral(referralId, reason!, closedAtLocal!);
     onClose();
   }
 
@@ -112,9 +164,10 @@ export function CloseV1ReferralDrawer({
             <ValidateDatePicker
               label="When was this Referral closed?"
               value={closedAtLocal}
-              onChange={(date) => setFields({ ...fields, closedAtLocal: date })}
+              onChange={updateClosedAtLocal}
               onErrorChange={setDateError}
               disableFuture
+              includeTime
               textFieldProps={{ fullWidth: true, required: true }}
             />
           </Grid>

--- a/src/caretogether-pwa/src/V1Referrals/CloseV1ReferralDrawer.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/CloseV1ReferralDrawer.tsx
@@ -20,6 +20,28 @@ interface CloseV1ReferralDrawerProps {
   onClose: () => void;
 }
 
+function isSameLocalDate(left: Date, right: Date) {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+function withCurrentLocalTimeIfToday(date: Date, now = new Date()) {
+  if (!isSameLocalDate(date, now)) return date;
+
+  const dateWithCurrentTime = new Date(date);
+  dateWithCurrentTime.setHours(
+    now.getHours(),
+    now.getMinutes(),
+    now.getSeconds(),
+    now.getMilliseconds()
+  );
+
+  return dateWithCurrentTime;
+}
+
 export function CloseV1ReferralDrawer({
   referralId,
   onClose,
@@ -41,7 +63,11 @@ export function CloseV1ReferralDrawer({
   const canSave = reason !== null && closedAtLocal !== null && !dateError;
 
   async function save() {
-    await closeReferral(referralId, reason!, closedAtLocal!);
+    await closeReferral(
+      referralId,
+      reason!,
+      withCurrentLocalTimeIfToday(closedAtLocal!)
+    );
     onClose();
   }
 

--- a/src/caretogether-pwa/src/V1Referrals/CloseV1ReferralDrawer.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/CloseV1ReferralDrawer.tsx
@@ -20,48 +20,6 @@ interface CloseV1ReferralDrawerProps {
   onClose: () => void;
 }
 
-function isSameLocalDate(left: Date, right: Date) {
-  return (
-    left.getFullYear() === right.getFullYear() &&
-    left.getMonth() === right.getMonth() &&
-    left.getDate() === right.getDate()
-  );
-}
-
-function isSameLocalTime(left: Date, right: Date) {
-  return (
-    left.getHours() === right.getHours() &&
-    left.getMinutes() === right.getMinutes() &&
-    left.getSeconds() === right.getSeconds() &&
-    left.getMilliseconds() === right.getMilliseconds()
-  );
-}
-
-function withLocalTime(date: Date, time: Date) {
-  const dateWithTime = new Date(date);
-  dateWithTime.setHours(
-    time.getHours(),
-    time.getMinutes(),
-    time.getSeconds(),
-    time.getMilliseconds()
-  );
-
-  return dateWithTime;
-}
-
-function atStartOfLocalDay(date: Date) {
-  const dateAtStartOfDay = new Date(date);
-  dateAtStartOfDay.setHours(0, 0, 0, 0);
-
-  return dateAtStartOfDay;
-}
-
-function defaultCloseDateTimeForDate(date: Date, now = new Date()) {
-  return isSameLocalDate(date, now)
-    ? withLocalTime(date, now)
-    : atStartOfLocalDay(date);
-}
-
 export function CloseV1ReferralDrawer({
   referralId,
   onClose,
@@ -74,49 +32,13 @@ export function CloseV1ReferralDrawer({
     closedAtLocal: Date | null;
   }>({
     reason: null,
-    closedAtLocal: new Date(),
+    closedAtLocal: null,
   });
-  const [timeWasEdited, setTimeWasEdited] = useState(false);
 
   const [dateError, setDateError] = useState(false);
   const { reason, closedAtLocal } = fields;
 
   const canSave = reason !== null && closedAtLocal !== null && !dateError;
-
-  function updateClosedAtLocal(date: Date | null) {
-    if (date === null) {
-      setFields({ ...fields, closedAtLocal: null });
-      setTimeWasEdited(false);
-      return;
-    }
-
-    if (!closedAtLocal) {
-      setFields({
-        ...fields,
-        closedAtLocal: defaultCloseDateTimeForDate(date),
-      });
-      return;
-    }
-
-    const dateChanged = !isSameLocalDate(date, closedAtLocal);
-    const timeChanged = !isSameLocalTime(date, closedAtLocal);
-
-    if (!dateChanged && timeChanged) {
-      setTimeWasEdited(true);
-      setFields({ ...fields, closedAtLocal: date });
-      return;
-    }
-
-    if (dateChanged && !timeWasEdited) {
-      setFields({
-        ...fields,
-        closedAtLocal: defaultCloseDateTimeForDate(date),
-      });
-      return;
-    }
-
-    setFields({ ...fields, closedAtLocal: date });
-  }
 
   async function save() {
     await closeReferral(referralId, reason!, closedAtLocal!);
@@ -164,10 +86,9 @@ export function CloseV1ReferralDrawer({
             <ValidateDatePicker
               label="When was this Referral closed?"
               value={closedAtLocal}
-              onChange={updateClosedAtLocal}
+              onChange={(date) => setFields({ ...fields, closedAtLocal: date })}
               onErrorChange={setDateError}
               disableFuture
-              includeTime
               textFieldProps={{ fullWidth: true, required: true }}
             />
           </Grid>

--- a/src/caretogether-pwa/src/V1Referrals/V1ReferralTimeline.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/V1ReferralTimeline.tsx
@@ -77,7 +77,7 @@ export function ReferralTimeline({
             >
               <Box sx={{ color: 'text.disabled', mb: 0.5 }}>
                 <span style={{ marginRight: 16 }}>
-                  {format(item.timestamp, 'M/d/yy h:mm a')}
+                  {format(item.timestamp, 'M/d/yy')}
                 </span>
                 {item.userId ? (
                   <PersonName person={userLookup(item.userId)} />


### PR DESCRIPTION
Set today’s referral close time to the current time while keeping past close dates at 12:00 AM.
<img width="454" height="818" alt="Screenshot (1032)" src="https://github.com/user-attachments/assets/c64eadf8-7fb8-4b10-a2c8-96c522061164" />
Use MUI DateTimePicker for referral close dates so today defaults to the current time and past dates default to 12:00 AM unless the user changes the time.
<img width="1723" height="911" alt="Screenshot (1035)" src="https://github.com/user-attachments/assets/50a83c33-695f-41f8-9bfc-71594c70f8c5" />

