### PR TITLE
Optimization records resource indexes no benchmarks

### DIFF
--- a/docs/records-authorization-performance.md
+++ b/docs/records-authorization-performance.md
@@ -1,0 +1,83 @@
+# Records Authorization Performance
+
+## Background
+
+The `/Records` endpoint was profiled with
+`/home/pablo/github/CareTogether/tfg-optimization/app_perf.speedscope.json`.
+The profile showed that records listing spent most of its CPU time repeatedly
+recalculating authorization and rebuilding filtered immutable collections.
+
+The biggest hotspots were:
+
+- `UserAccessCalculation.AuthorizeUserAccessAsync`
+- repeated `ImmutableList.CreateRange` calls inside authorization
+- repeated `ApprovalsResource.TryGetVolunteerFamilyAsync` calls
+- repeated `CombinedFamilyInfoFormatter.RenderCombinedFamilyInfoAsync` calls
+- repeated family disclosure authorization from `AuthorizationEngine.DiscloseFamilyAsync`
+
+The main issue was not one expensive permission rule. It was the request shape:
+`RecordsManager.ListVisibleAggregatesAsync` authorized every family, referral,
+and community independently, and family rendering then authorized the same family
+again during disclosure.
+
+## What Changed
+
+### Request-Scoped Authorization Snapshot
+
+`UserAccessCalculation` now supports a `UserAccessCalculationSnapshot`.
+
+The snapshot preloads the tenant and user data needed by authorization once per
+records-list request:
+
+- current user family
+- V1 cases grouped by partnering family id
+- V1 cases grouped by assigned volunteer family id
+- referrals by referral id
+- volunteer family ids
+- communities
+- community ids by family id
+- current user's community role assignments
+- permission sets applicable to the user's configured roles
+
+`RecordsManager.ListVisibleAggregatesAsync` creates this snapshot once and then
+uses synchronous snapshot evaluation for family, referral, and community
+visibility checks.
+
+### Reused Family Permissions During Disclosure
+
+`AuthorizationEngine.DiscloseFamilyAsync` now has an overload that accepts
+precomputed family permissions.
+
+`CombinedFamilyInfoFormatter.RenderCombinedFamilyInfoAsync` accepts optional
+precomputed permissions and passes them into disclosure when available.
+
+`RecordsManager.ListVisibleAggregatesAsync` now carries the permissions from the
+family visibility check into family rendering. This avoids recalculating family
+authorization during disclosure for records-list rendering.
+
+## Expected Impact
+
+The change reduces repeated work in the `/Records` request path:
+
+- fewer full-tenant V1 case scans during authorization
+- fewer repeated approval lookups for the same family ids
+- fewer repeated community membership scans
+- fewer immutable list materializations inside authorization
+- one family authorization pass for records visibility and disclosure instead of two
+
+This does not yet optimize every hotspot from the profile. In particular,
+family rendering still performs repeated resource-level filtering for notes,
+V1 cases, and referrals. Those are good follow-up candidates for model-level
+secondary indexes or a batch rendering context.
+
+## Verification
+
+The change was verified with:
+
+```bash
+dotnet test test/CareTogether.Core.Test/CareTogether.Core.Test.csproj --no-restore -nologo /nodeReuse:false /maxcpucount:1
+dotnet build CareTogetherCMS.sln --no-restore -nologo /nodeReuse:false /maxcpucount:1
+```
+
+Both commands passed. The solution build regenerated API/client artifacts through
+NSwag and reported no generated file changes.

--- a/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
@@ -928,18 +928,37 @@ namespace CareTogether.Engines.Authorization
                 new CommunityAuthorizationContext(community.Community.Id)
             );
 
-            return community with
-            {
-                Community = community.Community with
+            return await DiscloseCommunityAsync(
+                userContext,
+                organizationId,
+                locationId,
+                community,
+                contextPermissions
+            );
+        }
+
+        public Task<CommunityInfo> DiscloseCommunityAsync(
+            SessionUserContext userContext,
+            Guid organizationId,
+            Guid locationId,
+            CommunityInfo community,
+            ImmutableList<Permission> contextPermissions
+        )
+        {
+            return Task.FromResult(
+                community with
                 {
-                    UploadedDocuments = contextPermissions.Contains(
-                        Permission.ViewCommunityDocumentMetadata
-                    )
-                        ? community.Community.UploadedDocuments
-                        : ImmutableList<UploadedDocumentInfo>.Empty,
-                },
-                UserPermissions = contextPermissions,
-            };
+                    Community = community.Community with
+                    {
+                        UploadedDocuments = contextPermissions.Contains(
+                            Permission.ViewCommunityDocumentMetadata
+                        )
+                            ? community.Community.UploadedDocuments
+                            : ImmutableList<UploadedDocumentInfo>.Empty,
+                    },
+                    UserPermissions = contextPermissions,
+                }
+            );
         }
 
         internal PartneringFamilyInfo DisclosePartneringFamilyInfo(

--- a/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/AuthorizationEngine.cs
@@ -851,6 +851,23 @@ namespace CareTogether.Engines.Authorization
                 new FamilyAuthorizationContext(family.Family.Id, family.Family)
             );
 
+            return await DiscloseFamilyAsync(
+                userContext,
+                organizationId,
+                locationId,
+                family,
+                contextPermissions
+            );
+        }
+
+        public async Task<CombinedFamilyInfo> DiscloseFamilyAsync(
+            SessionUserContext userContext,
+            Guid organizationId,
+            Guid locationId,
+            CombinedFamilyInfo family,
+            ImmutableList<Permission> contextPermissions
+        )
+        {
             return family with
             {
                 PartneringFamilyInfo =

--- a/src/CareTogether.Core/Engines/Authorization/IAuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/IAuthorizationEngine.cs
@@ -130,6 +130,14 @@ namespace CareTogether.Engines.Authorization
             CombinedFamilyInfo family
         );
 
+        Task<CombinedFamilyInfo> DiscloseFamilyAsync(
+            SessionUserContext user,
+            Guid organizationId,
+            Guid locationId,
+            CombinedFamilyInfo family,
+            ImmutableList<Permission> contextPermissions
+        );
+
         Task<CommunityInfo> DiscloseCommunityAsync(
             SessionUserContext user,
             Guid organizationId,

--- a/src/CareTogether.Core/Engines/Authorization/IAuthorizationEngine.cs
+++ b/src/CareTogether.Core/Engines/Authorization/IAuthorizationEngine.cs
@@ -144,5 +144,13 @@ namespace CareTogether.Engines.Authorization
             Guid locationId,
             CommunityInfo community
         );
+
+        Task<CommunityInfo> DiscloseCommunityAsync(
+            SessionUserContext user,
+            Guid organizationId,
+            Guid locationId,
+            CommunityInfo community,
+            ImmutableList<Permission> contextPermissions
+        );
     }
 }

--- a/src/CareTogether.Core/Engines/Authorization/IUserAccessCalculation.cs
+++ b/src/CareTogether.Core/Engines/Authorization/IUserAccessCalculation.cs
@@ -1,16 +1,53 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using CareTogether.Resources.Communities;
+using CareTogether.Resources.Directory;
+using CareTogether.Resources.Policies;
+using CareTogether.Resources.V1Referrals;
 
 namespace CareTogether.Engines.Authorization
 {
+    public sealed record UserAccessCalculationSnapshot(
+        Guid OrganizationId,
+        Guid LocationId,
+        SessionUserContext UserContext,
+        Guid? UserPersonId,
+        Family? UserFamily,
+        ImmutableDictionary<Guid, Family> FamiliesById,
+        ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesByFamilyId,
+        ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesAssignedToVolunteerFamilyId,
+        ImmutableDictionary<Guid, V1Referral> V1ReferralsById,
+        ImmutableHashSet<Guid> VolunteerFamilyIds,
+        ImmutableList<Community> Communities,
+        ImmutableDictionary<Guid, ImmutableList<Guid>> CommunityIdsByFamilyId,
+        ImmutableList<(Guid Id, string CommunityRole)> UserCommunityRoleAssignments,
+        ImmutableList<ContextualPermissionSet> UserPermissionSets
+    );
+
     public interface IUserAccessCalculation
     {
         Task<ImmutableList<Permission>> AuthorizeUserAccessAsync(
             Guid organizationId,
             Guid locationId,
             SessionUserContext userContext,
+            AuthorizationContext context
+        );
+
+        Task<UserAccessCalculationSnapshot> CreateSnapshotAsync(
+            Guid organizationId,
+            Guid locationId,
+            SessionUserContext userContext,
+            IEnumerable<Family>? families = null,
+            IEnumerable<V1Referral>? referrals = null,
+            IEnumerable<Community>? communities = null,
+            IEnumerable<Guid>? volunteerFamilyIds = null
+        );
+
+        ImmutableList<Permission> AuthorizeUserAccess(
+            UserAccessCalculationSnapshot snapshot,
             AuthorizationContext context
         );
     }

--- a/src/CareTogether.Core/Engines/Authorization/IUserAccessCalculation.cs
+++ b/src/CareTogether.Core/Engines/Authorization/IUserAccessCalculation.cs
@@ -18,7 +18,10 @@ namespace CareTogether.Engines.Authorization
         Family? UserFamily,
         ImmutableDictionary<Guid, Family> FamiliesById,
         ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesByFamilyId,
-        ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesAssignedToVolunteerFamilyId,
+        ImmutableDictionary<
+            Guid,
+            ImmutableList<Resources.V1Cases.V1CaseEntry>
+        > V1CasesAssignedToVolunteerFamilyId,
         ImmutableDictionary<Guid, V1Referral> V1ReferralsById,
         ImmutableHashSet<Guid> VolunteerFamilyIds,
         ImmutableList<Community> Communities,

--- a/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
+++ b/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -59,132 +60,199 @@ namespace CareTogether.Engines.Authorization
             if (userLocalIdentity == null)
                 return ImmutableList<Permission>.Empty;
 
-            // Look up the user's family, which will be referenced several times.
-            var userPersonId = userContext.User.PersonId(organizationId, locationId);
-            var userFamily =
-                userContext.UserFamily
+            var familyContext = context as FamilyAuthorizationContext;
+            var targetFamily =
+                familyContext?.Family
                 ?? (
-                    userPersonId == null
+                    familyContext == null
                         ? null
-                        : await directoryResource.FindPersonFamilyAsync(
+                        : await directoryResource.FindFamilyAsync(
                             organizationId,
                             locationId,
-                            userPersonId.Value
+                            familyContext.FamilyId
                         )
                 );
+            var targetV1Referral =
+                context is V1ReferralAuthorizationContext referralContext
+                    ? await v1ReferralsResource.GetReferralAsync(
+                        organizationId,
+                        locationId,
+                        referralContext.ReferralId
+                    )
+                    : null;
+            var targetVolunteerFamily =
+                familyContext == null
+                    ? null
+                    : await approvalsResource.TryGetVolunteerFamilyAsync(
+                        organizationId,
+                        locationId,
+                        familyContext.FamilyId
+                    );
+            var snapshot = await CreateSnapshotAsync(
+                organizationId,
+                locationId,
+                userContext,
+                targetFamily == null ? null : [targetFamily],
+                targetV1Referral == null ? null : [targetV1Referral],
+                volunteerFamilyIds: targetVolunteerFamily == null ? [] : [targetVolunteerFamily.FamilyId]
+            );
 
-            // If in a family authorization context, look up the target family, which will be referenced several times.
-            var familyAuthorizationContext = context is FamilyAuthorizationContext fac ? fac : null;
+            return AuthorizeUserAccess(snapshot, context);
+        }
+
+        public async Task<UserAccessCalculationSnapshot> CreateSnapshotAsync(
+            Guid organizationId,
+            Guid locationId,
+            SessionUserContext userContext,
+            IEnumerable<Family>? families = null,
+            IEnumerable<V1Referral>? referrals = null,
+            IEnumerable<Community>? communities = null,
+            IEnumerable<Guid>? volunteerFamilyIds = null
+        )
+        {
+            var userPersonId = userContext.User.PersonId(organizationId, locationId);
+            var userFamilyTask =
+                userContext.UserFamily != null || userPersonId == null
+                    ? Task.FromResult(userContext.UserFamily)
+                    : directoryResource.FindPersonFamilyAsync(
+                        organizationId,
+                        locationId,
+                        userPersonId.Value
+                    );
+            var v1CasesTask = v1CasesResource.ListV1CasessAsync(organizationId, locationId);
+            var communitiesTask =
+                communities == null
+                    ? communitiesResource.ListLocationCommunitiesAsync(
+                        organizationId,
+                        locationId
+                    )
+                    : Task.FromResult(communities.ToImmutableList());
+            var volunteerFamilyIdsTask =
+                volunteerFamilyIds == null
+                    ? ListVolunteerFamilyIdsAsync(organizationId, locationId)
+                    : Task.FromResult(volunteerFamilyIds.ToArray());
+            var configTask = policiesResource.GetConfigurationAsync(organizationId);
+
+            var userFamily = await userFamilyTask;
+            var v1Cases = await v1CasesTask;
+            var locationCommunities = (await communitiesTask).ToImmutableList();
+            var knownVolunteerFamilyIds = (await volunteerFamilyIdsTask).ToImmutableHashSet();
+            var config = await configTask;
+            var userLocalIdentity = userContext.User.LocationIdentity(organizationId, locationId);
+            var userPermissionSets =
+                userLocalIdentity == null
+                    ? ImmutableList<ContextualPermissionSet>.Empty
+                    : config
+                        .Roles.Where(role =>
+                            userLocalIdentity.HasClaim(
+                                userLocalIdentity.RoleClaimType,
+                                role.RoleName
+                            )
+                        )
+                        .SelectMany(role => role.PermissionSets)
+                        .ToImmutableList();
+
+            return new UserAccessCalculationSnapshot(
+                organizationId,
+                locationId,
+                userContext,
+                userPersonId,
+                userFamily,
+                BuildFamiliesById(families, userFamily),
+                v1Cases.GroupBy(v1Case => v1Case.FamilyId)
+                    .ToImmutableDictionary(
+                        group => group.Key,
+                        group => group.ToImmutableList()
+                    ),
+                BuildV1CasesAssignedToVolunteerFamilyId(v1Cases),
+                (referrals ?? [])
+                    .ToImmutableDictionary(referral => referral.ReferralId, referral => referral),
+                knownVolunteerFamilyIds,
+                locationCommunities,
+                BuildCommunityIdsByFamilyId(locationCommunities),
+                BuildUserCommunityRoleAssignments(locationCommunities, userPersonId),
+                userPermissionSets
+            );
+        }
+
+        public ImmutableList<Permission> AuthorizeUserAccess(
+            UserAccessCalculationSnapshot snapshot,
+            AuthorizationContext context
+        )
+        {
+            if (
+                snapshot.UserContext.User.Identity?.AuthenticationType == "API Key"
+                && (
+                    snapshot.UserContext.User.HasClaim(
+                        Claims.OrganizationId,
+                        snapshot.OrganizationId.ToString()
+                    )
+                    || snapshot.UserContext.User.HasClaim(Claims.Global, true.ToString())
+                )
+            )
+                return Enum.GetValues<Permission>().ToImmutableList();
+
+            var userLocalIdentity = snapshot.UserContext.User.LocationIdentity(
+                snapshot.OrganizationId,
+                snapshot.LocationId
+            );
+            if (userLocalIdentity == null)
+                return ImmutableList<Permission>.Empty;
+
+            var familyAuthorizationContext = context as FamilyAuthorizationContext;
             var familyId = familyAuthorizationContext?.FamilyId;
             var targetFamily =
-                familyAuthorizationContext?.Family != null ? familyAuthorizationContext?.Family
-                : familyId.HasValue
-                    ? await directoryResource.FindFamilyAsync(
-                        organizationId,
-                        locationId,
-                        familyId.Value
-                    )
-                : null;
-
-            // Look up the target family's volunteer info to determine if they are a volunteer family.
+                familyAuthorizationContext?.Family
+                ?? (
+                    familyId.HasValue
+                    && snapshot.FamiliesById.TryGetValue(familyId.Value, out var family)
+                        ? family
+                        : null
+                );
             var targetFamilyIsVolunteerFamily =
-                familyId.HasValue
-                && await approvalsResource.TryGetVolunteerFamilyAsync(
-                    organizationId,
-                    locationId,
-                    familyId.Value
-                ) != null;
-
-            // Look up the v1 cases info for both the user's family and the target family.
-            //TODO: This could be optimized to find only the user family's v1 cases or the target family's v1 cases.
-            var v1Cases = await v1CasesResource.ListV1CasessAsync(organizationId, locationId);
-            var userFamilyV1Cases = v1Cases
-                .Where(v1Case => v1Case.FamilyId == userFamily?.Id)
-                .ToImmutableList();
-            var targetFamilyV1Cases = v1Cases
-                .Where(v1Case => v1Case.FamilyId == targetFamily?.Id)
-                .ToImmutableList();
-            var v1ReferralAuthorizationContext = context is V1ReferralAuthorizationContext vrac
-                ? vrac
-                : null;
+                familyId.HasValue && snapshot.VolunteerFamilyIds.Contains(familyId.Value);
+            var userFamilyV1Cases =
+                snapshot.UserFamily == null
+                    ? ImmutableList<Resources.V1Cases.V1CaseEntry>.Empty
+                    : snapshot.V1CasesByFamilyId.GetValueOrEmptyList(snapshot.UserFamily.Id);
+            var targetFamilyV1Cases =
+                targetFamily == null
+                    ? ImmutableList<Resources.V1Cases.V1CaseEntry>.Empty
+                    : snapshot.V1CasesByFamilyId.GetValueOrEmptyList(targetFamily.Id);
             var targetV1Referral =
-                v1ReferralAuthorizationContext == null
-                    ? null
-                    : await v1ReferralsResource.GetReferralAsync(
-                        organizationId,
-                        locationId,
-                        v1ReferralAuthorizationContext.ReferralId
+                context is V1ReferralAuthorizationContext referralContext
+                && snapshot.V1ReferralsById.TryGetValue(
+                    referralContext.ReferralId,
+                    out var referral
+                )
+                    ? referral
+                    : null;
+            var assignedV1Cases =
+                snapshot.UserFamily == null
+                    ? ImmutableList<Resources.V1Cases.V1CaseEntry>.Empty
+                    : snapshot.V1CasesAssignedToVolunteerFamilyId.GetValueOrEmptyList(
+                        snapshot.UserFamily.Id
                     );
-            var assignedV1Cases = v1Cases
-                .Where(v1Case =>
-                    v1Case.Arrangements.Any(arrangement =>
-                        arrangement.Value.FamilyVolunteerAssignments.Exists(assignment =>
-                            assignment.FamilyId == userFamily?.Id
-                        )
-                        || arrangement.Value.IndividualVolunteerAssignments.Exists(assignment =>
-                            assignment.FamilyId == userFamily?.Id
-                        )
-                    )
-                )
-                .ToImmutableList();
-
-            var targetFamilyAssignments = v1Cases
-                .Where(v1Case =>
-                    v1Case.Arrangements.Any(arrangement =>
-                        arrangement.Value.FamilyVolunteerAssignments.Exists(assignment =>
-                            assignment.FamilyId == targetFamily?.Id
-                        )
-                        || arrangement.Value.IndividualVolunteerAssignments.Exists(assignment =>
-                            assignment.FamilyId == targetFamily?.Id
-                        )
-                    )
-                )
-                .ToImmutableList();
-
-            // Look up the user's family's and target family's community memberships
-            var communities = await communitiesResource.ListLocationCommunitiesAsync(
-                organizationId,
-                locationId
-            );
+            var targetFamilyAssignments =
+                targetFamily == null
+                    ? ImmutableList<Resources.V1Cases.V1CaseEntry>.Empty
+                    : snapshot.V1CasesAssignedToVolunteerFamilyId.GetValueOrEmptyList(
+                        targetFamily.Id
+                    );
             var userFamilyCommunities =
-                userFamily != null
-                    ? communities
-                        .Where(community => community.MemberFamilies.Contains(userFamily.Id))
-                        .Select(community => community.Id)
-                        .ToImmutableList()
-                    : ImmutableList<Guid>.Empty;
+                snapshot.UserFamily == null
+                    ? ImmutableList<Guid>.Empty
+                    : snapshot.CommunityIdsByFamilyId.GetValueOrEmptyList(snapshot.UserFamily.Id);
             var targetFamilyCommunities =
-                targetFamily != null
-                    ? communities
-                        .Where(community => community.MemberFamilies.Contains(targetFamily.Id))
-                        .Select(community => community.Id)
-                        .ToImmutableList()
-                    : ImmutableList<Guid>.Empty;
-            var userCommunityRoleAssignments = communities
-                .SelectMany(community =>
-                    community
-                        .CommunityRoleAssignments.Where(assignment =>
-                            assignment.PersonId == userPersonId
-                        )
-                        .Select(assignment => (community.Id, assignment.CommunityRole))
-                )
-                .ToImmutableList();
-
-            // We need to evaluate each of the user's roles to determine which permission sets
-            // apply to the user's current context.
-            var config = await policiesResource.GetConfigurationAsync(organizationId);
-            var userPermissionSets = config
-                .Roles.Where(role =>
-                    userLocalIdentity.HasClaim(userLocalIdentity.RoleClaimType, role.RoleName)
-                )
-                .SelectMany(role => role.PermissionSets)
-                .ToImmutableList();
-            var applicablePermissionSets = userPermissionSets
+                targetFamily == null
+                    ? ImmutableList<Guid>.Empty
+                    : snapshot.CommunityIdsByFamilyId.GetValueOrEmptyList(targetFamily.Id);
+            var applicablePermissionSets = snapshot.UserPermissionSets
                 .Where(permissionSet =>
                     IsPermissionSetApplicable(
                         permissionSet,
                         context,
-                        userFamily,
+                        snapshot.UserFamily,
                         targetFamily,
                         targetFamilyIsVolunteerFamily,
                         userFamilyV1Cases,
@@ -192,11 +260,11 @@ namespace CareTogether.Engines.Authorization
                         assignedV1Cases,
                         targetFamilyAssignments,
                         targetV1Referral,
-                        userPersonId,
+                        snapshot.UserPersonId,
                         userFamilyCommunities,
                         targetFamilyCommunities,
-                        userCommunityRoleAssignments,
-                        communities
+                        snapshot.UserCommunityRoleAssignments,
+                        snapshot.Communities
                     )
                 )
                 .ToImmutableList();
@@ -204,6 +272,116 @@ namespace CareTogether.Engines.Authorization
             return applicablePermissionSets
                 .SelectMany(permissionSet => permissionSet.Permissions)
                 .Distinct()
+                .ToImmutableList();
+        }
+
+        private static ImmutableDictionary<Guid, Family> BuildFamiliesById(
+            IEnumerable<Family>? families,
+            Family? userFamily
+        )
+        {
+            var result = ImmutableDictionary<Guid, Family>.Empty;
+
+            foreach (var family in families ?? [])
+                result = result.SetItem(family.Id, family);
+
+            return userFamily == null ? result : result.SetItem(userFamily.Id, userFamily);
+        }
+
+        private async Task<Guid[]> ListVolunteerFamilyIdsAsync(
+            Guid organizationId,
+            Guid locationId
+        )
+        {
+            var volunteerFamilies = await approvalsResource.ListVolunteerFamiliesAsync(
+                organizationId,
+                locationId
+            );
+            return volunteerFamilies
+                .Select(volunteerFamily => volunteerFamily.FamilyId)
+                .ToArray();
+        }
+
+        private static ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> BuildV1CasesAssignedToVolunteerFamilyId(
+            IEnumerable<Resources.V1Cases.V1CaseEntry> v1Cases
+        )
+        {
+            var assignmentsByFamilyId = new Dictionary<Guid, List<Resources.V1Cases.V1CaseEntry>>();
+
+            foreach (var v1Case in v1Cases)
+            {
+                var assignedFamilyIds = v1Case
+                    .Arrangements.SelectMany(arrangement =>
+                        arrangement
+                            .Value.FamilyVolunteerAssignments.Select(assignment => assignment.FamilyId)
+                            .Concat(
+                                arrangement.Value.IndividualVolunteerAssignments.Select(assignment =>
+                                    assignment.FamilyId
+                                )
+                            )
+                    )
+                    .ToHashSet();
+
+                foreach (var assignedFamilyId in assignedFamilyIds)
+                {
+                    if (!assignmentsByFamilyId.TryGetValue(assignedFamilyId, out var assignedCases))
+                    {
+                        assignedCases = [];
+                        assignmentsByFamilyId.Add(assignedFamilyId, assignedCases);
+                    }
+
+                    assignedCases.Add(v1Case);
+                }
+            }
+
+            return assignmentsByFamilyId.ToImmutableDictionary(
+                x => x.Key,
+                x => x.Value.ToImmutableList()
+            );
+        }
+
+        private static ImmutableDictionary<Guid, ImmutableList<Guid>> BuildCommunityIdsByFamilyId(
+            IEnumerable<Community> communities
+        )
+        {
+            var communityIdsByFamilyId = new Dictionary<Guid, List<Guid>>();
+
+            foreach (var community in communities)
+            {
+                foreach (var familyId in community.MemberFamilies)
+                {
+                    if (!communityIdsByFamilyId.TryGetValue(familyId, out var communityIds))
+                    {
+                        communityIds = [];
+                        communityIdsByFamilyId.Add(familyId, communityIds);
+                    }
+
+                    communityIds.Add(community.Id);
+                }
+            }
+
+            return communityIdsByFamilyId.ToImmutableDictionary(
+                x => x.Key,
+                x => x.Value.ToImmutableList()
+            );
+        }
+
+        private static ImmutableList<(Guid Id, string CommunityRole)> BuildUserCommunityRoleAssignments(
+            IEnumerable<Community> communities,
+            Guid? userPersonId
+        )
+        {
+            if (userPersonId == null)
+                return [];
+
+            return communities
+                .SelectMany(community =>
+                    community
+                        .CommunityRoleAssignments.Where(assignment =>
+                            assignment.PersonId == userPersonId
+                        )
+                        .Select(assignment => (community.Id, assignment.CommunityRole))
+                )
                 .ToImmutableList();
         }
 

--- a/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
+++ b/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
@@ -60,26 +60,30 @@ namespace CareTogether.Engines.Authorization
             if (userLocalIdentity == null)
                 return ImmutableList<Permission>.Empty;
 
-            var familyContext = context as FamilyAuthorizationContext;
+            var familyContext =
+                context is FamilyAuthorizationContext
+                    ? context as FamilyAuthorizationContext
+                    : null;
+
             var targetFamily =
-                familyContext?.Family
-                ?? (
-                    familyContext == null
-                        ? null
-                        : await directoryResource.FindFamilyAsync(
+                familyContext == null
+                    ? null
+                    : familyContext.Family
+                        ?? await directoryResource.FindFamilyAsync(
                             organizationId,
                             locationId,
                             familyContext.FamilyId
-                        )
-                );
-            var targetV1Referral =
-                context is V1ReferralAuthorizationContext referralContext
-                    ? await v1ReferralsResource.GetReferralAsync(
-                        organizationId,
-                        locationId,
-                        referralContext.ReferralId
-                    )
-                    : null;
+                        );
+
+            var targetV1Referral = context is V1ReferralAuthorizationContext referralContext
+                ? await v1ReferralsResource.GetReferralAsync(
+                    organizationId,
+                    locationId,
+                    referralContext.ReferralId
+                )
+                : null;
+
+            // Look up the target family's volunteer info to determine if they are a volunteer family.
             var targetVolunteerFamily =
                 familyContext == null
                     ? null
@@ -88,13 +92,16 @@ namespace CareTogether.Engines.Authorization
                         locationId,
                         familyContext.FamilyId
                     );
+
             var snapshot = await CreateSnapshotAsync(
                 organizationId,
                 locationId,
                 userContext,
                 targetFamily == null ? null : [targetFamily],
                 targetV1Referral == null ? null : [targetV1Referral],
-                volunteerFamilyIds: targetVolunteerFamily == null ? [] : [targetVolunteerFamily.FamilyId]
+                volunteerFamilyIds: targetVolunteerFamily == null
+                    ? []
+                    : [targetVolunteerFamily.FamilyId]
             );
 
             return AuthorizeUserAccess(snapshot, context);
@@ -121,10 +128,7 @@ namespace CareTogether.Engines.Authorization
                     );
             var communitiesTask =
                 communities == null
-                    ? communitiesResource.ListLocationCommunitiesAsync(
-                        organizationId,
-                        locationId
-                    )
+                    ? communitiesResource.ListLocationCommunitiesAsync(organizationId, locationId)
                     : Task.FromResult(communities.ToImmutableList());
             var volunteerFamilyIdsTask =
                 volunteerFamilyIds == null
@@ -167,8 +171,10 @@ namespace CareTogether.Engines.Authorization
                 familiesById,
                 v1CaseIndexes.V1CasesByFamilyId,
                 v1CaseIndexes.V1CasesAssignedToVolunteerFamilyId,
-                (referrals ?? [])
-                    .ToImmutableDictionary(referral => referral.ReferralId, referral => referral),
+                (referrals ?? []).ToImmutableDictionary(
+                    referral => referral.ReferralId,
+                    referral => referral
+                ),
                 knownVolunteerFamilyIds,
                 locationCommunities,
                 BuildCommunityIdsByFamilyId(locationCommunities),
@@ -188,8 +194,7 @@ namespace CareTogether.Engines.Authorization
                     snapshot.UserContext.User.HasClaim(
                         Claims.OrganizationId,
                         snapshot.OrganizationId.ToString()
-                    )
-                    || snapshot.UserContext.User.HasClaim(Claims.Global, true.ToString())
+                    ) || snapshot.UserContext.User.HasClaim(Claims.Global, true.ToString())
                 )
             )
                 return Enum.GetValues<Permission>().ToImmutableList();
@@ -249,8 +254,8 @@ namespace CareTogether.Engines.Authorization
                 targetFamily == null
                     ? ImmutableList<Guid>.Empty
                     : snapshot.CommunityIdsByFamilyId.GetValueOrEmptyList(targetFamily.Id);
-            var applicablePermissionSets = snapshot.UserPermissionSets
-                .Where(permissionSet =>
+            var applicablePermissionSets = snapshot
+                .UserPermissionSets.Where(permissionSet =>
                     IsPermissionSetApplicable(
                         permissionSet,
                         context,
@@ -291,8 +296,14 @@ namespace CareTogether.Engines.Authorization
         }
 
         private async Task<(
-            ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesByFamilyId,
-            ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesAssignedToVolunteerFamilyId
+            ImmutableDictionary<
+                Guid,
+                ImmutableList<Resources.V1Cases.V1CaseEntry>
+            > V1CasesByFamilyId,
+            ImmutableDictionary<
+                Guid,
+                ImmutableList<Resources.V1Cases.V1CaseEntry>
+            > V1CasesAssignedToVolunteerFamilyId
         )> LoadV1CaseIndexesAsync(
             Guid organizationId,
             Guid locationId,
@@ -308,7 +319,8 @@ namespace CareTogether.Engines.Authorization
             {
                 var v1Cases = await v1CasesResource.ListV1CasessAsync(organizationId, locationId);
                 return (
-                    v1Cases.GroupBy(v1Case => v1Case.FamilyId)
+                    v1Cases
+                        .GroupBy(v1Case => v1Case.FamilyId)
                         .ToImmutableDictionary(
                             group => group.Key,
                             group => group.ToImmutableList()
@@ -352,21 +364,19 @@ namespace CareTogether.Engines.Authorization
             );
         }
 
-        private async Task<Guid[]> ListVolunteerFamilyIdsAsync(
-            Guid organizationId,
-            Guid locationId
-        )
+        private async Task<Guid[]> ListVolunteerFamilyIdsAsync(Guid organizationId, Guid locationId)
         {
             var volunteerFamilies = await approvalsResource.ListVolunteerFamiliesAsync(
                 organizationId,
                 locationId
             );
-            return volunteerFamilies
-                .Select(volunteerFamily => volunteerFamily.FamilyId)
-                .ToArray();
+            return volunteerFamilies.Select(volunteerFamily => volunteerFamily.FamilyId).ToArray();
         }
 
-        private static ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> BuildV1CasesAssignedToVolunteerFamilyId(
+        private static ImmutableDictionary<
+            Guid,
+            ImmutableList<Resources.V1Cases.V1CaseEntry>
+        > BuildV1CasesAssignedToVolunteerFamilyId(
             IEnumerable<Resources.V1Cases.V1CaseEntry> v1Cases
         )
         {
@@ -377,10 +387,12 @@ namespace CareTogether.Engines.Authorization
                 var assignedFamilyIds = v1Case
                     .Arrangements.SelectMany(arrangement =>
                         arrangement
-                            .Value.FamilyVolunteerAssignments.Select(assignment => assignment.FamilyId)
+                            .Value.FamilyVolunteerAssignments.Select(assignment =>
+                                assignment.FamilyId
+                            )
                             .Concat(
-                                arrangement.Value.IndividualVolunteerAssignments.Select(assignment =>
-                                    assignment.FamilyId
+                                arrangement.Value.IndividualVolunteerAssignments.Select(
+                                    assignment => assignment.FamilyId
                                 )
                             )
                     )
@@ -430,10 +442,10 @@ namespace CareTogether.Engines.Authorization
             );
         }
 
-        private static ImmutableList<(Guid Id, string CommunityRole)> BuildUserCommunityRoleAssignments(
-            IEnumerable<Community> communities,
-            Guid? userPersonId
-        )
+        private static ImmutableList<(
+            Guid Id,
+            string CommunityRole
+        )> BuildUserCommunityRoleAssignments(IEnumerable<Community> communities, Guid? userPersonId)
         {
             if (userPersonId == null)
                 return [];

--- a/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
+++ b/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
@@ -45,14 +45,7 @@ namespace CareTogether.Engines.Authorization
             AuthorizationContext context
         )
         {
-            // If the caller is using an API key, give full access.
-            if (
-                userContext.User.Identity?.AuthenticationType == "API Key"
-                && (
-                    userContext.User.HasClaim(Claims.OrganizationId, organizationId.ToString())
-                    || userContext.User.HasClaim(Claims.Global, true.ToString())
-                )
-            )
+            if (HasApiKeyFullAccess(userContext, organizationId))
                 return Enum.GetValues<Permission>().ToImmutableList();
 
             // The user must have access to this organization and location.
@@ -188,15 +181,7 @@ namespace CareTogether.Engines.Authorization
             AuthorizationContext context
         )
         {
-            if (
-                snapshot.UserContext.User.Identity?.AuthenticationType == "API Key"
-                && (
-                    snapshot.UserContext.User.HasClaim(
-                        Claims.OrganizationId,
-                        snapshot.OrganizationId.ToString()
-                    ) || snapshot.UserContext.User.HasClaim(Claims.Global, true.ToString())
-                )
-            )
+            if (HasApiKeyFullAccess(snapshot.UserContext, snapshot.OrganizationId))
                 return Enum.GetValues<Permission>().ToImmutableList();
 
             var userLocalIdentity = snapshot.UserContext.User.LocationIdentity(
@@ -280,6 +265,15 @@ namespace CareTogether.Engines.Authorization
                 .SelectMany(permissionSet => permissionSet.Permissions)
                 .Distinct()
                 .ToImmutableList();
+        }
+
+        private static bool HasApiKeyFullAccess(SessionUserContext userContext, Guid organizationId)
+        {
+            if (userContext.User.Identity?.AuthenticationType != "API Key")
+                return false;
+
+            return userContext.User.HasClaim(Claims.OrganizationId, organizationId.ToString())
+                || userContext.User.HasClaim(Claims.Global, true.ToString());
         }
 
         private static ImmutableDictionary<Guid, Family> BuildFamiliesById(

--- a/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
+++ b/src/CareTogether.Core/Engines/Authorization/UserAccessCalculation.cs
@@ -119,7 +119,6 @@ namespace CareTogether.Engines.Authorization
                         locationId,
                         userPersonId.Value
                     );
-            var v1CasesTask = v1CasesResource.ListV1CasessAsync(organizationId, locationId);
             var communitiesTask =
                 communities == null
                     ? communitiesResource.ListLocationCommunitiesAsync(
@@ -134,7 +133,6 @@ namespace CareTogether.Engines.Authorization
             var configTask = policiesResource.GetConfigurationAsync(organizationId);
 
             var userFamily = await userFamilyTask;
-            var v1Cases = await v1CasesTask;
             var locationCommunities = (await communitiesTask).ToImmutableList();
             var knownVolunteerFamilyIds = (await volunteerFamilyIdsTask).ToImmutableHashSet();
             var config = await configTask;
@@ -151,6 +149,14 @@ namespace CareTogether.Engines.Authorization
                         )
                         .SelectMany(role => role.PermissionSets)
                         .ToImmutableList();
+            var familiesById = BuildFamiliesById(families, userFamily);
+            var v1CaseIndexes = await LoadV1CaseIndexesAsync(
+                organizationId,
+                locationId,
+                volunteerFamilyIds == null,
+                familiesById.Keys,
+                knownVolunteerFamilyIds.Union(familiesById.Keys)
+            );
 
             return new UserAccessCalculationSnapshot(
                 organizationId,
@@ -158,13 +164,9 @@ namespace CareTogether.Engines.Authorization
                 userContext,
                 userPersonId,
                 userFamily,
-                BuildFamiliesById(families, userFamily),
-                v1Cases.GroupBy(v1Case => v1Case.FamilyId)
-                    .ToImmutableDictionary(
-                        group => group.Key,
-                        group => group.ToImmutableList()
-                    ),
-                BuildV1CasesAssignedToVolunteerFamilyId(v1Cases),
+                familiesById,
+                v1CaseIndexes.V1CasesByFamilyId,
+                v1CaseIndexes.V1CasesAssignedToVolunteerFamilyId,
                 (referrals ?? [])
                     .ToImmutableDictionary(referral => referral.ReferralId, referral => referral),
                 knownVolunteerFamilyIds,
@@ -286,6 +288,68 @@ namespace CareTogether.Engines.Authorization
                 result = result.SetItem(family.Id, family);
 
             return userFamily == null ? result : result.SetItem(userFamily.Id, userFamily);
+        }
+
+        private async Task<(
+            ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesByFamilyId,
+            ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesAssignedToVolunteerFamilyId
+        )> LoadV1CaseIndexesAsync(
+            Guid organizationId,
+            Guid locationId,
+            bool loadAllV1Cases,
+            IEnumerable<Guid> familyIds,
+            IEnumerable<Guid> assignedVolunteerFamilyIds
+        )
+        {
+            var familyIdSet = familyIds.ToImmutableHashSet();
+            var assignedVolunteerFamilyIdSet = assignedVolunteerFamilyIds.ToImmutableHashSet();
+
+            if (loadAllV1Cases)
+            {
+                var v1Cases = await v1CasesResource.ListV1CasessAsync(organizationId, locationId);
+                return (
+                    v1Cases.GroupBy(v1Case => v1Case.FamilyId)
+                        .ToImmutableDictionary(
+                            group => group.Key,
+                            group => group.ToImmutableList()
+                        ),
+                    BuildV1CasesAssignedToVolunteerFamilyId(v1Cases)
+                );
+            }
+
+            var v1CasesByFamilyTasks = familyIdSet
+                .Select(async familyId =>
+                    (
+                        familyId,
+                        v1Cases: await v1CasesResource.ListV1CasesForFamilyAsync(
+                            organizationId,
+                            locationId,
+                            familyId
+                        )
+                    )
+                )
+                .ToArray();
+            var assignedV1CasesByVolunteerFamilyTasks = assignedVolunteerFamilyIdSet
+                .Select(async volunteerFamilyId =>
+                    (
+                        volunteerFamilyId,
+                        v1Cases: await v1CasesResource.ListV1CasesAssignedToVolunteerFamilyAsync(
+                            organizationId,
+                            locationId,
+                            volunteerFamilyId
+                        )
+                    )
+                )
+                .ToArray();
+
+            return (
+                (await Task.WhenAll(v1CasesByFamilyTasks))
+                    .Where(x => !x.v1Cases.IsEmpty)
+                    .ToImmutableDictionary(x => x.familyId, x => x.v1Cases),
+                (await Task.WhenAll(assignedV1CasesByVolunteerFamilyTasks))
+                    .Where(x => !x.v1Cases.IsEmpty)
+                    .ToImmutableDictionary(x => x.volunteerFamilyId, x => x.v1Cases)
+            );
         }
 
         private async Task<Guid[]> ListVolunteerFamilyIdsAsync(

--- a/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
+++ b/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
@@ -89,27 +89,21 @@ namespace CareTogether.Managers
 
             return new(
                 locationPolicy,
-                notes.GroupBy(note => note.FamilyId)
-                    .ToImmutableDictionary(
-                        group => group.Key,
-                        group => group.ToImmutableList()
-                    ),
-                v1Cases.GroupBy(v1Case => v1Case.FamilyId)
-                    .ToImmutableDictionary(
-                        group => group.Key,
-                        group => group.ToImmutableList()
-                    ),
+                notes
+                    .GroupBy(note => note.FamilyId)
+                    .ToImmutableDictionary(group => group.Key, group => group.ToImmutableList()),
+                v1Cases
+                    .GroupBy(v1Case => v1Case.FamilyId)
+                    .ToImmutableDictionary(group => group.Key, group => group.ToImmutableList()),
                 BuildAssignedV1CasesByVolunteerFamilyId(v1Cases),
                 volunteerFamilies.ToImmutableDictionary(
                     volunteerFamily => volunteerFamily.FamilyId,
                     volunteerFamily => volunteerFamily
                 ),
-                locationReferrals.Where(referral => referral.FamilyId.HasValue)
+                locationReferrals
+                    .Where(referral => referral.FamilyId.HasValue)
                     .GroupBy(referral => referral.FamilyId!.Value)
-                    .ToImmutableDictionary(
-                        group => group.Key,
-                        group => group.ToImmutableList()
-                    )
+                    .ToImmutableDictionary(group => group.Key, group => group.ToImmutableList())
             );
         }
 
@@ -169,11 +163,7 @@ namespace CareTogether.Managers
                 );
             var notes =
                 renderingSnapshot?.NotesByFamilyId.GetValueOrEmptyList(familyId)
-                ?? await notesResource.ListFamilyNotesAsync(
-                    organizationId,
-                    locationId,
-                    familyId
-                );
+                ?? await notesResource.ListFamilyNotesAsync(organizationId, locationId, familyId);
             var renderedNotes = notes
                 .Select(note => new Note(
                     note.Id,
@@ -417,9 +407,7 @@ namespace CareTogether.Managers
             var combinedFamilyApprovals = approvalCalculation.ApprovalStatus;
 
             var v1CaseEntries =
-                renderingSnapshot?.AssignedV1CasesByVolunteerFamilyId.GetValueOrEmptyList(
-                    family.Id
-                )
+                renderingSnapshot?.AssignedV1CasesByVolunteerFamilyId.GetValueOrEmptyList(family.Id)
                 ?? await v1CasesResource.ListV1CasesAssignedToVolunteerFamilyAsync(
                     organizationId,
                     locationId,
@@ -443,11 +431,13 @@ namespace CareTogether.Managers
                 .Select(arrangementEntry => arrangementEntry.Value)
                 .ToImmutableList();
 
-            var completedCustomFields = (entry.CompletedCustomFields ?? ImmutableDictionary<string, CompletedCustomFieldInfo>.Empty)
-                .Values
-                .ToImmutableList();
+            var completedCustomFields = (
+                entry.CompletedCustomFields
+                ?? ImmutableDictionary<string, CompletedCustomFieldInfo>.Empty
+            ).Values.ToImmutableList();
 
-            var volunteerCustomFields = locationPolicy.VolunteerPolicy?.CustomFields ?? ImmutableList<CustomField>.Empty;
+            var volunteerCustomFields =
+                locationPolicy.VolunteerPolicy?.CustomFields ?? ImmutableList<CustomField>.Empty;
             var missingCustomFields = volunteerCustomFields
                 .Where(customField =>
                     !completedCustomFields.Any(completed =>
@@ -511,20 +501,19 @@ namespace CareTogether.Managers
             IEnumerable<Resources.V1Cases.V1CaseEntry> v1Cases
         )
         {
-            var assignmentsByFamilyId = new Dictionary<
-                Guid,
-                List<Resources.V1Cases.V1CaseEntry>
-            >();
+            var assignmentsByFamilyId = new Dictionary<Guid, List<Resources.V1Cases.V1CaseEntry>>();
 
             foreach (var v1Case in v1Cases)
             {
                 var assignedFamilyIds = v1Case
                     .Arrangements.SelectMany(arrangement =>
                         arrangement
-                            .Value.FamilyVolunteerAssignments.Select(assignment => assignment.FamilyId)
+                            .Value.FamilyVolunteerAssignments.Select(assignment =>
+                                assignment.FamilyId
+                            )
                             .Concat(
-                                arrangement.Value.IndividualVolunteerAssignments.Select(assignment =>
-                                    assignment.FamilyId
+                                arrangement.Value.IndividualVolunteerAssignments.Select(
+                                    assignment => assignment.FamilyId
                                 )
                             )
                     )

--- a/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
+++ b/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,6 +17,18 @@ using Nito.AsyncEx;
 
 namespace CareTogether.Managers
 {
+    public sealed record CombinedFamilyRenderingSnapshot(
+        EffectiveLocationPolicy LocationPolicy,
+        ImmutableDictionary<Guid, ImmutableList<NoteEntry>> NotesByFamilyId,
+        ImmutableDictionary<Guid, ImmutableList<Resources.V1Cases.V1CaseEntry>> V1CasesByFamilyId,
+        ImmutableDictionary<
+            Guid,
+            ImmutableList<Resources.V1Cases.V1CaseEntry>
+        > AssignedV1CasesByVolunteerFamilyId,
+        ImmutableDictionary<Guid, VolunteerFamilyEntry> VolunteerFamiliesByFamilyId,
+        ImmutableDictionary<Guid, ImmutableList<V1Referral>> ReferralsByFamilyId
+    );
+
     public class CombinedFamilyInfoFormatter
     {
         private readonly IPolicyEvaluationEngine policyEvaluationEngine;
@@ -51,6 +64,55 @@ namespace CareTogether.Managers
             this.accountsResource = accountsResource;
         }
 
+        public async Task<CombinedFamilyRenderingSnapshot> CreateRenderingSnapshotAsync(
+            Guid organizationId,
+            Guid locationId,
+            EffectiveLocationPolicy locationPolicy,
+            IEnumerable<V1Referral>? referrals = null
+        )
+        {
+            var notesTask = notesResource.ListNotesAsync(organizationId, locationId);
+            var v1CasesTask = v1CasesResource.ListV1CasessAsync(organizationId, locationId);
+            var volunteerFamiliesTask = approvalsResource.ListVolunteerFamiliesAsync(
+                organizationId,
+                locationId
+            );
+            var referralsTask =
+                referrals == null
+                    ? v1ReferralsResource.ListReferralsAsync(organizationId, locationId)
+                    : Task.FromResult(referrals.ToImmutableList());
+
+            var notes = await notesTask;
+            var v1Cases = await v1CasesTask;
+            var volunteerFamilies = await volunteerFamiliesTask;
+            var locationReferrals = await referralsTask;
+
+            return new(
+                locationPolicy,
+                notes.GroupBy(note => note.FamilyId)
+                    .ToImmutableDictionary(
+                        group => group.Key,
+                        group => group.ToImmutableList()
+                    ),
+                v1Cases.GroupBy(v1Case => v1Case.FamilyId)
+                    .ToImmutableDictionary(
+                        group => group.Key,
+                        group => group.ToImmutableList()
+                    ),
+                BuildAssignedV1CasesByVolunteerFamilyId(v1Cases),
+                volunteerFamilies.ToImmutableDictionary(
+                    volunteerFamily => volunteerFamily.FamilyId,
+                    volunteerFamily => volunteerFamily
+                ),
+                locationReferrals.Where(referral => referral.FamilyId.HasValue)
+                    .GroupBy(referral => referral.FamilyId!.Value)
+                    .ToImmutableDictionary(
+                        group => group.Key,
+                        group => group.ToImmutableList()
+                    )
+            );
+        }
+
         public async Task<CombinedFamilyInfo?> RenderCombinedFamilyInfoAsync(
             Guid organizationId,
             EffectiveLocationPolicy locationPolicy,
@@ -58,7 +120,8 @@ namespace CareTogether.Managers
             Guid familyId,
             Family? family,
             SessionUserContext userContext,
-            ImmutableList<Permission>? contextPermissions = null
+            ImmutableList<Permission>? contextPermissions = null,
+            CombinedFamilyRenderingSnapshot? renderingSnapshot = null
         )
         {
             family =
@@ -92,16 +155,25 @@ namespace CareTogether.Managers
             var partneringFamilyInfo = await RenderPartneringFamilyInfoAsync(
                 organizationId,
                 locationId,
-                family
+                family,
+                renderingSnapshot
             );
 
             var (volunteerFamilyInfo, uploadedApprovalDocuments) =
-                await RenderVolunteerFamilyInfoAsync(organizationId, locationId, locationPolicy, family);
-            var notes = await notesResource.ListFamilyNotesAsync(
-                organizationId,
-                locationId,
-                familyId
-            );
+                await RenderVolunteerFamilyInfoAsync(
+                    organizationId,
+                    locationId,
+                    renderingSnapshot?.LocationPolicy ?? locationPolicy,
+                    family,
+                    renderingSnapshot
+                );
+            var notes =
+                renderingSnapshot?.NotesByFamilyId.GetValueOrEmptyList(familyId)
+                ?? await notesResource.ListFamilyNotesAsync(
+                    organizationId,
+                    locationId,
+                    familyId
+                );
             var renderedNotes = notes
                 .Select(note => new Note(
                     note.Id,
@@ -203,20 +275,29 @@ namespace CareTogether.Managers
         private async Task<PartneringFamilyInfo?> RenderPartneringFamilyInfoAsync(
             Guid organizationId,
             Guid locationId,
-            Family family
+            Family family,
+            CombinedFamilyRenderingSnapshot? renderingSnapshot
         )
         {
-            var v1CaseEntries = (
-                await v1CasesResource.ListV1CasessAsync(organizationId, locationId)
-            )
-                .Where(r => r.FamilyId == family.Id)
-                .ToImmutableList();
+            var v1CaseEntries =
+                renderingSnapshot?.V1CasesByFamilyId.GetValueOrEmptyList(family.Id)
+                ?? await v1CasesResource.ListV1CasesForFamilyAsync(
+                    organizationId,
+                    locationId,
+                    family.Id
+                );
 
             if (v1CaseEntries.Count == 0)
             {
-                var hasLinkedReferral = (
-                    await v1ReferralsResource.ListReferralsAsync(organizationId, locationId)
-                ).Any(referral => referral.FamilyId == family.Id);
+                var hasLinkedReferral =
+                    renderingSnapshot?.ReferralsByFamilyId.GetValueOrEmptyList(family.Id).Any()
+                    ?? (
+                        await v1ReferralsResource.ListReferralsForFamilyAsync(
+                            organizationId,
+                            locationId,
+                            family.Id
+                        )
+                    ).Any();
 
                 if (!hasLinkedReferral)
                     return null;
@@ -303,13 +384,25 @@ namespace CareTogether.Managers
         private async Task<(
             VolunteerFamilyInfo?,
             ImmutableList<UploadedDocumentInfo>
-        )> RenderVolunteerFamilyInfoAsync(Guid organizationId, Guid locationId, EffectiveLocationPolicy locationPolicy, Family family)
+        )> RenderVolunteerFamilyInfoAsync(
+            Guid organizationId,
+            Guid locationId,
+            EffectiveLocationPolicy locationPolicy,
+            Family family,
+            CombinedFamilyRenderingSnapshot? renderingSnapshot
+        )
         {
-            var entry = await approvalsResource.TryGetVolunteerFamilyAsync(
-                organizationId,
-                locationId,
-                family.Id
-            );
+            var entry =
+                renderingSnapshot?.VolunteerFamiliesByFamilyId.TryGetValue(
+                    family.Id,
+                    out var snapshotEntry
+                ) == true
+                    ? snapshotEntry
+                    : await approvalsResource.TryGetVolunteerFamilyAsync(
+                        organizationId,
+                        locationId,
+                        family.Id
+                    );
 
             if (entry == null)
                 return (null, ImmutableList<UploadedDocumentInfo>.Empty);
@@ -323,9 +416,15 @@ namespace CareTogether.Managers
                 );
             var combinedFamilyApprovals = approvalCalculation.ApprovalStatus;
 
-            var v1CaseEntries = (
-                await v1CasesResource.ListV1CasessAsync(organizationId, locationId)
-            ).ToImmutableList();
+            var v1CaseEntries =
+                renderingSnapshot?.AssignedV1CasesByVolunteerFamilyId.GetValueOrEmptyList(
+                    family.Id
+                )
+                ?? await v1CasesResource.ListV1CasesAssignedToVolunteerFamilyAsync(
+                    organizationId,
+                    locationId,
+                    family.Id
+                );
 
             var assignments = v1CaseEntries
                 .SelectMany(entry => entry.Arrangements)
@@ -403,6 +502,50 @@ namespace CareTogether.Managers
             );
 
             return (volunteerFamilyInfo, entry.UploadedDocuments);
+        }
+
+        private static ImmutableDictionary<
+            Guid,
+            ImmutableList<Resources.V1Cases.V1CaseEntry>
+        > BuildAssignedV1CasesByVolunteerFamilyId(
+            IEnumerable<Resources.V1Cases.V1CaseEntry> v1Cases
+        )
+        {
+            var assignmentsByFamilyId = new Dictionary<
+                Guid,
+                List<Resources.V1Cases.V1CaseEntry>
+            >();
+
+            foreach (var v1Case in v1Cases)
+            {
+                var assignedFamilyIds = v1Case
+                    .Arrangements.SelectMany(arrangement =>
+                        arrangement
+                            .Value.FamilyVolunteerAssignments.Select(assignment => assignment.FamilyId)
+                            .Concat(
+                                arrangement.Value.IndividualVolunteerAssignments.Select(assignment =>
+                                    assignment.FamilyId
+                                )
+                            )
+                    )
+                    .ToHashSet();
+
+                foreach (var assignedFamilyId in assignedFamilyIds)
+                {
+                    if (!assignmentsByFamilyId.TryGetValue(assignedFamilyId, out var assignedCases))
+                    {
+                        assignedCases = [];
+                        assignmentsByFamilyId.Add(assignedFamilyId, assignedCases);
+                    }
+
+                    assignedCases.Add(v1Case);
+                }
+            }
+
+            return assignmentsByFamilyId.ToImmutableDictionary(
+                x => x.Key,
+                x => x.Value.ToImmutableList()
+            );
         }
     }
 }

--- a/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
+++ b/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
@@ -57,7 +57,8 @@ namespace CareTogether.Managers
             Guid locationId,
             Guid familyId,
             Family? family,
-            SessionUserContext userContext
+            SessionUserContext userContext,
+            ImmutableList<Permission>? contextPermissions = null
         )
         {
             family =
@@ -180,12 +181,21 @@ namespace CareTogether.Managers
                 ImmutableList<Permission>.Empty
             );
 
-            var disclosedFamily = await authorizationEngine.DiscloseFamilyAsync(
-                userContext,
-                organizationId,
-                locationId,
-                renderedFamily
-            );
+            var disclosedFamily =
+                contextPermissions == null
+                    ? await authorizationEngine.DiscloseFamilyAsync(
+                        userContext,
+                        organizationId,
+                        locationId,
+                        renderedFamily
+                    )
+                    : await authorizationEngine.DiscloseFamilyAsync(
+                        userContext,
+                        organizationId,
+                        locationId,
+                        renderedFamily,
+                        contextPermissions
+                    );
 
             return disclosedFamily;
         }

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -102,25 +102,14 @@ namespace CareTogether.Managers.Records
         {
             var userContext = await CreateSessionUserContext(user, organizationId, locationId);
             var familiesTask = directoryResource.ListFamiliesAsync(organizationId, locationId);
-            var locationPolicyTask = policiesResource.GetCurrentPolicy(
-                organizationId,
-                locationId
-            );
+            var locationPolicyTask = policiesResource.GetCurrentPolicy(organizationId, locationId);
             var communitiesTask = communitiesResource.ListLocationCommunitiesAsync(
                 organizationId,
                 locationId
             );
-            var referralsTask = v1ReferralsResource.ListReferralsAsync(
-                organizationId,
-                locationId
-            );
+            var referralsTask = v1ReferralsResource.ListReferralsAsync(organizationId, locationId);
 
-            await Task.WhenAll(
-                familiesTask,
-                locationPolicyTask,
-                communitiesTask,
-                referralsTask
-            );
+            await Task.WhenAll(familiesTask, locationPolicyTask, communitiesTask, referralsTask);
             var families = await familiesTask;
             var locationPolicy = await locationPolicyTask;
             var communities = await communitiesTask;
@@ -150,19 +139,18 @@ namespace CareTogether.Managers.Records
             );
 
             var visibleFamilies = (
-                families
-                    .Select(family =>
-                    {
-                        var permissions = userAccessCalculation.AuthorizeUserAccess(
-                            authorizationSnapshot,
-                            new FamilyAuthorizationContext(family.Id, family)
-                        );
-                        return (
-                            family,
-                            permissions,
-                            hasPermissions: permissions.Except(irrelevantPermissions).Any()
-                        );
-                    })
+                families.Select(family =>
+                {
+                    var permissions = userAccessCalculation.AuthorizeUserAccess(
+                        authorizationSnapshot,
+                        new FamilyAuthorizationContext(family.Id, family)
+                    );
+                    return (
+                        family,
+                        permissions,
+                        hasPermissions: permissions.Except(irrelevantPermissions).Any()
+                    );
+                })
             ).Where(x => x.hasPermissions).ToImmutableList();
 
             var renderedFamilies = (
@@ -210,19 +198,18 @@ namespace CareTogether.Managers.Records
             ).WhereNotNull().ToImmutableList();
 
             var visibleCommunities = (
-                communities
-                    .Select(community =>
-                    {
-                        var permissions = userAccessCalculation.AuthorizeUserAccess(
-                            authorizationSnapshot,
-                            new CommunityAuthorizationContext(community.Id)
-                        );
-                        return (
-                            community,
-                            permissions,
-                            hasPermissions: permissions.Except(irrelevantPermissions).Any()
-                        );
-                    })
+                communities.Select(community =>
+                {
+                    var permissions = userAccessCalculation.AuthorizeUserAccess(
+                        authorizationSnapshot,
+                        new CommunityAuthorizationContext(community.Id)
+                    );
+                    return (
+                        community,
+                        permissions,
+                        hasPermissions: permissions.Except(irrelevantPermissions).Any()
+                    );
+                })
             ).Where(x => x.hasPermissions).ToImmutableList();
 
             var renderedCommunities = await visibleCommunities
@@ -233,7 +220,10 @@ namespace CareTogether.Managers.Records
                         userContext,
                         organizationId,
                         locationId,
-                        new CommunityInfo(communityAccess.community, ImmutableList<Permission>.Empty),
+                        new CommunityInfo(
+                            communityAccess.community,
+                            ImmutableList<Permission>.Empty
+                        ),
                         communityAccess.permissions
                     );
                     return new CommunityRecordsAggregate(renderedCommunity);
@@ -1008,8 +998,8 @@ namespace CareTogether.Managers.Records
                 locationId
             );
             var assignmentPolicy =
-                locationPolicy.V1ReferralPolicy.FunctionAssignmentPolicies.SingleOrDefault(
-                    policy => policy.AssignmentRole == assignIndividualVolunteer.AssignmentRole
+                locationPolicy.V1ReferralPolicy.FunctionAssignmentPolicies.SingleOrDefault(policy =>
+                    policy.AssignmentRole == assignIndividualVolunteer.AssignmentRole
                 );
 
             if (assignmentPolicy == null)

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -133,6 +133,12 @@ namespace CareTogether.Managers.Records
                 referrals,
                 communities
             );
+            var renderingSnapshot = await combinedFamilyInfoFormatter.CreateRenderingSnapshotAsync(
+                organizationId,
+                locationId,
+                locationPolicy,
+                referrals
+            );
 
             // The following permissions should not be construed as granting access to an actual aggregate.
             //TODO: More of this logic should be handled by the AuthorizationEngine.
@@ -171,7 +177,8 @@ namespace CareTogether.Managers.Records
                                 familyAccess.family.Id,
                                 familyAccess.family,
                                 userContext,
-                                familyAccess.permissions.ToImmutableList()
+                                familyAccess.permissions.ToImmutableList(),
+                                renderingSnapshot
                             );
                         if (renderedFamily == null)
                             return null;
@@ -212,20 +219,22 @@ namespace CareTogether.Managers.Records
                         );
                         return (
                             community,
+                            permissions,
                             hasPermissions: permissions.Except(irrelevantPermissions).Any()
                         );
                     })
-            ).Where(x => x.hasPermissions).Select(x => x.community).ToImmutableList();
+            ).Where(x => x.hasPermissions).ToImmutableList();
 
             var renderedCommunities = await visibleCommunities
-                .Select(async community =>
+                .Select(async communityAccess =>
                 {
                     //TODO: Rendering actions (e.g., permissions - which can be on a base aggregate type along with ID!)
                     var renderedCommunity = await authorizationEngine.DiscloseCommunityAsync(
                         userContext,
                         organizationId,
                         locationId,
-                        new CommunityInfo(community, ImmutableList<Permission>.Empty)
+                        new CommunityInfo(communityAccess.community, ImmutableList<Permission>.Empty),
+                        communityAccess.permissions
                     );
                     return new CommunityRecordsAggregate(renderedCommunity);
                 })

--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -101,10 +101,37 @@ namespace CareTogether.Managers.Records
         )
         {
             var userContext = await CreateSessionUserContext(user, organizationId, locationId);
-
-            var locationPolicy = await policiesResource.GetCurrentPolicy(
+            var familiesTask = directoryResource.ListFamiliesAsync(organizationId, locationId);
+            var locationPolicyTask = policiesResource.GetCurrentPolicy(
                 organizationId,
                 locationId
+            );
+            var communitiesTask = communitiesResource.ListLocationCommunitiesAsync(
+                organizationId,
+                locationId
+            );
+            var referralsTask = v1ReferralsResource.ListReferralsAsync(
+                organizationId,
+                locationId
+            );
+
+            await Task.WhenAll(
+                familiesTask,
+                locationPolicyTask,
+                communitiesTask,
+                referralsTask
+            );
+            var families = await familiesTask;
+            var locationPolicy = await locationPolicyTask;
+            var communities = await communitiesTask;
+            var referrals = await referralsTask;
+            var authorizationSnapshot = await userAccessCalculation.CreateSnapshotAsync(
+                organizationId,
+                locationId,
+                userContext,
+                families,
+                referrals,
+                communities
             );
 
             // The following permissions should not be construed as granting access to an actual aggregate.
@@ -116,38 +143,35 @@ namespace CareTogether.Managers.Records
                 Permission.AccessVolunteersScreen
             );
 
-            var families = await directoryResource.ListFamiliesAsync(organizationId, locationId);
-
             var visibleFamilies = (
-                await families
-                    .Select(async family =>
+                families
+                    .Select(family =>
                     {
-                        var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
-                            organizationId,
-                            locationId,
-                            userContext,
+                        var permissions = userAccessCalculation.AuthorizeUserAccess(
+                            authorizationSnapshot,
                             new FamilyAuthorizationContext(family.Id, family)
                         );
                         return (
                             family,
+                            permissions,
                             hasPermissions: permissions.Except(irrelevantPermissions).Any()
                         );
                     })
-                    .WhenAll()
-            ).Where(x => x.hasPermissions).Select(x => x.family).ToImmutableList();
+            ).Where(x => x.hasPermissions).ToImmutableList();
 
             var renderedFamilies = (
                 await visibleFamilies
-                    .Select(async family =>
+                    .Select(async familyAccess =>
                     {
                         var renderedFamily =
                             await combinedFamilyInfoFormatter.RenderCombinedFamilyInfoAsync(
                                 organizationId,
                                 locationPolicy,
                                 locationId,
-                                family.Id,
-                                family,
-                                userContext
+                                familyAccess.family.Id,
+                                familyAccess.family,
+                                userContext,
+                                familyAccess.permissions.ToImmutableList()
                             );
                         if (renderedFamily == null)
                             return null;
@@ -156,24 +180,12 @@ namespace CareTogether.Managers.Records
                     .WhenAll()
             ).WhereNotNull().ToImmutableList();
 
-            var communities = await communitiesResource.ListLocationCommunitiesAsync(
-                organizationId,
-                locationId
-            );
-
-            var referrals = await v1ReferralsResource.ListReferralsAsync(
-                organizationId,
-                locationId
-            );
-
             var renderedReferrals = (
                 await referrals
                     .Select(async referral =>
                     {
-                        var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
-                            organizationId,
-                            locationId,
-                            userContext,
+                        var permissions = userAccessCalculation.AuthorizeUserAccess(
+                            authorizationSnapshot,
                             new V1ReferralAuthorizationContext(referral.ReferralId)
                         );
                         if (!permissions.Contains(Permission.ViewV1Referral))
@@ -191,13 +203,11 @@ namespace CareTogether.Managers.Records
             ).WhereNotNull().ToImmutableList();
 
             var visibleCommunities = (
-                await communities
-                    .Select(async community =>
+                communities
+                    .Select(community =>
                     {
-                        var permissions = await userAccessCalculation.AuthorizeUserAccessAsync(
-                            organizationId,
-                            locationId,
-                            userContext,
+                        var permissions = userAccessCalculation.AuthorizeUserAccess(
+                            authorizationSnapshot,
                             new CommunityAuthorizationContext(community.Id)
                         );
                         return (
@@ -205,7 +215,6 @@ namespace CareTogether.Managers.Records
                             hasPermissions: permissions.Except(irrelevantPermissions).Any()
                         );
                     })
-                    .WhenAll()
             ).Where(x => x.hasPermissions).Select(x => x.community).ToImmutableList();
 
             var renderedCommunities = await visibleCommunities

--- a/src/CareTogether.Core/Resources/Notes/INotesResource.cs
+++ b/src/CareTogether.Core/Resources/Notes/INotesResource.cs
@@ -76,6 +76,8 @@ namespace CareTogether.Resources.Notes
     /// </summary>
     public interface INotesResource
     {
+        Task<ImmutableList<NoteEntry>> ListNotesAsync(Guid organizationId, Guid locationId);
+
         Task<ImmutableList<NoteEntry>> ListFamilyNotesAsync(
             Guid organizationId,
             Guid locationId,

--- a/src/CareTogether.Core/Resources/Notes/NotesModel.cs
+++ b/src/CareTogether.Core/Resources/Notes/NotesModel.cs
@@ -24,6 +24,8 @@ namespace CareTogether.Resources.Notes
             Guid,
             NoteEntry
         >.Empty;
+        private ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> noteIdsByFamilyId =
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>>.Empty;
 
         public long LastKnownSequenceNumber { get; private set; } = -1;
 
@@ -157,10 +159,16 @@ namespace CareTogether.Resources.Notes
                 OnCommit: () =>
                 {
                     LastKnownSequenceNumber++;
+                    notes.TryGetValue(command.NoteId, out var existingNoteEntry);
                     notes =
                         noteEntryToUpsert == null
                             ? notes.Remove(command.NoteId)
                             : notes.SetItem(command.NoteId, noteEntryToUpsert);
+                    noteIdsByFamilyId = UpdateFamilyNoteIndex(
+                        noteIdsByFamilyId,
+                        existingNoteEntry,
+                        noteEntryToUpsert
+                    );
                 }
             );
         }
@@ -170,7 +178,60 @@ namespace CareTogether.Resources.Notes
             return notes.Values.Where(predicate).ToImmutableList();
         }
 
+        public ImmutableList<NoteEntry> GetFamilyNoteEntries(Guid familyId)
+        {
+            return noteIdsByFamilyId.TryGetValue(familyId, out var noteIds)
+                ? noteIds.Select(noteId => notes[noteId]).ToImmutableList()
+                : ImmutableList<NoteEntry>.Empty;
+        }
+
         public NoteEntry GetNoteEntry(Guid noteId) => notes[noteId];
+
+        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> UpdateFamilyNoteIndex(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            NoteEntry? previousEntry,
+            NoteEntry? nextEntry
+        )
+        {
+            var result = index;
+
+            if (previousEntry != null)
+                result = RemoveFamilyNoteId(result, previousEntry.FamilyId, previousEntry.Id);
+
+            if (nextEntry != null)
+                result = AddFamilyNoteId(result, nextEntry.FamilyId, nextEntry.Id);
+
+            return result;
+        }
+
+        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> AddFamilyNoteId(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            Guid familyId,
+            Guid noteId
+        )
+        {
+            return index.SetItem(
+                familyId,
+                index.TryGetValue(familyId, out var existingNoteIds)
+                    ? existingNoteIds.Add(noteId)
+                    : ImmutableSortedSet.Create(noteId)
+            );
+        }
+
+        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> RemoveFamilyNoteId(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            Guid familyId,
+            Guid noteId
+        )
+        {
+            if (!index.TryGetValue(familyId, out var existingNoteIds))
+                return index;
+
+            var updatedNoteIds = existingNoteIds.Remove(noteId);
+            return updatedNoteIds.IsEmpty
+                ? index.Remove(familyId)
+                : index.SetItem(familyId, updatedNoteIds);
+        }
 
         private void ReplayEvent(NotesEvent domainEvent, long sequenceNumber)
         {

--- a/src/CareTogether.Core/Resources/Notes/NotesResource.cs
+++ b/src/CareTogether.Core/Resources/Notes/NotesResource.cs
@@ -119,7 +119,20 @@ namespace CareTogether.Resources.Notes
                 var lockedModel = await tenantModels.ReadLockItemAsync((organizationId, locationId))
             )
             {
-                return lockedModel.Value.FindNoteEntries(note => note.FamilyId == familyId);
+                return lockedModel.Value.GetFamilyNoteEntries(familyId);
+            }
+        }
+
+        public async Task<ImmutableList<NoteEntry>> ListNotesAsync(
+            Guid organizationId,
+            Guid locationId
+        )
+        {
+            using (
+                var lockedModel = await tenantModels.ReadLockItemAsync((organizationId, locationId))
+            )
+            {
+                return lockedModel.Value.FindNoteEntries(_ => true);
             }
         }
     }

--- a/src/CareTogether.Core/Resources/Referrals/IReferralsResource.cs
+++ b/src/CareTogether.Core/Resources/Referrals/IReferralsResource.cs
@@ -515,6 +515,18 @@ namespace CareTogether.Resources.V1Cases
     {
         Task<ImmutableList<V1CaseEntry>> ListV1CasessAsync(Guid organizationId, Guid locationId);
 
+        Task<ImmutableList<V1CaseEntry>> ListV1CasesForFamilyAsync(
+            Guid organizationId,
+            Guid locationId,
+            Guid familyId
+        );
+
+        Task<ImmutableList<V1CaseEntry>> ListV1CasesAssignedToVolunteerFamilyAsync(
+            Guid organizationId,
+            Guid locationId,
+            Guid volunteerFamilyId
+        );
+
         Task<V1CaseEntry> ExecuteV1CaseCommandAsync(
             Guid organizationId,
             Guid locationId,

--- a/src/CareTogether.Core/Resources/Referrals/ReferralModel.cs
+++ b/src/CareTogether.Core/Resources/Referrals/ReferralModel.cs
@@ -83,8 +83,13 @@ namespace CareTogether.Resources.V1Cases
         >.Empty;
         private ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> v1CaseIdsByFamilyId =
             ImmutableDictionary<Guid, ImmutableSortedSet<Guid>>.Empty;
-        private ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> v1CaseIdsByAssignedVolunteerFamilyId =
-            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>>.Empty;
+        private ImmutableDictionary<
+            Guid,
+            ImmutableSortedSet<Guid>
+        > v1CaseIdsByAssignedVolunteerFamilyId = ImmutableDictionary<
+            Guid,
+            ImmutableSortedSet<Guid>
+        >.Empty;
 
         public long LastKnownSequenceNumber { get; private set; } = -1;
 
@@ -273,23 +278,16 @@ namespace CareTogether.Resources.V1Cases
                         History =
                             v1CaseEntryToUpsert.Item2 == null
                                 ? v1CaseEntryToUpsert.Item1.History
-                                : v1CaseEntryToUpsert.Item1.History.Add(
-                                    v1CaseEntryToUpsert.Item2
-                                ),
+                                : v1CaseEntryToUpsert.Item1.History.Add(v1CaseEntryToUpsert.Item2),
                     };
-                    v1Cases = v1Cases.SetItem(
-                        updatedV1CaseEntry.Id,
-                        updatedV1CaseEntry
-                    );
-                    (
-                        v1CaseIdsByFamilyId,
-                        v1CaseIdsByAssignedVolunteerFamilyId
-                    ) = UpdateV1CaseIndexes(
-                        v1CaseIdsByFamilyId,
-                        v1CaseIdsByAssignedVolunteerFamilyId,
-                        existingV1CaseEntry,
-                        updatedV1CaseEntry
-                    );
+                    v1Cases = v1Cases.SetItem(updatedV1CaseEntry.Id, updatedV1CaseEntry);
+                    (v1CaseIdsByFamilyId, v1CaseIdsByAssignedVolunteerFamilyId) =
+                        UpdateV1CaseIndexes(
+                            v1CaseIdsByFamilyId,
+                            v1CaseIdsByAssignedVolunteerFamilyId,
+                            existingV1CaseEntry,
+                            updatedV1CaseEntry
+                        );
                 }
             );
         }
@@ -911,15 +909,13 @@ namespace CareTogether.Resources.V1Cases
                     LastKnownSequenceNumber++;
                     v1Cases.TryGetValue(v1CaseEntryToUpsert.Id, out var existingV1CaseEntry);
                     v1Cases = v1Cases.SetItem(v1CaseEntryToUpsert.Id, v1CaseEntryToUpsert);
-                    (
-                        v1CaseIdsByFamilyId,
-                        v1CaseIdsByAssignedVolunteerFamilyId
-                    ) = UpdateV1CaseIndexes(
-                        v1CaseIdsByFamilyId,
-                        v1CaseIdsByAssignedVolunteerFamilyId,
-                        existingV1CaseEntry,
-                        v1CaseEntryToUpsert
-                    );
+                    (v1CaseIdsByFamilyId, v1CaseIdsByAssignedVolunteerFamilyId) =
+                        UpdateV1CaseIndexes(
+                            v1CaseIdsByFamilyId,
+                            v1CaseIdsByAssignedVolunteerFamilyId,
+                            existingV1CaseEntry,
+                            v1CaseEntryToUpsert
+                        );
                 }
             );
         }
@@ -1090,7 +1086,10 @@ namespace CareTogether.Resources.V1Cases
             ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> V1CaseIdsByAssignedVolunteerFamilyId
         ) UpdateV1CaseIndexes(
             ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> v1CaseIdsByFamilyId,
-            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> v1CaseIdsByAssignedVolunteerFamilyId,
+            ImmutableDictionary<
+                Guid,
+                ImmutableSortedSet<Guid>
+            > v1CaseIdsByAssignedVolunteerFamilyId,
             V1CaseEntry? previousEntry,
             V1CaseEntry nextEntry
         )
@@ -1106,7 +1105,9 @@ namespace CareTogether.Resources.V1Cases
                     previousEntry.Id
                 );
 
-                foreach (var assignedVolunteerFamilyId in GetAssignedVolunteerFamilyIds(previousEntry))
+                foreach (
+                    var assignedVolunteerFamilyId in GetAssignedVolunteerFamilyIds(previousEntry)
+                )
                 {
                     updatedV1CaseIdsByAssignedVolunteerFamilyId = RemoveIndexedV1CaseId(
                         updatedV1CaseIdsByAssignedVolunteerFamilyId,
@@ -1131,10 +1132,7 @@ namespace CareTogether.Resources.V1Cases
                 );
             }
 
-            return (
-                updatedV1CaseIdsByFamilyId,
-                updatedV1CaseIdsByAssignedVolunteerFamilyId
-            );
+            return (updatedV1CaseIdsByFamilyId, updatedV1CaseIdsByAssignedVolunteerFamilyId);
         }
 
         private static ImmutableHashSet<Guid> GetAssignedVolunteerFamilyIds(V1CaseEntry entry) =>

--- a/src/CareTogether.Core/Resources/Referrals/ReferralModel.cs
+++ b/src/CareTogether.Core/Resources/Referrals/ReferralModel.cs
@@ -81,6 +81,10 @@ namespace CareTogether.Resources.V1Cases
             Guid,
             V1CaseEntry
         >.Empty;
+        private ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> v1CaseIdsByFamilyId =
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>>.Empty;
+        private ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> v1CaseIdsByAssignedVolunteerFamilyId =
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>>.Empty;
 
         public long LastKnownSequenceNumber { get; private set; } = -1;
 
@@ -263,17 +267,28 @@ namespace CareTogether.Resources.V1Cases
                 OnCommit: () =>
                 {
                     LastKnownSequenceNumber++;
+                    v1Cases.TryGetValue(v1CaseEntryToUpsert.Item1.Id, out var existingV1CaseEntry);
+                    var updatedV1CaseEntry = v1CaseEntryToUpsert.Item1 with
+                    {
+                        History =
+                            v1CaseEntryToUpsert.Item2 == null
+                                ? v1CaseEntryToUpsert.Item1.History
+                                : v1CaseEntryToUpsert.Item1.History.Add(
+                                    v1CaseEntryToUpsert.Item2
+                                ),
+                    };
                     v1Cases = v1Cases.SetItem(
-                        v1CaseEntryToUpsert.Item1.Id,
-                        v1CaseEntryToUpsert.Item1 with
-                        {
-                            History =
-                                v1CaseEntryToUpsert.Item2 == null
-                                    ? v1CaseEntryToUpsert.Item1.History
-                                    : v1CaseEntryToUpsert.Item1.History.Add(
-                                        v1CaseEntryToUpsert.Item2
-                                    ),
-                        }
+                        updatedV1CaseEntry.Id,
+                        updatedV1CaseEntry
+                    );
+                    (
+                        v1CaseIdsByFamilyId,
+                        v1CaseIdsByAssignedVolunteerFamilyId
+                    ) = UpdateV1CaseIndexes(
+                        v1CaseIdsByFamilyId,
+                        v1CaseIdsByAssignedVolunteerFamilyId,
+                        existingV1CaseEntry,
+                        updatedV1CaseEntry
                     );
                 }
             );
@@ -894,7 +909,17 @@ namespace CareTogether.Resources.V1Cases
                 OnCommit: () =>
                 {
                     LastKnownSequenceNumber++;
+                    v1Cases.TryGetValue(v1CaseEntryToUpsert.Id, out var existingV1CaseEntry);
                     v1Cases = v1Cases.SetItem(v1CaseEntryToUpsert.Id, v1CaseEntryToUpsert);
+                    (
+                        v1CaseIdsByFamilyId,
+                        v1CaseIdsByAssignedVolunteerFamilyId
+                    ) = UpdateV1CaseIndexes(
+                        v1CaseIdsByFamilyId,
+                        v1CaseIdsByAssignedVolunteerFamilyId,
+                        existingV1CaseEntry,
+                        v1CaseEntryToUpsert
+                    );
                 }
             );
         }
@@ -973,7 +998,24 @@ namespace CareTogether.Resources.V1Cases
             return v1Cases.Values.Where(predicate).ToImmutableList();
         }
 
+        public ImmutableList<V1CaseEntry> GetV1CaseEntriesForFamily(Guid familyId) =>
+            GetIndexedV1CaseEntries(v1CaseIdsByFamilyId, familyId);
+
+        public ImmutableList<V1CaseEntry> GetV1CaseEntriesAssignedToVolunteerFamily(
+            Guid volunteerFamilyId
+        ) => GetIndexedV1CaseEntries(v1CaseIdsByAssignedVolunteerFamilyId, volunteerFamilyId);
+
         public V1CaseEntry GetV1CaseEntry(Guid v1CaseId) => v1Cases[v1CaseId];
+
+        private ImmutableList<V1CaseEntry> GetIndexedV1CaseEntries(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            Guid familyId
+        )
+        {
+            return index.TryGetValue(familyId, out var v1CaseIds)
+                ? v1CaseIds.Select(v1CaseId => v1Cases[v1CaseId]).ToImmutableList()
+                : ImmutableList<V1CaseEntry>.Empty;
+        }
 
         private static string FormatV1CaseCloseReason(V1CaseCloseReason closeReason) =>
             closeReason switch
@@ -1015,7 +1057,7 @@ namespace CareTogether.Resources.V1Cases
             if (v1CaseEntry.CloseReason == null)
                 throw new InvalidOperationException("The case is already open.");
 
-            var familyCases = v1Cases.Values.Where(x => x.FamilyId == command.FamilyId).ToList();
+            var familyCases = GetV1CaseEntriesForFamily(command.FamilyId).ToList();
 
             var hasAnotherOpenCase = familyCases.Any(x =>
                 x.Id != command.ReferralId && x.CloseReason == null
@@ -1041,6 +1083,100 @@ namespace CareTogether.Resources.V1Cases
                 CloseReason = null,
                 ClosedAtUtc = null,
             };
+        }
+
+        private static (
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> V1CaseIdsByFamilyId,
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> V1CaseIdsByAssignedVolunteerFamilyId
+        ) UpdateV1CaseIndexes(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> v1CaseIdsByFamilyId,
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> v1CaseIdsByAssignedVolunteerFamilyId,
+            V1CaseEntry? previousEntry,
+            V1CaseEntry nextEntry
+        )
+        {
+            var updatedV1CaseIdsByFamilyId = v1CaseIdsByFamilyId;
+            var updatedV1CaseIdsByAssignedVolunteerFamilyId = v1CaseIdsByAssignedVolunteerFamilyId;
+
+            if (previousEntry != null)
+            {
+                updatedV1CaseIdsByFamilyId = RemoveIndexedV1CaseId(
+                    updatedV1CaseIdsByFamilyId,
+                    previousEntry.FamilyId,
+                    previousEntry.Id
+                );
+
+                foreach (var assignedVolunteerFamilyId in GetAssignedVolunteerFamilyIds(previousEntry))
+                {
+                    updatedV1CaseIdsByAssignedVolunteerFamilyId = RemoveIndexedV1CaseId(
+                        updatedV1CaseIdsByAssignedVolunteerFamilyId,
+                        assignedVolunteerFamilyId,
+                        previousEntry.Id
+                    );
+                }
+            }
+
+            updatedV1CaseIdsByFamilyId = AddIndexedV1CaseId(
+                updatedV1CaseIdsByFamilyId,
+                nextEntry.FamilyId,
+                nextEntry.Id
+            );
+
+            foreach (var assignedVolunteerFamilyId in GetAssignedVolunteerFamilyIds(nextEntry))
+            {
+                updatedV1CaseIdsByAssignedVolunteerFamilyId = AddIndexedV1CaseId(
+                    updatedV1CaseIdsByAssignedVolunteerFamilyId,
+                    assignedVolunteerFamilyId,
+                    nextEntry.Id
+                );
+            }
+
+            return (
+                updatedV1CaseIdsByFamilyId,
+                updatedV1CaseIdsByAssignedVolunteerFamilyId
+            );
+        }
+
+        private static ImmutableHashSet<Guid> GetAssignedVolunteerFamilyIds(V1CaseEntry entry) =>
+            entry
+                .Arrangements.SelectMany(arrangement =>
+                    arrangement
+                        .Value.FamilyVolunteerAssignments.Select(assignment => assignment.FamilyId)
+                        .Concat(
+                            arrangement.Value.IndividualVolunteerAssignments.Select(assignment =>
+                                assignment.FamilyId
+                            )
+                        )
+                )
+                .ToImmutableHashSet();
+
+        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> AddIndexedV1CaseId(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            Guid familyId,
+            Guid v1CaseId
+        )
+        {
+            return index.SetItem(
+                familyId,
+                index.TryGetValue(familyId, out var existingV1CaseIds)
+                    ? existingV1CaseIds.Add(v1CaseId)
+                    : ImmutableSortedSet.Create(v1CaseId)
+            );
+        }
+
+        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> RemoveIndexedV1CaseId(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            Guid familyId,
+            Guid v1CaseId
+        )
+        {
+            if (!index.TryGetValue(familyId, out var existingV1CaseIds))
+                return index;
+
+            var updatedV1CaseIds = existingV1CaseIds.Remove(v1CaseId);
+            return updatedV1CaseIds.IsEmpty
+                ? index.Remove(familyId)
+                : index.SetItem(familyId, updatedV1CaseIds);
         }
 
         private void ReplayEvent(V1CaseEvent domainEvent, long sequenceNumber)

--- a/src/CareTogether.Core/Resources/Referrals/ReferralsResource.cs
+++ b/src/CareTogether.Core/Resources/Referrals/ReferralsResource.cs
@@ -99,5 +99,35 @@ namespace CareTogether.Resources.V1Cases
                 return lockedModel.Value.FindV1CaseEntries(_ => true);
             }
         }
+
+        public async Task<ImmutableList<V1CaseEntry>> ListV1CasesForFamilyAsync(
+            Guid organizationId,
+            Guid locationId,
+            Guid familyId
+        )
+        {
+            using (
+                var lockedModel = await tenantModels.ReadLockItemAsync((organizationId, locationId))
+            )
+            {
+                return lockedModel.Value.GetV1CaseEntriesForFamily(familyId);
+            }
+        }
+
+        public async Task<ImmutableList<V1CaseEntry>> ListV1CasesAssignedToVolunteerFamilyAsync(
+            Guid organizationId,
+            Guid locationId,
+            Guid volunteerFamilyId
+        )
+        {
+            using (
+                var lockedModel = await tenantModels.ReadLockItemAsync((organizationId, locationId))
+            )
+            {
+                return lockedModel.Value.GetV1CaseEntriesAssignedToVolunteerFamily(
+                    volunteerFamilyId
+                );
+            }
+        }
     }
 }

--- a/src/CareTogether.Core/Resources/V1Referrals/IV1ReferralsResource.cs
+++ b/src/CareTogether.Core/Resources/V1Referrals/IV1ReferralsResource.cs
@@ -136,6 +136,12 @@ namespace CareTogether.Resources.V1Referrals
 
         Task<ImmutableList<V1Referral>> ListReferralsAsync(Guid organizationId, Guid locationId);
 
+        Task<ImmutableList<V1Referral>> ListReferralsForFamilyAsync(
+            Guid organizationId,
+            Guid locationId,
+            Guid familyId
+        );
+
         Task<Uri> GetV1ReferralDocumentReadValetUrl(
             Guid organizationId,
             Guid locationId,

--- a/src/CareTogether.Core/Resources/V1Referrals/V1ReferralModel.cs
+++ b/src/CareTogether.Core/Resources/V1Referrals/V1ReferralModel.cs
@@ -438,7 +438,10 @@ namespace CareTogether.Resources.V1Referrals
             return existingReferral;
         }
 
-        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> UpdateFamilyReferralIndex(
+        private static ImmutableDictionary<
+            Guid,
+            ImmutableSortedSet<Guid>
+        > UpdateFamilyReferralIndex(
             ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
             V1Referral? previousReferral,
             V1Referral nextReferral

--- a/src/CareTogether.Core/Resources/V1Referrals/V1ReferralModel.cs
+++ b/src/CareTogether.Core/Resources/V1Referrals/V1ReferralModel.cs
@@ -66,6 +66,8 @@ namespace CareTogether.Resources.V1Referrals
             Guid,
             V1Referral
         >.Empty;
+        private ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> referralIdsByFamilyId =
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>>.Empty;
 
         public long LastKnownSequenceNumber { get; private set; } = -1;
 
@@ -102,7 +104,13 @@ namespace CareTogether.Resources.V1Referrals
                 OnCommit: () =>
                 {
                     LastKnownSequenceNumber++;
+                    referrals.TryGetValue(updatedReferral.ReferralId, out var existingReferral);
                     referrals = referrals.SetItem(updatedReferral.ReferralId, updatedReferral);
+                    referralIdsByFamilyId = UpdateFamilyReferralIndex(
+                        referralIdsByFamilyId,
+                        existingReferral,
+                        updatedReferral
+                    );
                 }
             );
         }
@@ -112,6 +120,13 @@ namespace CareTogether.Resources.V1Referrals
 
         public ImmutableList<V1Referral> FindReferrals(Func<V1Referral, bool> predicate) =>
             referrals.Values.Where(predicate).ToImmutableList();
+
+        public ImmutableList<V1Referral> GetFamilyReferrals(Guid familyId)
+        {
+            return referralIdsByFamilyId.TryGetValue(familyId, out var referralIds)
+                ? referralIds.Select(referralId => referrals[referralId]).ToImmutableList()
+                : ImmutableList<V1Referral>.Empty;
+        }
 
         private (V1Referral Referral, Activity? Activity) ExecuteCommand(
             V1ReferralCommand command,
@@ -421,6 +436,58 @@ namespace CareTogether.Resources.V1Referrals
                 throw new InvalidOperationException("Closed referrals cannot be edited.");
 
             return existingReferral;
+        }
+
+        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> UpdateFamilyReferralIndex(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            V1Referral? previousReferral,
+            V1Referral nextReferral
+        )
+        {
+            var result = index;
+
+            if (previousReferral != null)
+            {
+                if (previousReferral.FamilyId != null)
+                    result = RemoveFamilyReferralId(
+                        result,
+                        previousReferral.FamilyId.Value,
+                        previousReferral.ReferralId
+                    );
+            }
+
+            return nextReferral.FamilyId == null
+                ? result
+                : AddFamilyReferralId(result, nextReferral.FamilyId.Value, nextReferral.ReferralId);
+        }
+
+        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> AddFamilyReferralId(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            Guid familyId,
+            Guid referralId
+        )
+        {
+            return index.SetItem(
+                familyId,
+                index.TryGetValue(familyId, out var existingReferralIds)
+                    ? existingReferralIds.Add(referralId)
+                    : ImmutableSortedSet.Create(referralId)
+            );
+        }
+
+        private static ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> RemoveFamilyReferralId(
+            ImmutableDictionary<Guid, ImmutableSortedSet<Guid>> index,
+            Guid familyId,
+            Guid referralId
+        )
+        {
+            if (!index.TryGetValue(familyId, out var existingReferralIds))
+                return index;
+
+            var updatedReferralIds = existingReferralIds.Remove(referralId);
+            return updatedReferralIds.IsEmpty
+                ? index.Remove(familyId)
+                : index.SetItem(familyId, updatedReferralIds);
         }
 
         private void ReplayEvent(V1ReferralEvent domainEvent, long sequenceNumber)

--- a/src/CareTogether.Core/Resources/V1Referrals/V1ReferralsResource.cs
+++ b/src/CareTogether.Core/Resources/V1Referrals/V1ReferralsResource.cs
@@ -86,6 +86,20 @@ namespace CareTogether.Resources.V1Referrals
             }
         }
 
+        public async Task<ImmutableList<V1Referral>> ListReferralsForFamilyAsync(
+            Guid organizationId,
+            Guid locationId,
+            Guid familyId
+        )
+        {
+            using (
+                var lockedModel = await tenantModels.ReadLockItemAsync((organizationId, locationId))
+            )
+            {
+                return lockedModel.Value.GetFamilyReferrals(familyId);
+            }
+        }
+
         public async Task<Uri> GetV1ReferralDocumentReadValetUrl(
             Guid organizationId,
             Guid locationId,

--- a/src/CareTogether.Core/Utilities/EventLog/AppendBlobEventLog.cs
+++ b/src/CareTogether.Core/Utilities/EventLog/AppendBlobEventLog.cs
@@ -119,28 +119,24 @@ namespace CareTogether.Utilities.EventLog
 
                 var appendBlob = tenantContainer.GetAppendBlobClient(blob.Name);
 
-                var eventStream = await appendBlob.OpenReadAsync();
+                using var eventStream = await appendBlob.OpenReadAsync();
+                using var reader = new StreamReader(eventStream);
 
-                var eventString = new StreamReader(eventStream).ReadToEnd();
+                string? line;
 
-                using (var reader = new StringReader(eventString))
+                while ((line = await reader.ReadLineAsync()) != null)
                 {
-                    string? line;
+                    eventSequenceNumber++;
 
-                    while ((line = reader.ReadLine()) != null)
-                    {
-                        eventSequenceNumber++;
+                    var item = JsonConvert.DeserializeObject<T>(line);
 
-                        var item = JsonConvert.DeserializeObject<T>(line);
-
-                        yield return item == null
-                            ? throw new InvalidOperationException(
-                                $"Unexpected null object deserialized in organization {organizationId}, location {locationId}, "
-                                    + $"log type {logType}, blob '{blob.Name}', event sequence # {eventSequenceNumber}. "
-                                    + $"Expected type: {typeof(T).FullName}"
-                            )
-                            : (item, eventSequenceNumber);
-                    }
+                    yield return item == null
+                        ? throw new InvalidOperationException(
+                            $"Unexpected null object deserialized in organization {organizationId}, location {locationId}, "
+                                + $"log type {logType}, blob '{blob.Name}', event sequence # {eventSequenceNumber}. "
+                                + $"Expected type: {typeof(T).FullName}"
+                        )
+                        : (item, eventSequenceNumber);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Improves `/Records` performance by replacing repeated per-aggregate authorization and resource scans with request-scoped snapshots and model-maintained indexes.

The changes are based on the captured CPU profile and local benchmark runs against the same large records dataset.

## Changes

- Preload authorization inputs once per records request and evaluate family, referral, and community visibility from a `UserAccessCalculationSnapshot`.
- Reuse precomputed family and community permissions during disclosure instead of recalculating authorization.
- Create a family-rendering snapshot for notes, V1 cases, volunteer-family approvals, and referrals.
- Maintain secondary indexes for notes by family, V1 cases by family and assigned volunteer family, and referrals by family.
- Add targeted resource lookups so non-snapshot callers avoid full collection scans.
- Stream append-blob event logs asynchronously line by line instead of buffering each blob in memory.
- Document the profiling findings, implementation, expected impact, and remaining opportunities in `docs/records-authorization-performance.md`.

## Expected Impact

- Fewer full-tenant scans and immutable collection materializations during authorization.
- Fewer repeated approval, note, V1 case, and referral lookups while rendering families.
- One authorization pass for records visibility and disclosure where permissions can be reused.
- Lower peak memory use while replaying append-blob event logs.

## Benchmark Results

The benchmark exercised the same `/Records` endpoint and location for every run. Timings are from the `IRecordsManager.ListVisibleAggregatesAsync` boundary in `../tfg-optimization/benchmark-records-boundaries.csv`.

| Version | Runs | Mean | Range |
| --- | ---: | ---: | ---: |
| Baseline (`base-run-*`) | 4 | 63.390 s | 59.985-65.449 s |
| Authorization snapshot only (`auth*`) | 4 | 27.898 s | 27.125-29.513 s |
| Final indexed implementation (`indexes-*`) | 3 | 1.490 s | 1.467-1.525 s |

Compared with the baseline, the final implementation is **42.5x faster** and reduces measured records-list time by **97.65%**.

The resource indexes and rendering snapshot account for a further **18.7x improvement** over the authorization-snapshot-only version. In the final runs:

- `ListFamilyNotesAsync` calls fell from 5,757 to zero, replaced by one bulk `ListNotesAsync` call.
- `ListV1CasessAsync` calls fell from 22,281 to 2.
- `ListReferralsAsync` calls fell from 4,931 to 1.
- `ListLocationCommunitiesAsync` calls fell from 11,597 to 1.
- `AuthorizeUserAccessAsync` calls fell from 11,596 to zero, replaced by one request-scoped snapshot and synchronous evaluations.

## Verification

The branch was also verified with:

```bash
dotnet test test/CareTogether.Core.Test/CareTogether.Core.Test.csproj --no-restore -nologo /nodeReuse:false /maxcpucount:1
dotnet build CareTogetherCMS.sln --no-restore -nologo /nodeReuse:false /maxcpucount:1
```

The solution build regenerated the API/client artifacts through NSwag with no generated file changes.
