### PR TITLE
 Fix canceled assignment status

### DIFF
--- a/src/caretogether-pwa/src/Families/AssignmentCard.tsx
+++ b/src/caretogether-pwa/src/Families/AssignmentCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Typography, Box } from '@mui/material';
+import { Card, CardContent, Typography, Box, Chip } from '@mui/material';
 import {
   CalendarToday as CalendarTodayIcon,
   PersonPinCircle as PersonPinCircleIcon,
@@ -13,6 +13,7 @@ import { partneringFamiliesData } from '../Model/V1CasesModel';
 import { useAppNavigate } from '../Hooks/useAppNavigate';
 import { format } from 'date-fns';
 import { FamilyName } from './FamilyName';
+import { getAssignmentStatus } from './assignmentStatus';
 
 interface AssignmentCardProps {
   assignment: ArrangementEntry;
@@ -43,9 +44,7 @@ export function AssignmentCard({ assignment }: AssignmentCardProps) {
   const partneringFamilies = useLoadable(partneringFamiliesData);
   const navigate = useAppNavigate();
 
-  const isCompleted = assignment.endedAtUtc !== undefined;
-  const progressWidth = isCompleted ? '100%' : '50%';
-  const statusColor = isCompleted ? '#2E7D32' : '#E3AE01';
+  const status = getAssignmentStatus(assignment);
 
   const personInfo = assignment.partneringFamilyPersonId
     ? personAndFamilyLookup(assignment.partneringFamilyPersonId)
@@ -102,16 +101,36 @@ export function AssignmentCard({ assignment }: AssignmentCardProps) {
       <Box
         sx={{
           height: 8,
-          backgroundColor: statusColor,
-          width: progressWidth,
+          backgroundColor: status.color,
+          width: status.progressWidth,
           transition: 'width 0.5s ease-in-out',
         }}
       />
 
       <CardContent>
-        <Typography variant="h6" sx={{ marginBottom: 1 }}>
-          {assignment.arrangementType || 'Unknown Type'}
-        </Typography>
+        <Box
+          sx={{
+            alignItems: 'flex-start',
+            display: 'flex',
+            gap: 1,
+            justifyContent: 'space-between',
+            marginBottom: 1,
+          }}
+        >
+          <Typography variant="h6">
+            {assignment.arrangementType || 'Unknown Type'}
+          </Typography>
+          <Chip
+            label={status.label}
+            size="small"
+            sx={{
+              backgroundColor: status.color,
+              color: 'white',
+              flexShrink: 0,
+              fontWeight: 600,
+            }}
+          />
+        </Box>
 
         <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
           {personInfo?.person

--- a/src/caretogether-pwa/src/Families/assignmentStatus.ts
+++ b/src/caretogether-pwa/src/Families/assignmentStatus.ts
@@ -1,0 +1,55 @@
+import { ArrangementEntry } from '../GeneratedClient';
+
+export type AssignmentStatus = 'Setup' | 'Active' | 'Completed' | 'Canceled';
+
+export interface AssignmentStatusDisplay {
+  label: AssignmentStatus;
+  color: string;
+  progressWidth: string;
+}
+
+type AssignmentStatusSource = Pick<
+  ArrangementEntry,
+  'active' | 'startedAtUtc' | 'endedAtUtc' | 'cancelledAtUtc'
+>;
+
+export const assignmentStatusColorMap: Record<AssignmentStatus, string> = {
+  Setup: '#E3AE01',
+  Active: '#E3AE01',
+  Completed: '#2E7D32',
+  Canceled: '#9E9E9E',
+};
+
+export function getAssignmentStatus(
+  assignment: AssignmentStatusSource
+): AssignmentStatusDisplay {
+  if (assignment.cancelledAtUtc) {
+    return {
+      label: 'Canceled',
+      color: assignmentStatusColorMap.Canceled,
+      progressWidth: '100%',
+    };
+  }
+
+  if (assignment.endedAtUtc) {
+    return {
+      label: 'Completed',
+      color: assignmentStatusColorMap.Completed,
+      progressWidth: '100%',
+    };
+  }
+
+  if (assignment.active || assignment.startedAtUtc) {
+    return {
+      label: 'Active',
+      color: assignmentStatusColorMap.Active,
+      progressWidth: '50%',
+    };
+  }
+
+  return {
+    label: 'Setup',
+    color: assignmentStatusColorMap.Setup,
+    progressWidth: '50%',
+  };
+}


### PR DESCRIPTION
I fixed the assignment status display so canceled assignments now show as "Canceled." I also updated the assignment card styling so canceled assignments use a gray status color instead of the setup yellow. On top of that, I added explicit status precedence logic to make sure canceled assignments always take priority over any setup or active-looking assignment data.
<img width="1921" height="954" alt="Screenshot (1166)" src="https://github.com/user-attachments/assets/3c086b96-807d-4eb8-98a9-4fb94726bc2a" />
