### PR TITLE
Contain wide tables within page height

### DIFF
--- a/src/caretogether-pwa/src/Utilities/WideTableContainer.tsx
+++ b/src/caretogether-pwa/src/Utilities/WideTableContainer.tsx
@@ -1,0 +1,29 @@
+import { TableContainer } from '@mui/material';
+import { ReactNode } from 'react';
+
+type WideTableContainerProps = {
+  children: ReactNode;
+};
+
+function WideTableContainer(props: WideTableContainerProps) {
+  const { children } = props;
+
+  return (
+    <TableContainer
+      sx={{
+        borderBottom: '1px solid rgba(224, 224, 224, 1)',
+        flex: 1,
+        maxWidth: '100%',
+        minHeight: 0,
+        overflow: 'auto',
+        overflowX: 'auto',
+        overflowY: 'auto',
+        WebkitOverflowScrolling: 'touch',
+      }}
+    >
+      {children}
+    </TableContainer>
+  );
+}
+
+export { WideTableContainer };

--- a/src/caretogether-pwa/src/Utilities/stickyHeaderTableSx.ts
+++ b/src/caretogether-pwa/src/Utilities/stickyHeaderTableSx.ts
@@ -14,3 +14,11 @@ export const stickyHeaderTableSx = {
     py: { xs: 1, sm: 1.5 },
   },
 };
+
+export const containedStickyHeaderTableSx = {
+  ...stickyHeaderTableSx,
+  '& .MuiTableCell-stickyHeader': {
+    ...stickyHeaderTableSx['& .MuiTableCell-stickyHeader'],
+    top: 0,
+  },
+};

--- a/src/caretogether-pwa/src/Utilities/wideTablePageSx.ts
+++ b/src/caretogether-pwa/src/Utilities/wideTablePageSx.ts
@@ -1,0 +1,43 @@
+const FEATUREBASE_CHAT_WIDGET_SAFE_HEIGHT = 96;
+const MOBILE_BOTTOM_NAVIGATION_HEIGHT = 56;
+const MOBILE_BOTTOM_SAFE_HEIGHT =
+  FEATUREBASE_CHAT_WIDGET_SAFE_HEIGHT + MOBILE_BOTTOM_NAVIGATION_HEIGHT;
+
+function wideTablePageSx(hasFeaturebaseChat: boolean) {
+  const bottomOffset = hasFeaturebaseChat
+    ? {
+        xs: `${MOBILE_BOTTOM_SAFE_HEIGHT}px`,
+        sm: `${MOBILE_BOTTOM_SAFE_HEIGHT}px`,
+        md: `${FEATUREBASE_CHAT_WIDGET_SAFE_HEIGHT}px`,
+      }
+    : {
+        xs: `${MOBILE_BOTTOM_NAVIGATION_HEIGHT}px`,
+        sm: `${MOBILE_BOTTOM_NAVIGATION_HEIGHT}px`,
+        md: '0px',
+      };
+
+  const sx = {
+    display: 'flex',
+    flexDirection: 'column',
+    flexWrap: 'nowrap',
+    height: {
+      xs: `calc(100dvh - 56px - ${bottomOffset.xs})`,
+      sm: `calc(100dvh - 64px - ${bottomOffset.sm})`,
+      md: `calc(100dvh - 48px - ${bottomOffset.md})`,
+    },
+    // ShellRootLayout always reserves Featurebase space; reclaim it when chat is hidden.
+    minHeight: 0,
+    overflow: 'hidden',
+  } as const;
+
+  if (hasFeaturebaseChat) {
+    return sx;
+  }
+
+  return {
+    ...sx,
+    marginBottom: `-${FEATUREBASE_CHAT_WIDGET_SAFE_HEIGHT}px`,
+  } as const;
+}
+
+export { wideTablePageSx };

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
@@ -1,5 +1,5 @@
-import Grid from '@mui/material/GridLegacy';
 import {
+  Box,
   Button,
   FormControl,
   InputBase,
@@ -11,7 +11,6 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TableRow,
   ToggleButton,
@@ -36,7 +35,10 @@ import { policyData } from '../Model/ConfigurationModel';
 import { SearchBar } from '../Shell/SearchBar';
 import { filterFamiliesByText } from '../Families/FamilyUtils';
 import { usePersonAndFamilyLookup } from '../Model/DirectoryModel';
-import { useAllPartneringFamiliesPermissions } from '../Model/SessionModel';
+import {
+  useAllPartneringFamiliesPermissions,
+  useGlobalPermissions,
+} from '../Model/SessionModel';
 import { useScreenTitle } from '../Shell/ShellScreenTitle';
 import { useLoadable } from '../Hooks/useLoadable';
 import { ProgressBackdrop } from '../Shell/ProgressBackdrop';
@@ -48,7 +50,9 @@ import { forceCheck } from '../Utilities/reactLazyLoadInterop';
 import { PartneringFamilyTableItem } from './PartneringFamilies/PartneringFamilyTableItem';
 import { arrangementStatusSummary } from './PartneringFamilies/arrangementStatusSummary';
 import { ArrangementsFilter } from './PartneringFamilies/types';
-import { stickyHeaderTableSx } from '../Utilities/stickyHeaderTableSx';
+import { containedStickyHeaderTableSx } from '../Utilities/stickyHeaderTableSx';
+import { WideTableContainer } from '../Utilities/WideTableContainer';
+import { wideTablePageSx } from '../Utilities/wideTablePageSx';
 import { getFamilyCounty } from '../Utilities/getFamilyCounty';
 import { CountyFilter } from '../V1Referrals/CountyFilter';
 import { visibleReferralsQuery } from '../Model/Data';
@@ -81,6 +85,7 @@ function isSetupOrActiveArrangementPhase(phase: ArrangementPhase | undefined) {
 function PartneringFamilies() {
   const appNavigate = useAppNavigate();
   const personAndFamilyLookup = usePersonAndFamilyLookup();
+  const globalPermissions = useGlobalPermissions();
   const {
     SidePanel: CustomFieldFiltersSidePanel,
     openSidePanel: openCustomFieldFiltersSidePanel,
@@ -319,6 +324,13 @@ function PartneringFamilies() {
   const canCreateFamily =
     permissions(Permission.EditFamilyInfo) &&
     permissions(Permission.CreateV1Case);
+  const tableColumnCount =
+    3 +
+    assignmentRoles.length +
+    referralCustomFields.length +
+    (expandedView ? 0 : (arrangementTypes?.length ?? 0));
+  const tableMinWidth = Math.max(700, tableColumnCount * 160);
+  const hasFeaturebaseChat = globalPermissions(Permission.AccessSupportScreen);
 
   // const showAddFamilyButton = !referralsEnabled && canCreateFamily;
   const showAddFamilyButton = true;
@@ -330,8 +342,8 @@ function PartneringFamilies() {
       <p>Loading families...</p>
     </ProgressBackdrop>
   ) : (
-    <Grid container>
-      <Grid item xs={12}>
+    <Box sx={wideTablePageSx(hasFeaturebaseChat)}>
+      <Box sx={{ flex: '0 0 auto' }}>
         <Stack
           direction="row"
           sx={{
@@ -509,17 +521,18 @@ function PartneringFamilies() {
             onClose={closeCustomFieldFiltersSidePanel}
           />
         </CustomFieldFiltersSidePanel>
-      </Grid>
-      <Grid item xs={12} className="cases-table">
-        <TableContainer
-          sx={{
-            borderBottom: '1px solid rgba(224, 224, 224, 1)',
-            overflow: 'visible',
-          }}
-        >
+      </Box>
+      <Box
+        className="cases-table"
+        sx={{ display: 'flex', flex: 1, flexDirection: 'column', minHeight: 0 }}
+      >
+        <WideTableContainer>
           <Table
             stickyHeader
-            sx={{ ...stickyHeaderTableSx, minWidth: '700px' }}
+            sx={{
+              ...containedStickyHeaderTableSx,
+              minWidth: tableMinWidth,
+            }}
             size="small"
           >
             <TableHead>
@@ -581,7 +594,7 @@ function PartneringFamilies() {
               ))}
             </TableBody>
           </Table>
-        </TableContainer>
+        </WideTableContainer>
 
         {createPartneringFamilyDialogOpen && (
           <CreatePartneringFamilyDrawer
@@ -596,8 +609,8 @@ function PartneringFamilies() {
             }}
           />
         )}
-      </Grid>
-    </Grid>
+      </Box>
+    </Box>
   );
 }
 

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies/PartneringFamilyTableItem.tsx
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies/PartneringFamilyTableItem.tsx
@@ -72,6 +72,7 @@ function PartneringFamilyPlaceholderRow(
       >
         <LazyLoad
           once
+          overflow
           height={height}
           offset={300}
           placeholder={<Box sx={{ minHeight: `${height}px` }} />}

--- a/src/caretogether-pwa/src/V1Referrals/V1Referrals.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/V1Referrals.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
-import Grid from '@mui/material/GridLegacy';
 import {
+  Box,
   Table,
   TableBody,
   TableCell,
   TableHead,
   TableRow,
-  TableContainer,
   Drawer,
 } from '@mui/material';
 import { Routes, Route } from 'react-router-dom';
@@ -39,6 +38,9 @@ import {
   assignmentRolesForColumns,
   matchesAssignmentFilters,
 } from '../FunctionAssignments/assignmentRoleColumns';
+import { containedStickyHeaderTableSx } from '../Utilities/stickyHeaderTableSx';
+import { WideTableContainer } from '../Utilities/WideTableContainer';
+import { wideTablePageSx } from '../Utilities/wideTablePageSx';
 
 const REFERRALS_FEATURE_FLAG = 'referrals';
 
@@ -139,6 +141,9 @@ function V1ReferralsContent() {
         )
       )
     : [];
+  const tableColumnCount = 4 + assignmentRoles.length;
+  const tableMinWidth = Math.max(700, tableColumnCount * 160);
+  const hasFeaturebaseChat = permissions(Permission.AccessSupportScreen);
 
   const rows = referrals
     .map((r) => {
@@ -208,8 +213,8 @@ function V1ReferralsContent() {
       <Route
         path=""
         element={
-          <Grid container>
-            <Grid item xs={12}>
+          <Box sx={wideTablePageSx(hasFeaturebaseChat)}>
+            <Box sx={{ flex: '0 0 auto' }}>
               <ReferralsFilters
                 filterText={filterText}
                 setFilterText={setFilterText}
@@ -249,11 +254,25 @@ function V1ReferralsContent() {
                       family != null
                   )}
               />
-            </Grid>
+            </Box>
 
-            <Grid item xs={12}>
-              <TableContainer>
-                <Table size="small">
+            <Box
+              sx={{
+                display: 'flex',
+                flex: 1,
+                flexDirection: 'column',
+                minHeight: 0,
+              }}
+            >
+              <WideTableContainer>
+                <Table
+                  stickyHeader
+                  size="small"
+                  sx={{
+                    ...containedStickyHeaderTableSx,
+                    minWidth: tableMinWidth,
+                  }}
+                >
                   <TableHead>
                     <TableRow>
                       <TableCell>Referral Title</TableCell>
@@ -282,8 +301,8 @@ function V1ReferralsContent() {
                     ))}
                   </TableBody>
                 </Table>
-              </TableContainer>
-            </Grid>
+              </WideTableContainer>
+            </Box>
 
             <Drawer
               anchor="right"
@@ -293,7 +312,7 @@ function V1ReferralsContent() {
             >
               <AddNewReferralDrawer onClose={() => setOpenNewReferral(false)} />
             </Drawer>
-          </Grid>
+          </Box>
         }
       />
 

--- a/src/caretogether-pwa/src/Volunteers/VolunteerApprovalTab/VolunteerApproval.tsx
+++ b/src/caretogether-pwa/src/Volunteers/VolunteerApprovalTab/VolunteerApproval.tsx
@@ -1,7 +1,5 @@
-import Grid from '@mui/material/GridLegacy';
 import {
   Table,
-  TableContainer,
   TableBody,
   TableCell,
   TableHead,
@@ -47,7 +45,10 @@ import { Link, useLocation } from 'react-router-dom';
 import { SearchBar } from '../../Shell/SearchBar';
 import { useLocalStorage } from '../../Hooks/useLocalStorage';
 import { useScrollMemory } from '../../Hooks/useScrollMemory';
-import { useAllVolunteerFamiliesPermissions } from '../../Model/SessionModel';
+import {
+  useAllVolunteerFamiliesPermissions,
+  useGlobalPermissions,
+} from '../../Model/SessionModel';
 import { BulkSmsSideSheet } from '../BulkSmsSideSheet';
 import { useWindowSize } from '../../Hooks/useWindowSize';
 import { useScreenTitle } from '../../Shell/ShellScreenTitle';
@@ -74,12 +75,15 @@ import { forceCheck } from '../../Utilities/reactLazyLoadInterop';
 import { VolunteerApprovalTableItem } from './VolunteerApprovalTableItem';
 import { VolunteerCustomFieldFiltersSidePanel } from './VolunteerCustomFieldFiltersSidePanel';
 import { useSidePanel } from '../../Hooks/useSidePanel';
-import { stickyHeaderTableSx } from '../../Utilities/stickyHeaderTableSx';
+import { containedStickyHeaderTableSx } from '../../Utilities/stickyHeaderTableSx';
+import { WideTableContainer } from '../../Utilities/WideTableContainer';
+import { wideTablePageSx } from '../../Utilities/wideTablePageSx';
 
 function VolunteerApproval(props: { onOpen: () => void }) {
   const { onOpen } = props;
   useEffect(onOpen);
   const appNavigate = useAppNavigate();
+  const globalPermissions = useGlobalPermissions();
   const [uncheckedFamilies, setUncheckedFamilies] = useState<string[]>([]);
   const {
     SidePanel: CustomFieldFiltersSidePanel,
@@ -504,6 +508,10 @@ function VolunteerApproval(props: { onOpen: () => void }) {
   const windowSize = useWindowSize();
 
   const permissions = useAllVolunteerFamiliesPermissions();
+  const tableColumnCount = 2 + customFieldNames.length + (smsMode ? 1 : 0);
+  const tableMinWidth = Math.max(700, tableColumnCount * 160);
+  const hasFeaturebaseChat = globalPermissions(Permission.AccessSupportScreen);
+  const tablePageSx = wideTablePageSx(hasFeaturebaseChat);
 
   useScreenTitle('Volunteers');
 
@@ -513,16 +521,17 @@ function VolunteerApproval(props: { onOpen: () => void }) {
     </ProgressBackdrop>
   ) : (
     <>
-      <Grid
-        container
+      <Box
         sx={{
-          paddingRight: smsMode && !isMobile ? '400px' : null,
+          ...tablePageSx,
+          ...(smsMode && !isMobile ? { paddingRight: '400px' } : {}),
           height:
-            smsMode && isMobile ? `${windowSize.height - 500 - 24}px` : null,
-          overflow: smsMode && isMobile ? 'scroll' : null,
+            smsMode && isMobile
+              ? `${windowSize.height - 500 - 24}px`
+              : tablePageSx.height,
         }}
       >
-        <Grid item xs={12}>
+        <Box sx={{ flex: '0 0 auto' }}>
           <Stack
             direction={{ xs: 'column', md: 'row' }}
             sx={{
@@ -720,17 +729,22 @@ function VolunteerApproval(props: { onOpen: () => void }) {
                 Add new volunteer family
               </Button>
             )}
-        </Grid>
-        <Grid item xs={12}>
-          <TableContainer
-            sx={{
-              borderBottom: '1px solid rgba(224, 224, 224, 1)',
-              overflow: 'visible',
-            }}
-          >
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            flex: 1,
+            flexDirection: 'column',
+            minHeight: 0,
+          }}
+        >
+          <WideTableContainer>
             <Table
               stickyHeader
-              sx={{ ...stickyHeaderTableSx, minWidth: '700px' }}
+              sx={{
+                ...containedStickyHeaderTableSx,
+                minWidth: tableMinWidth,
+              }}
               size="small"
             >
               <TableHead>
@@ -781,18 +795,23 @@ function VolunteerApproval(props: { onOpen: () => void }) {
                 ))}
               </TableBody>
             </Table>
-          </TableContainer>
+          </WideTableContainer>
 
           {createVolunteerFamilyDialogOpen && (
             <CreateVolunteerFamilyDialog
               onClose={(volunteerFamilyId) => {
                 setCreateVolunteerFamilyDialogOpen(false);
-                volunteerFamilyId && openFamily(volunteerFamilyId);
+
+                if (!volunteerFamilyId) {
+                  return;
+                }
+
+                openFamily(volunteerFamilyId);
               }}
             />
           )}
-        </Grid>
-      </Grid>
+        </Box>
+      </Box>
       {smsMode && (
         <BulkSmsSideSheet
           selectedFamilies={selectedFamilies}

--- a/src/caretogether-pwa/src/Volunteers/VolunteerApprovalTab/VolunteerApprovalTableItem.tsx
+++ b/src/caretogether-pwa/src/Volunteers/VolunteerApprovalTab/VolunteerApprovalTableItem.tsx
@@ -106,6 +106,7 @@ function VolunteerApprovalPlaceholderRow(
       >
         <LazyLoad
           once
+          overflow
           height={height}
           offset={300}
           placeholder={<Box sx={{ minHeight: `${height}px` }} />}


### PR DESCRIPTION
## Summary
- Contain Partnering Families, Volunteer Approval, and Referrals list tables within the page viewport
- Adjust table height based on Featurebase chat access
- Add shared wide table container/styles for horizontal and vertical scrolling

## Testing
- npm run type-check
- npx eslint src/Utilities/WideTableContainer.tsx src/Utilities/wideTablePageSx.ts src/V1Cases/PartneringFamilies.tsx src/Volunteers/VolunteerApprovalTab/VolunteerApproval.tsx src/V1Referrals/V1Referrals.tsx --report-unused-disable-directives --max-warnings 0

Note: full npm run lint still fails on existing unrelated lint issues.