### PR TITLE
Add first-name sorting to cases and volunteers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything in the repo:
-*                    @PabloDinella @LarsKemmann
+*                    @PabloDinella
 
 # Modifications to GitHub settings and the license require founder review:
 /.github/            @LarsKemmann

--- a/src/caretogether-pwa/src/Families/FamilyUtils.tsx
+++ b/src/caretogether-pwa/src/Families/FamilyUtils.tsx
@@ -9,6 +9,71 @@ export function familyLastName(family: CombinedFamilyInfo) {
   );
 }
 
+export type FamilyNameSortMode =
+  | 'lastNameAsc'
+  | 'lastNameDesc'
+  | 'firstNameAsc'
+  | 'firstNameDesc';
+
+export function normalizeFamilyNameSortMode(value: unknown): FamilyNameSortMode {
+  if (
+    value === 'lastNameAsc' ||
+    value === 'lastNameDesc' ||
+    value === 'firstNameAsc' ||
+    value === 'firstNameDesc'
+  ) {
+    return value;
+  }
+
+  return 'lastNameAsc';
+}
+
+function familyFirstName(family: CombinedFamilyInfo) {
+  return (
+    family.family!.adults?.filter(
+      (adult) => family.family!.primaryFamilyContactPersonId === adult.item1?.id
+    )[0]?.item1?.firstName || 'MISSING PRIMARY CONTACT'
+  );
+}
+
+function compareByFamilyLastName(
+  firstFamily: CombinedFamilyInfo,
+  secondFamily: CombinedFamilyInfo
+) {
+  const firstLastName = familyLastName(firstFamily);
+  const secondLastName = familyLastName(secondFamily);
+
+  if (firstLastName < secondLastName) {
+    return -1;
+  }
+
+  if (firstLastName > secondLastName) {
+    return 1;
+  }
+
+  return (firstFamily.family?.id ?? '').localeCompare(
+    secondFamily.family?.id ?? ''
+  );
+}
+
+function compareByFamilyFirstName(
+  firstFamily: CombinedFamilyInfo,
+  secondFamily: CombinedFamilyInfo
+) {
+  const firstFirstName = familyFirstName(firstFamily);
+  const secondFirstName = familyFirstName(secondFamily);
+
+  if (firstFirstName < secondFirstName) {
+    return -1;
+  }
+
+  if (firstFirstName > secondFirstName) {
+    return 1;
+  }
+
+  return compareByFamilyLastName(firstFamily, secondFamily);
+}
+
 export function filterFamiliesByText(
   families: CombinedFamilyInfo[],
   inputText: string
@@ -27,6 +92,27 @@ export function filterFamiliesByText(
         )
       )
   );
+}
+
+export function sortFamiliesByName(
+  families: CombinedFamilyInfo[],
+  sortMode: FamilyNameSortMode
+) {
+  return families.map((family) => family).sort((firstFamily, secondFamily) => {
+    if (sortMode === 'lastNameDesc') {
+      return compareByFamilyLastName(secondFamily, firstFamily);
+    }
+
+    if (sortMode === 'firstNameDesc') {
+      return compareByFamilyFirstName(secondFamily, firstFamily);
+    }
+
+    if (sortMode === 'firstNameAsc') {
+      return compareByFamilyFirstName(firstFamily, secondFamily);
+    }
+
+    return compareByFamilyLastName(firstFamily, secondFamily);
+  });
 }
 
 export function sortFamiliesByLastNameDesc(families: CombinedFamilyInfo[]) {

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies.tsx
@@ -504,6 +504,10 @@ function PartneringFamilies() {
             >
               <MenuItem value="lastNameAsc">Last name (ascending)</MenuItem>
               <MenuItem value="lastNameDesc">Last name (descending)</MenuItem>
+              <MenuItem value="firstNameAsc">First name (ascending)</MenuItem>
+              <MenuItem value="firstNameDesc">
+                First name (descending)
+              </MenuItem>
               <MenuItem value="dateOpenedDesc">
                 Date opened (descending)
               </MenuItem>

--- a/src/caretogether-pwa/src/V1Cases/PartneringFamilies/sortPartneringFamilies.ts
+++ b/src/caretogether-pwa/src/V1Cases/PartneringFamilies/sortPartneringFamilies.ts
@@ -8,6 +8,8 @@ import { familyLastName } from '../../Families/FamilyUtils';
 export type PartneringFamiliesSortMode =
   | 'lastNameAsc'
   | 'lastNameDesc'
+  | 'firstNameAsc'
+  | 'firstNameDesc'
   | 'dateOpenedDesc'
   | 'dateOpenedAsc';
 
@@ -17,6 +19,8 @@ export function normalizePartneringFamiliesSortMode(
   if (
     value === 'lastNameAsc' ||
     value === 'lastNameDesc' ||
+    value === 'firstNameAsc' ||
+    value === 'firstNameDesc' ||
     value === 'dateOpenedDesc' ||
     value === 'dateOpenedAsc'
   ) {
@@ -54,6 +58,32 @@ function compareByFamilyName(
   return (firstFamily.family?.id ?? '').localeCompare(
     secondFamily.family?.id ?? ''
   );
+}
+
+function familyFirstName(family: CombinedFamilyInfo) {
+  return (
+    family.family!.adults?.filter(
+      (adult) => family.family!.primaryFamilyContactPersonId === adult.item1?.id
+    )[0]?.item1?.firstName || 'MISSING PRIMARY CONTACT'
+  );
+}
+
+function compareByFamilyFirstName(
+  firstFamily: CombinedFamilyInfo,
+  secondFamily: CombinedFamilyInfo
+) {
+  const firstFirstName = familyFirstName(firstFamily);
+  const secondFirstName = familyFirstName(secondFamily);
+
+  if (firstFirstName < secondFirstName) {
+    return -1;
+  }
+
+  if (firstFirstName > secondFirstName) {
+    return 1;
+  }
+
+  return compareByFamilyName(firstFamily, secondFamily);
 }
 
 export function openReferralByFamilyId(referrals: V1Referral[]) {
@@ -159,6 +189,14 @@ export function sortPartneringFamilies(
 
     if (sortMode === 'lastNameDesc') {
       return compareByFamilyName(secondFamily, firstFamily);
+    }
+
+    if (sortMode === 'firstNameDesc') {
+      return compareByFamilyFirstName(secondFamily, firstFamily);
+    }
+
+    if (sortMode === 'firstNameAsc') {
+      return compareByFamilyFirstName(firstFamily, secondFamily);
     }
 
     return compareByFamilyName(firstFamily, secondFamily);

--- a/src/caretogether-pwa/src/Volunteers/VolunteerApprovalTab/VolunteerApproval.tsx
+++ b/src/caretogether-pwa/src/Volunteers/VolunteerApprovalTab/VolunteerApproval.tsx
@@ -12,8 +12,10 @@ import {
   IconButton,
   FormControl,
   InputBase,
+  InputLabel,
   MenuItem,
   Select,
+  SelectChangeEvent,
   Stack,
   ToggleButton,
   ToggleButtonGroup,
@@ -59,7 +61,6 @@ import { useAppNavigate } from '../../Hooks/useAppNavigate';
 import { useGlobalSnackBar } from '../../Hooks/useGlobalSnackBar';
 import { statusFiltersState } from './statusFiltersState';
 import { checkStatusEquivalence } from './checkStatusEquivalence';
-import { familyLastName } from './familyLastName';
 import { simplify } from './simplify';
 import { filterType } from './filterType';
 import { roleFiltersState } from './roleFiltersState';
@@ -78,6 +79,13 @@ import { useSidePanel } from '../../Hooks/useSidePanel';
 import { containedStickyHeaderTableSx } from '../../Utilities/stickyHeaderTableSx';
 import { WideTableContainer } from '../../Utilities/WideTableContainer';
 import { wideTablePageSx } from '../../Utilities/wideTablePageSx';
+import {
+  FamilyNameSortMode,
+  normalizeFamilyNameSortMode,
+  sortFamiliesByName,
+} from '../../Families/FamilyUtils';
+
+const VOLUNTEER_APPROVAL_SORT_STORAGE_KEY = 'volunteer-approval-sortMode';
 
 function VolunteerApproval(props: { onOpen: () => void }) {
   const { onOpen } = props;
@@ -129,15 +137,21 @@ function VolunteerApproval(props: { onOpen: () => void }) {
 
   // The array object returned by Recoil is read-only. We need to copy it before we can do an in-place sort.
   const volunteerFamiliesLoadable = useLoadable(volunteerFamiliesData);
-  const volunteerFamilies = (volunteerFamiliesLoadable || [])
-    .map((x) => x)
-    .sort((a, b) =>
-      familyLastName(a) < familyLastName(b)
-        ? -1
-        : familyLastName(a) > familyLastName(b)
-          ? 1
-          : 0
+  const [storedSortMode, setStoredSortMode] =
+    useLocalStorage<FamilyNameSortMode>(
+      VOLUNTEER_APPROVAL_SORT_STORAGE_KEY,
+      'lastNameAsc'
     );
+  const sortMode = normalizeFamilyNameSortMode(storedSortMode);
+
+  function setSortMode(value: FamilyNameSortMode) {
+    setStoredSortMode(value);
+  }
+
+  const volunteerFamilies = sortFamiliesByName(
+    volunteerFamiliesLoadable || [],
+    sortMode
+  );
 
   const {
     selectedValuesByField: customFieldFilters,
@@ -432,7 +446,7 @@ function VolunteerApproval(props: { onOpen: () => void }) {
 
   useEffect(() => {
     forceCheck();
-  }, [customFieldFilters, filterText, roleFilters, statusFilters]);
+  }, [customFieldFilters, filterText, roleFilters, sortMode, statusFilters]);
 
   const selectedFamilies = filteredVolunteerFamilies.filter(
     (family) => !uncheckedFamilies.some((f) => f === family.family!.id!)
@@ -704,6 +718,53 @@ function VolunteerApproval(props: { onOpen: () => void }) {
               </Stack>
             </Stack>
           </Stack>
+          <Stack
+            my={2}
+            direction="row"
+            justifyContent="flex-end"
+            alignItems="center"
+            sx={{ gap: 1, flexWrap: 'wrap' }}
+          >
+            {permissions(Permission.EditFamilyInfo) &&
+              permissions(Permission.ActivateVolunteerFamily) && (
+                <Button
+                  variant="contained"
+                  startIcon={<AddIcon />}
+                  onClick={() => setCreateVolunteerFamilyDialogOpen(true)}
+                  sx={{
+                    marginRight: 'auto',
+                    width: { xs: '100%', sm: 'auto' },
+                  }}
+                >
+                  Add new volunteer family
+                </Button>
+              )}
+            <FormControl
+              size="small"
+              sx={{ minWidth: 180, width: { xs: '100%', sm: 'auto' } }}
+            >
+              <InputLabel id="volunteer-approval-sort-label">
+                Sort by
+              </InputLabel>
+              <Select
+                labelId="volunteer-approval-sort-label"
+                value={sortMode}
+                label="Sort by"
+                onChange={(event: SelectChangeEvent) =>
+                  setSortMode(event.target.value as FamilyNameSortMode)
+                }
+              >
+                <MenuItem value="lastNameAsc">Last name (ascending)</MenuItem>
+                <MenuItem value="lastNameDesc">Last name (descending)</MenuItem>
+                <MenuItem value="firstNameAsc">
+                  First name (ascending)
+                </MenuItem>
+                <MenuItem value="firstNameDesc">
+                  First name (descending)
+                </MenuItem>
+              </Select>
+            </FormControl>
+          </Stack>
           <CustomFieldFiltersSidePanel>
             <VolunteerCustomFieldFiltersSidePanel
               customFields={(policy.customFamilyFields || []).concat(policy.volunteerPolicy?.customFields || [])}
@@ -714,21 +775,6 @@ function VolunteerApproval(props: { onOpen: () => void }) {
             />
           </CustomFieldFiltersSidePanel>
 
-          {permissions(Permission.EditFamilyInfo) &&
-            permissions(Permission.ActivateVolunteerFamily) && (
-              <Button
-                variant="contained"
-                startIcon={<AddIcon />}
-                onClick={() => setCreateVolunteerFamilyDialogOpen(true)}
-                sx={{
-                  marginRight: 'auto',
-                  marginY: 2,
-                  width: { xs: '100%', sm: 'auto' },
-                }}
-              >
-                Add new volunteer family
-              </Button>
-            )}
         </Box>
         <Box
           sx={{

--- a/src/caretogether-pwa/src/Volunteers/VolunteerProgressTab/VolunteerProgress.tsx
+++ b/src/caretogether-pwa/src/Volunteers/VolunteerProgressTab/VolunteerProgress.tsx
@@ -8,6 +8,11 @@ import {
   TableRow,
   Button,
   ButtonGroup,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
   useMediaQuery,
   useTheme,
   Stack,
@@ -28,8 +33,10 @@ import { SearchBar } from '../../Shell/SearchBar';
 import { useLocalStorage } from '../../Hooks/useLocalStorage';
 import { useScrollMemory } from '../../Hooks/useScrollMemory';
 import {
+  FamilyNameSortMode,
   filterFamiliesByText,
-  sortFamiliesByLastNameDesc,
+  normalizeFamilyNameSortMode,
+  sortFamiliesByName,
 } from '../../Families/FamilyUtils';
 import { useAllVolunteerFamiliesPermissions } from '../../Model/SessionModel';
 import { Permission } from '../../GeneratedClient';
@@ -42,6 +49,8 @@ import { forceCheck } from '../../Utilities/reactLazyLoadInterop';
 import { VolunteerProgressTableItem } from './VolunteerProgressTableItem';
 import { stickyHeaderTableSx } from '../../Utilities/stickyHeaderTableSx';
 
+const VOLUNTEER_PROGRESS_SORT_STORAGE_KEY = 'volunteer-progress-sortMode';
+
 function VolunteerProgress(props: { onOpen: () => void }) {
   const { onOpen } = props;
   useEffect(onOpen);
@@ -50,8 +59,20 @@ function VolunteerProgress(props: { onOpen: () => void }) {
 
   // The array object returned by Recoil is read-only. We need to copy it before we can do an in-place sort.
   const volunteerFamiliesLoadable = useLoadable(volunteerFamiliesData);
-  const volunteerFamilies = sortFamiliesByLastNameDesc(
-    volunteerFamiliesLoadable || []
+  const [storedSortMode, setStoredSortMode] =
+    useLocalStorage<FamilyNameSortMode>(
+      VOLUNTEER_PROGRESS_SORT_STORAGE_KEY,
+      'lastNameAsc'
+    );
+  const sortMode = normalizeFamilyNameSortMode(storedSortMode);
+
+  function setSortMode(value: FamilyNameSortMode) {
+    setStoredSortMode(value);
+  }
+
+  const volunteerFamilies = sortFamiliesByName(
+    volunteerFamiliesLoadable || [],
+    sortMode
   );
   const allApprovalAndOnboardingRequirements = useLoadable(
     allApprovalAndOnboardingRequirementsData
@@ -65,7 +86,7 @@ function VolunteerProgress(props: { onOpen: () => void }) {
 
   useEffect(() => {
     forceCheck();
-  }, [filterText]);
+  }, [filterText, sortMode]);
 
   useScrollMemory();
 
@@ -153,18 +174,44 @@ function VolunteerProgress(props: { onOpen: () => void }) {
             </Button>
           </ButtonGroup>
         </Stack>
-
-        {permissions(Permission.EditFamilyInfo) &&
-          permissions(Permission.ActivateVolunteerFamily) && (
-            <Button
-              variant="contained"
-              startIcon={<AddIcon />}
-              onClick={() => setCreateVolunteerFamilyDialogOpen(true)}
-              sx={{ marginRight: 'auto', marginY: 2 }}
+        <Stack
+          my={2}
+          direction="row"
+          justifyContent="flex-end"
+          alignItems="center"
+          sx={{ gap: 1, flexWrap: 'wrap' }}
+        >
+          {permissions(Permission.EditFamilyInfo) &&
+            permissions(Permission.ActivateVolunteerFamily) && (
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => setCreateVolunteerFamilyDialogOpen(true)}
+                sx={{ marginRight: 'auto', width: { xs: '100%', sm: 'auto' } }}
+              >
+                Add new volunteer family
+              </Button>
+            )}
+          <FormControl
+            size="small"
+            sx={{ minWidth: 180, width: { xs: '100%', sm: 'auto' } }}
+          >
+            <InputLabel id="volunteer-progress-sort-label">Sort by</InputLabel>
+            <Select
+              labelId="volunteer-progress-sort-label"
+              value={sortMode}
+              label="Sort by"
+              onChange={(event: SelectChangeEvent) =>
+                setSortMode(event.target.value as FamilyNameSortMode)
+              }
             >
-              Add new volunteer family
-            </Button>
-          )}
+              <MenuItem value="lastNameAsc">Last name (ascending)</MenuItem>
+              <MenuItem value="lastNameDesc">Last name (descending)</MenuItem>
+              <MenuItem value="firstNameAsc">First name (ascending)</MenuItem>
+              <MenuItem value="firstNameDesc">First name (descending)</MenuItem>
+            </Select>
+          </FormControl>
+        </Stack>
       </Grid>
       <Grid item xs={12}>
         <TableContainer
@@ -213,7 +260,12 @@ function VolunteerProgress(props: { onOpen: () => void }) {
           <CreateVolunteerFamilyDialog
             onClose={(volunteerFamilyId) => {
               setCreateVolunteerFamilyDialogOpen(false);
-              volunteerFamilyId && openFamily(volunteerFamilyId);
+
+              if (!volunteerFamilyId) {
+                return;
+              }
+
+              openFamily(volunteerFamilyId);
             }}
           />
         )}


### PR DESCRIPTION
## Summary

- Add first-name ascending/descending sort options to the cases list.
- Add shared primary-contact name sorting and persisted sort controls to volunteer approval and progress tabs.
- Place volunteer add-family and sort controls together in the secondary toolbar row for consistency with the cases list.

## Testing

- npm run type-check
- npx eslint src/Families/FamilyUtils.tsx src/Volunteers/VolunteerApprovalTab/VolunteerApproval.tsx src/Volunteers/VolunteerProgressTab/VolunteerProgress.tsx --report-unused-disable-directives --max-warnings 0

Note: full npm run lint still reports pre-existing unrelated lint failures outside these changes.