### PR TITLE
 Support Family Screen V2 rollout with Early Access opt-out

### DIFF
--- a/src/caretogether-pwa/src/Families/FamilyScreenRoute.tsx
+++ b/src/caretogether-pwa/src/Families/FamilyScreenRoute.tsx
@@ -11,14 +11,20 @@ import { FamilyScreenV2 } from './FamilyScreenV2';
 
 export function FamilyScreenRoute() {
   const posthog = usePostHog();
-  const rolloutEnabled = useFeatureFlagEnabled(
-    FAMILY_SCREEN_V2_FEATURE_FLAG
+  const rolloutEnabled = useFeatureFlagEnabled(FAMILY_SCREEN_V2_FEATURE_FLAG);
+  const earlyAccessFlagEnabled = useFeatureFlagEnabled(
+    FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG
   );
-  const featureFlagsLoaded = posthog.featureFlags.hasLoadedFlags;
+  const [featureFlagsLoaded, setFeatureFlagsLoaded] = useState(
+    () => posthog.featureFlags.hasLoadedFlags
+  );
   const [earlyAccessEnrollment, setEarlyAccessEnrollment] = useState<
     boolean | undefined
   >(() =>
-    getEarlyAccessEnrollment(posthog, FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG)
+    getEarlyAccessEnrollment(
+      posthog,
+      FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG
+    )
   );
 
   useEffect(() => {
@@ -31,9 +37,13 @@ export function FamilyScreenRoute() {
       );
     }
 
+    setFeatureFlagsLoaded(posthog.featureFlags.hasLoadedFlags);
     updateEarlyAccessEnrollment();
 
-    return posthog.onFeatureFlags(updateEarlyAccessEnrollment);
+    return posthog.onFeatureFlags(() => {
+      setFeatureFlagsLoaded(true);
+      updateEarlyAccessEnrollment();
+    });
   }, [posthog]);
 
   if (!featureFlagsLoaded) {
@@ -44,11 +54,9 @@ export function FamilyScreenRoute() {
     );
   }
 
-  const showFamilyScreenV2 = earlyAccessEnrollment ?? (rolloutEnabled === true);
+  const showFamilyScreenV2 =
+    earlyAccessEnrollment ??
+    (earlyAccessFlagEnabled === true || rolloutEnabled === true);
 
-  return showFamilyScreenV2 ? (
-    <FamilyScreenV2 />
-  ) : (
-    <FamilyScreen />
-  );
+  return showFamilyScreenV2 ? <FamilyScreenV2 /> : <FamilyScreen />;
 }

--- a/src/caretogether-pwa/src/Families/FamilyScreenRoute.tsx
+++ b/src/caretogether-pwa/src/Families/FamilyScreenRoute.tsx
@@ -1,112 +1,42 @@
 import { useEffect, useState } from 'react';
-import { usePostHog } from 'posthog-js/react';
+import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react';
 import {
-  FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_NAME,
-  FAMILY_SCREEN_V2_ENROLLMENT_CHANGED_EVENT,
-  POSTHOG_STORED_PERSON_PROPERTIES_KEY,
+  FAMILY_SCREEN_V2_FEATURE_FLAG,
+  FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG,
 } from '../featureFlags';
+import { getEarlyAccessEnrollment } from '../Utilities/Instrumentation/earlyAccessEnrollment';
 import { ProgressBackdrop } from '../Shell/ProgressBackdrop';
 import { FamilyScreen } from './FamilyScreen';
 import { FamilyScreenV2 } from './FamilyScreenV2';
 
-type EnrollmentState = 'loading' | 'enrolled' | 'not-enrolled';
-
-function earlyAccessEnrollmentProperty(flagKey: string) {
-  return `$feature_enrollment/${flagKey}`;
-}
-
-function getEarlyAccessEnrollment(
-  posthog: ReturnType<typeof usePostHog>,
-  flagKey: string
-) {
-  const personProperties = posthog.get_property(
-    POSTHOG_STORED_PERSON_PROPERTIES_KEY
-  ) as Record<string, unknown> | undefined;
-
-  return personProperties?.[earlyAccessEnrollmentProperty(flagKey)] === true;
-}
-
 export function FamilyScreenRoute() {
   const posthog = usePostHog();
-  const [enrollmentState, setEnrollmentState] =
-    useState<EnrollmentState>('loading');
-  const [earlyAccessFlagKey, setEarlyAccessFlagKey] = useState<string | null>(
-    null
+  const rolloutEnabled = useFeatureFlagEnabled(
+    FAMILY_SCREEN_V2_FEATURE_FLAG
+  );
+  const featureFlagsLoaded = posthog.featureFlags.hasLoadedFlags;
+  const [earlyAccessEnrollment, setEarlyAccessEnrollment] = useState<
+    boolean | undefined
+  >(() =>
+    getEarlyAccessEnrollment(posthog, FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG)
   );
 
   useEffect(() => {
-    let isCurrentLoad = true;
-
-    setEnrollmentState('loading');
-
-    posthog.getEarlyAccessFeatures((features) => {
-      if (!isCurrentLoad) {
-        return;
-      }
-
-      const familyScreenV2Feature = features.find(
-        (feature) => feature.name === FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_NAME
+    function updateEarlyAccessEnrollment() {
+      setEarlyAccessEnrollment(
+        getEarlyAccessEnrollment(
+          posthog,
+          FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG
+        )
       );
+    }
 
-      if (!familyScreenV2Feature?.flagKey) {
-        setEnrollmentState('not-enrolled');
-        return;
-      }
+    updateEarlyAccessEnrollment();
 
-      setEarlyAccessFlagKey(familyScreenV2Feature.flagKey);
-      setEnrollmentState(
-        getEarlyAccessEnrollment(posthog, familyScreenV2Feature.flagKey)
-          ? 'enrolled'
-          : 'not-enrolled'
-      );
-    }, true);
-
-    return () => {
-      isCurrentLoad = false;
-    };
+    return posthog.onFeatureFlags(updateEarlyAccessEnrollment);
   }, [posthog]);
 
-  useEffect(() => {
-    if (!earlyAccessFlagKey) {
-      return;
-    }
-
-    return posthog.onFeatureFlags(() => {
-      setEnrollmentState(
-        getEarlyAccessEnrollment(posthog, earlyAccessFlagKey)
-          ? 'enrolled'
-          : 'not-enrolled'
-      );
-    });
-  }, [earlyAccessFlagKey, posthog]);
-
-  useEffect(() => {
-    function handleEnrollmentChanged(event: Event) {
-      const enrollmentChangedEvent = event as CustomEvent<{
-        flagKey: string;
-        isEnrolled: boolean;
-      }>;
-
-      setEarlyAccessFlagKey(enrollmentChangedEvent.detail.flagKey);
-      setEnrollmentState(
-        enrollmentChangedEvent.detail.isEnrolled ? 'enrolled' : 'not-enrolled'
-      );
-    }
-
-    window.addEventListener(
-      FAMILY_SCREEN_V2_ENROLLMENT_CHANGED_EVENT,
-      handleEnrollmentChanged
-    );
-
-    return () => {
-      window.removeEventListener(
-        FAMILY_SCREEN_V2_ENROLLMENT_CHANGED_EVENT,
-        handleEnrollmentChanged
-      );
-    };
-  }, []);
-
-  if (enrollmentState === 'loading') {
+  if (!featureFlagsLoaded) {
     return (
       <ProgressBackdrop opaque>
         <p>Loading...</p>
@@ -114,9 +44,11 @@ export function FamilyScreenRoute() {
     );
   }
 
-  if (enrollmentState !== 'enrolled') {
-    return <FamilyScreen />;
-  }
+  const showFamilyScreenV2 = earlyAccessEnrollment ?? (rolloutEnabled === true);
 
-  return <FamilyScreenV2 />;
+  return showFamilyScreenV2 ? (
+    <FamilyScreenV2 />
+  ) : (
+    <FamilyScreen />
+  );
 }

--- a/src/caretogether-pwa/src/Shell/EarlyAccessFeaturesDialog.tsx
+++ b/src/caretogether-pwa/src/Shell/EarlyAccessFeaturesDialog.tsx
@@ -14,34 +14,21 @@ import {
   Typography,
 } from '@mui/material';
 import type { EarlyAccessFeature } from 'posthog-js';
-import { usePostHog } from 'posthog-js/react';
 import {
-  FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_NAME,
-  FAMILY_SCREEN_V2_ENROLLMENT_CHANGED_EVENT,
-  POSTHOG_STORED_PERSON_PROPERTIES_KEY,
+  useActiveFeatureFlags,
+  useFeatureFlagEnabled,
+  usePostHog,
+} from 'posthog-js/react';
+import {
+  FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG,
+  FAMILY_SCREEN_V2_FEATURE_FLAG,
 } from '../featureFlags';
+import { getEarlyAccessEnrollment } from '../Utilities/Instrumentation/earlyAccessEnrollment';
 
 type EarlyAccessFeaturesDialogProps = {
   open: boolean;
   onClose: () => void;
 };
-
-type EnrollmentByFlagKey = Record<string, boolean>;
-
-function earlyAccessEnrollmentProperty(flagKey: string) {
-  return `$feature_enrollment/${flagKey}`;
-}
-
-function getEarlyAccessEnrollment(
-  posthog: ReturnType<typeof usePostHog>,
-  flagKey: string
-) {
-  const personProperties = posthog.get_property(
-    POSTHOG_STORED_PERSON_PROPERTIES_KEY
-  ) as Record<string, unknown> | undefined;
-
-  return personProperties?.[earlyAccessEnrollmentProperty(flagKey)] === true;
-}
 
 function featureEnrollmentKey(feature: EarlyAccessFeature) {
   return feature.flagKey ?? feature.name;
@@ -52,12 +39,34 @@ export function EarlyAccessFeaturesDialog({
   onClose,
 }: EarlyAccessFeaturesDialogProps) {
   const posthog = usePostHog();
+  const activeFeatureFlags = useActiveFeatureFlags();
+  const familyScreenV2RolloutEnabled = useFeatureFlagEnabled(
+    FAMILY_SCREEN_V2_FEATURE_FLAG
+  );
   const [features, setFeatures] = useState<EarlyAccessFeature[]>([]);
-  const [enrollmentByFlagKey, setEnrollmentByFlagKey] =
-    useState<EnrollmentByFlagKey>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [updatingFlagKey, setUpdatingFlagKey] = useState<string | null>(null);
+  const [familyScreenV2Enrollment, setFamilyScreenV2Enrollment] = useState<
+    boolean | undefined
+  >(() =>
+    getEarlyAccessEnrollment(posthog, FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG)
+  );
+
+  useEffect(() => {
+    function updateFamilyScreenV2Enrollment() {
+      setFamilyScreenV2Enrollment(
+        getEarlyAccessEnrollment(
+          posthog,
+          FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG
+        )
+      );
+    }
+
+    updateFamilyScreenV2Enrollment();
+
+    return posthog.onFeatureFlags(updateFamilyScreenV2Enrollment);
+  }, [posthog]);
 
   useEffect(() => {
     if (!open) {
@@ -76,22 +85,6 @@ export function EarlyAccessFeaturesDialog({
         }
 
         setFeatures(earlyAccessFeatures);
-        setEnrollmentByFlagKey(
-          Object.fromEntries(
-            earlyAccessFeatures.flatMap((feature) => {
-              if (!feature.flagKey) {
-                return [];
-              }
-
-              return [
-                [
-                  feature.flagKey,
-                  getEarlyAccessEnrollment(posthog, feature.flagKey),
-                ],
-              ];
-            })
-          )
-        );
         setLoading(false);
       }, true);
     } catch (loadError) {
@@ -118,25 +111,30 @@ export function EarlyAccessFeaturesDialog({
         checked,
         feature.stage
       );
-      if (feature.name === FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_NAME) {
-        window.dispatchEvent(
-          new CustomEvent(FAMILY_SCREEN_V2_ENROLLMENT_CHANGED_EVENT, {
-            detail: {
-              flagKey: feature.flagKey,
-              isEnrolled: checked,
-            },
-          })
-        );
+      if (feature.flagKey === FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG) {
+        setFamilyScreenV2Enrollment(checked);
       }
-      setEnrollmentByFlagKey((current) => ({
-        ...current,
-        [feature.flagKey!]: checked,
-      }));
     } catch (updateError) {
       setError(`Unable to update beta feature enrollment. ${updateError}`);
     } finally {
       setUpdatingFlagKey(null);
     }
+  }
+
+  function featureIsEnabled(feature: EarlyAccessFeature) {
+    if (!feature.flagKey) {
+      return false;
+    }
+
+    if (feature.flagKey !== FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG) {
+      return activeFeatureFlags.includes(feature.flagKey);
+    }
+
+    return (
+      familyScreenV2Enrollment ??
+      (familyScreenV2RolloutEnabled === true ||
+        activeFeatureFlags.includes(feature.flagKey))
+    );
   }
 
   return (
@@ -183,11 +181,7 @@ export function EarlyAccessFeaturesDialog({
                     labelPlacement="start"
                     control={
                       <Switch
-                        checked={
-                          feature.flagKey
-                            ? enrollmentByFlagKey[feature.flagKey] === true
-                            : false
-                        }
+                        checked={featureIsEnabled(feature)}
                         disabled={
                           !feature.flagKey ||
                           updatingFlagKey === feature.flagKey

--- a/src/caretogether-pwa/src/Utilities/Instrumentation/earlyAccessEnrollment.ts
+++ b/src/caretogether-pwa/src/Utilities/Instrumentation/earlyAccessEnrollment.ts
@@ -1,0 +1,17 @@
+type PostHogEnrollmentReader = {
+  get_property: (propertyName: string) => unknown;
+};
+
+const POSTHOG_STORED_PERSON_PROPERTIES_KEY = '$stored_person_properties';
+
+export function getEarlyAccessEnrollment(
+  posthog: PostHogEnrollmentReader,
+  flagKey: string
+) {
+  const personProperties = posthog.get_property(
+    POSTHOG_STORED_PERSON_PROPERTIES_KEY
+  ) as Record<string, unknown> | undefined;
+  const enrollment = personProperties?.[`$feature_enrollment/${flagKey}`];
+
+  return typeof enrollment === 'boolean' ? enrollment : undefined;
+}

--- a/src/caretogether-pwa/src/featureFlags.ts
+++ b/src/caretogether-pwa/src/featureFlags.ts
@@ -1,6 +1,4 @@
-export const FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_NAME = 'Family Screen V2';
-export const FAMILY_SCREEN_V2_ENROLLMENT_CHANGED_EVENT =
-  'family-screen-v2-enrollment-changed';
-export const POSTHOG_STORED_PERSON_PROPERTIES_KEY =
-  '$stored_person_properties';
+export const FAMILY_SCREEN_V2_FEATURE_FLAG = 'family-screen-v2';
+export const FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG =
+  'family-screen-v2-ea';
 export const FUNCTION_ASSIGNMENTS_FEATURE_FLAG = 'volunteer-assignments';


### PR DESCRIPTION
This PR adds support for rolling out Family Screen V2 to specific organizations while preserving user-level Early Access preferences.

