### PR TITLE
 Make family relationship field optional with free form autocomplete

### DIFF
--- a/src/caretogether-pwa/src/Families/AddAdultDialog.tsx
+++ b/src/caretogether-pwa/src/Families/AddAdultDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogTitle,
   Divider,
+  Autocomplete,
   FormControl,
   FormControlLabel,
   FormGroup,
@@ -103,9 +104,6 @@ export function AddAdultDialog({ onClose }: AddAdultDialogProps) {
     await withBackdrop(async () => {
       if (firstName.length <= 0 || lastName.length <= 0) {
         alert('First and last name are required. Try again.');
-      } else if (relationshipToFamily === '') {
-        //TODO: Actual validation!
-        alert('Family relationship was not selected. Try again.');
       } else {
         const age = dateOfBirth == null ? null : new ExactAge();
         if (dateOfBirth != null) age!.dateOfBirth = dateOfBirth;
@@ -117,7 +115,7 @@ export function AddAdultDialog({ onClose }: AddAdultDialogProps) {
           age,
           optional(ethnicity),
           isInHousehold,
-          relationshipToFamily,
+          optional(relationshipToFamily),
           address == null
             ? null
             : new Address({ ...address, id: crypto.randomUUID() }),
@@ -177,32 +175,25 @@ export function AddAdultDialog({ onClose }: AddAdultDialogProps) {
               />
             </Grid>
             <Grid item xs={12} sm={6}>
-              <FormControl required fullWidth size="small">
-                <InputLabel id="family-relationship-label">
-                  Relationship to Family
-                </InputLabel>
-                <Select
-                  labelId="family-relationship-label"
-                  label="Relationship to Family"
-                  id="family-relationship"
-                  value={relationshipToFamily}
-                  onChange={(e) =>
-                    setFields({
-                      ...fields,
-                      relationshipToFamily: e.target.value as string,
-                    })
-                  }
-                >
-                  <MenuItem key="placeholder" value="" disabled>
-                    Select a relationship type
-                  </MenuItem>
-                  {relationshipTypes.map((relationshipType) => (
-                    <MenuItem key={relationshipType} value={relationshipType}>
-                      {relationshipType}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+              <Autocomplete
+                freeSolo
+                fullWidth
+                size="small"
+                options={relationshipTypes}
+                value={relationshipToFamily}
+                onChange={(_, value) =>
+                  setFields({
+                    ...fields,
+                    relationshipToFamily: value ?? '',
+                  })
+                }
+                onInputChange={(_, value) =>
+                  setFields({ ...fields, relationshipToFamily: value })
+                }
+                renderInput={(params) => (
+                  <TextField {...params} label="Relationship to Family" />
+                )}
+              />
             </Grid>
             <Grid item xs={12} sm={6}>
               <FormGroup row>

--- a/src/caretogether-pwa/src/Families/AdultFamilyRelationshipEditor.tsx
+++ b/src/caretogether-pwa/src/Families/AdultFamilyRelationshipEditor.tsx
@@ -1,12 +1,10 @@
 import {
+  Autocomplete,
   Checkbox,
-  FormControl,
   FormControlLabel,
   FormGroup,
   Grid,
-  InputLabel,
-  MenuItem,
-  Select,
+  TextField,
 } from '@mui/material';
 import { useDirectoryModel } from '../Model/DirectoryModel';
 import { useInlineEditor } from '../Hooks/useInlineEditor';
@@ -26,12 +24,17 @@ export function AdultFamilyRelationshipEditor({
 }: AdultFamilyRelationshipEditorProps) {
   const relationshipTypes = useRecoilValue(adultFamilyRelationshipsData);
   const directoryModel = useDirectoryModel();
+  const relationshipToFamilyDisplay =
+    relationship.relationshipToFamily || 'Not specified';
 
   const editor = useInlineEditor(
     async ({ isInHousehold, relationshipToFamily }) => {
       const valueToSave = new FamilyAdultRelationshipInfo();
       valueToSave.isInHousehold = isInHousehold;
-      valueToSave.relationshipToFamily = relationshipToFamily;
+      valueToSave.relationshipToFamily =
+        relationshipToFamily && relationshipToFamily.length > 0
+          ? relationshipToFamily
+          : undefined;
       await directoryModel.updateAdultRelationshipToFamily(
         familyId!,
         person.id!,
@@ -40,7 +43,7 @@ export function AdultFamilyRelationshipEditor({
     },
     {
       isInHousehold: relationship.isInHousehold,
-      relationshipToFamily: relationship.relationshipToFamily,
+      relationshipToFamily: relationship.relationshipToFamily ?? '',
     }
   );
 
@@ -49,32 +52,28 @@ export function AdultFamilyRelationshipEditor({
       {editor.editing ? (
         <>
           <Grid item xs={12} sm={6}>
-            <FormControl required fullWidth size="small">
-              <InputLabel id="family-relationship-label">
-                Relationship to Family
-              </InputLabel>
-              <Select
-                labelId="family-relationship-label"
-                label="Relationship to Family"
-                id="family-relationship"
-                value={editor.value?.relationshipToFamily}
-                onChange={(e) =>
-                  editor.setValue({
-                    isInHousehold: editor.value!.isInHousehold,
-                    relationshipToFamily: e.target.value as string,
-                  })
-                }
-              >
-                <MenuItem key="placeholder" value="" disabled>
-                  Select a relationship type
-                </MenuItem>
-                {relationshipTypes.map((relationshipType) => (
-                  <MenuItem key={relationshipType} value={relationshipType}>
-                    {relationshipType}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <Autocomplete
+              freeSolo
+              fullWidth
+              size="small"
+              options={relationshipTypes}
+              value={editor.value?.relationshipToFamily ?? ''}
+              onChange={(_, value) =>
+                editor.setValue({
+                  isInHousehold: editor.value!.isInHousehold,
+                  relationshipToFamily: value ?? '',
+                })
+              }
+              onInputChange={(_, value) =>
+                editor.setValue({
+                  isInHousehold: editor.value!.isInHousehold,
+                  relationshipToFamily: value,
+                })
+              }
+              renderInput={(params) => (
+                <TextField {...params} label="Relationship to Family" />
+              )}
+            />
           </Grid>
           <Grid item xs={12} sm={6}>
             <FormGroup row>
@@ -105,7 +104,7 @@ export function AdultFamilyRelationshipEditor({
         </>
       ) : (
         <Grid item xs={12}>
-          Relationship type: {relationship.relationshipToFamily},{' '}
+          Relationship type: {relationshipToFamilyDisplay},{' '}
           {relationship.isInHousehold ? 'household member' : 'not in household'}
           {editor.editButton}
         </Grid>

--- a/src/caretogether-pwa/src/Model/DirectoryModel.ts
+++ b/src/caretogether-pwa/src/Model/DirectoryModel.ts
@@ -560,7 +560,7 @@ export function useDirectoryModel() {
       age: Age | null,
       ethnicity: string | null,
       isInHousehold: boolean,
-      relationshipToFamily: string,
+      relationshipToFamily: string | null,
       address: Address | null,
       phoneNumber: string | null,
       phoneType: PhoneNumberType,
@@ -583,7 +583,7 @@ export function useDirectoryModel() {
           FamilyAdultRelationshipInfo,
           {
             isInHousehold: isInHousehold,
-            relationshipToFamily: relationshipToFamily,
+            relationshipToFamily: relationshipToFamily ?? undefined,
           }
         ),
         address: address ?? undefined,
@@ -647,7 +647,7 @@ export function useDirectoryModel() {
       age: Age | null,
       ethnicity: string | null,
       isInHousehold: boolean,
-      relationshipToFamily: string,
+      relationshipToFamily: string | null,
       address: Address | null,
       phoneNumber: string | null,
       phoneType: PhoneNumberType,
@@ -670,7 +670,7 @@ export function useDirectoryModel() {
           FamilyAdultRelationshipInfo,
           {
             isInHousehold: isInHousehold,
-            relationshipToFamily: relationshipToFamily,
+            relationshipToFamily: relationshipToFamily ?? undefined,
           }
         ),
         address: address == null ? undefined : address,

--- a/src/caretogether-pwa/src/V1Cases/CreatePartneringFamilyDrawer.tsx
+++ b/src/caretogether-pwa/src/V1Cases/CreatePartneringFamilyDrawer.tsx
@@ -196,17 +196,19 @@ export function CreatePartneringFamilyDrawer({
 
         <Grid item xs={12} sm={6}>
           <Autocomplete
+            freeSolo
             fullWidth
             size="small"
             options={relationshipTypes}
-            value={
-              relationshipTypes.find((r) => r === relationshipToFamily) ?? null
-            }
+            value={relationshipToFamily}
             onChange={(_, value) =>
               setFields({
                 ...fields,
                 relationshipToFamily: value ?? '',
               })
+            }
+            onInputChange={(_, value) =>
+              setFields({ ...fields, relationshipToFamily: value })
             }
             renderInput={(params) => (
               <TextField {...params} label="Relationship to Family" />

--- a/src/caretogether-pwa/src/Volunteers/CreateVolunteerFamilyDialog.tsx
+++ b/src/caretogether-pwa/src/Volunteers/CreateVolunteerFamilyDialog.tsx
@@ -13,6 +13,7 @@ import {
   FormGroup,
   FormLabel,
   Grid,
+  Autocomplete,
   InputAdornment,
   InputLabel,
   MenuItem,
@@ -98,9 +99,6 @@ export function CreateVolunteerFamilyDialog({
     await withBackdrop(async () => {
       if (firstName.length <= 0 || lastName.length <= 0) {
         alert('First and last name are required. Try again.');
-      } else if (relationshipToFamily === '') {
-        //TODO: Actual validation!
-        alert('Family relationship was not selected. Try again.');
       } else {
         const age = dateOfBirth == null ? null : new ExactAge();
         if (dateOfBirth != null) age!.dateOfBirth = dateOfBirth;
@@ -113,7 +111,7 @@ export function CreateVolunteerFamilyDialog({
           age,
           optional(ethnicity),
           isInHousehold,
-          relationshipToFamily,
+          optional(relationshipToFamily),
           address == null
             ? null
             : new Address({ ...address, id: crypto.randomUUID() }),
@@ -176,32 +174,25 @@ export function CreateVolunteerFamilyDialog({
               />
             </Grid>
             <Grid item xs={12} sm={6}>
-              <FormControl required fullWidth size="small">
-                <InputLabel id="family-relationship-label">
-                  Relationship to Family
-                </InputLabel>
-                <Select
-                  labelId="family-relationship-label"
-                  label="Relationship to Family"
-                  id="family-relationship"
-                  value={relationshipToFamily}
-                  onChange={(e) =>
-                    setFields({
-                      ...fields,
-                      relationshipToFamily: e.target.value as string,
-                    })
-                  }
-                >
-                  <MenuItem key="placeholder" value="" disabled>
-                    Select a relationship type
-                  </MenuItem>
-                  {relationshipTypes.map((relationshipType) => (
-                    <MenuItem key={relationshipType} value={relationshipType}>
-                      {relationshipType}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+              <Autocomplete
+                freeSolo
+                fullWidth
+                size="small"
+                options={relationshipTypes}
+                value={relationshipToFamily}
+                onChange={(_, value) =>
+                  setFields({
+                    ...fields,
+                    relationshipToFamily: value ?? '',
+                  })
+                }
+                onInputChange={(_, value) =>
+                  setFields({ ...fields, relationshipToFamily: value })
+                }
+                renderInput={(params) => (
+                  <TextField {...params} label="Relationship to Family" />
+                )}
+              />
             </Grid>
             <Grid item xs={12} sm={6}>
               <FormGroup row>


### PR DESCRIPTION
The field has been made optional when:

- Creating a new volunteer family
- Creating a new client family from referral flow
- Adding a new adult from the family screen
- Editing an adult’s family relationship 