### PR TITLE
[codex] Limit family screen V2 rollout to explicit gates

### DIFF
--- a/src/caretogether-pwa/src/Families/FamilyScreenRoute.tsx
+++ b/src/caretogether-pwa/src/Families/FamilyScreenRoute.tsx
@@ -12,9 +12,6 @@ import { FamilyScreenV2 } from './FamilyScreenV2';
 export function FamilyScreenRoute() {
   const posthog = usePostHog();
   const rolloutEnabled = useFeatureFlagEnabled(FAMILY_SCREEN_V2_FEATURE_FLAG);
-  const earlyAccessFlagEnabled = useFeatureFlagEnabled(
-    FAMILY_SCREEN_V2_EARLY_ACCESS_FEATURE_FLAG
-  );
   const [featureFlagsLoaded, setFeatureFlagsLoaded] = useState(
     () => posthog.featureFlags.hasLoadedFlags
   );
@@ -55,8 +52,7 @@ export function FamilyScreenRoute() {
   }
 
   const showFamilyScreenV2 =
-    earlyAccessEnrollment ??
-    (earlyAccessFlagEnabled === true || rolloutEnabled === true);
+    earlyAccessEnrollment ?? (rolloutEnabled === true);
 
   return showFamilyScreenV2 ? <FamilyScreenV2 /> : <FamilyScreen />;
 }


### PR DESCRIPTION


  Fixes the family screen V2 route gate so the evaluated early-access flag no longer causes broad V2 rollout.

  The route now shows Family Screen V2 only when the user has explicitly opted into the early-access enrollment, or when the
  new family-screen-v2 rollout flag evaluates true. Explicit early-access opt-out still keeps the user on V1.
