### PR TITLE
Improve dashboard calendar event filtering

### DIFF
--- a/src/caretogether-pwa/src/Dashboard/DashboardCalendar.tsx
+++ b/src/caretogether-pwa/src/Dashboard/DashboardCalendar.tsx
@@ -1,4 +1,13 @@
 import { MouseEvent, useMemo, useState } from 'react';
+import {
+  addDays,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns';
 import Grid from '../Generic/GridLegacyCompat';
 import {
   Box,
@@ -21,6 +30,7 @@ import {
 } from './dashboardCalendarEvents';
 
 const DASHBOARD_CALENDAR_VIEW_KEY = 'dashboardCalendarView';
+const DASHBOARD_CALENDAR_AGENDA_DAYS = 12;
 const DASHBOARD_CALENDAR_EVENT_COLORS = {
   teal: {
     backgroundColor: '#80cbc4',
@@ -139,6 +149,27 @@ function getSavedInitialView(): CalendarView {
   return 'month';
 }
 
+function getVisibleDateRange(view: CalendarView, visibleDate: Date) {
+  if (view === 'agenda') {
+    return {
+      start: startOfDay(visibleDate),
+      end: endOfDay(addDays(visibleDate, DASHBOARD_CALENDAR_AGENDA_DAYS - 1)),
+    };
+  }
+
+  if (view === 'month') {
+    return {
+      start: startOfWeek(startOfMonth(visibleDate), { weekStartsOn: 1 }),
+      end: endOfWeek(endOfMonth(visibleDate), { weekStartsOn: 1 }),
+    };
+  }
+
+  return {
+    start: startOfDay(visibleDate),
+    end: endOfDay(visibleDate),
+  };
+}
+
 function getDashboardCalendarEventId(element: Element | null) {
   const eventElement = element?.closest('.dashboard-calendar-event');
   const eventIdClass = Array.from(eventElement?.classList || []).find((name) =>
@@ -188,39 +219,48 @@ export function DashboardCalendar() {
   const partneringFamilies = useLoadable(partneringFamiliesData);
   const appNavigate = useAppNavigate();
   const [view, setView] = useState<CalendarView>(getSavedInitialView);
+  const [visibleDate, setVisibleDate] = useState(() => startOfDay(new Date()));
   const [selectedEventTypeFilterKeys, setSelectedEventTypeFilterKeys] =
     useState<Set<string>>(
       () => new Set(calendarEventTypeFilters.map((filter) => filter.key))
     );
 
+  const visibleDateRange = useMemo(
+    () => getVisibleDateRange(view, visibleDate),
+    [view, visibleDate]
+  );
+
   const eventGroups = useMemo(
     () =>
       buildDashboardCalendarEventGroups(
         partneringFamilies || undefined,
-        familyLookup
+        familyLookup,
+        visibleDateRange
       ),
-    [familyLookup, partneringFamilies]
+    [familyLookup, partneringFamilies, visibleDateRange]
   );
 
-  const filteredEvents = Object.values(CalendarFilters).flatMap((filter) =>
-    eventGroups[filter].filter((event) =>
-      selectedEventTypeFilterKeys.has(
-        getDashboardCalendarEventTypeFilterKey(filter, event)
-      )
-    )
-  );
-
-  const eventsById = useMemo(
+  const filteredEvents = useMemo(
     () =>
-      filteredEvents.reduce<Record<string, DashboardCalendarEvent>>(
-        (lookup, event) => ({
-          ...lookup,
-          [String(event.id)]: event,
-        }),
-        {}
+      Object.values(CalendarFilters).flatMap((filter) =>
+        eventGroups[filter].filter((event) =>
+          selectedEventTypeFilterKeys.has(
+            getDashboardCalendarEventTypeFilterKey(filter, event)
+          )
+        )
       ),
-    [filteredEvents]
+    [eventGroups, selectedEventTypeFilterKeys]
   );
+
+  const eventsById = useMemo(() => {
+    const lookup: Record<string, DashboardCalendarEvent> = {};
+
+    filteredEvents.forEach((event) => {
+      lookup[String(event.id)] = event;
+    });
+
+    return lookup;
+  }, [filteredEvents]);
 
   function navigateToCalendarEvent(event: DashboardCalendarEvent | undefined) {
     if (!event) {
@@ -558,8 +598,12 @@ export function DashboardCalendar() {
         />
         <EventCalendar
           events={filteredEvents}
+          visibleDate={visibleDate}
           view={view}
           views={calendarViews}
+          onVisibleDateChange={(nextVisibleDate) => {
+            setVisibleDate(startOfDay(nextVisibleDate));
+          }}
           onViewChange={(nextView) => {
             localStorage.setItem(DASHBOARD_CALENDAR_VIEW_KEY, nextView);
             setView(nextView);

--- a/src/caretogether-pwa/src/Dashboard/dashboardCalendarEvents.ts
+++ b/src/caretogether-pwa/src/Dashboard/dashboardCalendarEvents.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, isValid, parseISO } from 'date-fns';
 import type {
   SchedulerEvent,
   SchedulerEventColor,
@@ -51,6 +51,11 @@ type LegacyDashboardCalendarEvent = {
 
 type CalendarEventGroups = Record<CalendarFilters, DashboardCalendarEvent[]>;
 
+export type DashboardCalendarDateRange = {
+  start: Date;
+  end: Date;
+};
+
 type DashboardCalendarArrangement = {
   arrangement: Arrangement;
   person: Person;
@@ -64,6 +69,44 @@ function getSchedulerEventId(filter: CalendarFilters, index: number) {
 
 function isDefined<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
+}
+
+function toCalendarDate(value: Date | string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  const date = parseISO(value);
+
+  if (isValid(date)) {
+    return date;
+  }
+
+  return new Date(value);
+}
+
+function dateRangeOverlaps(
+  startValue: Date | string | undefined,
+  endValue: Date | string | undefined,
+  range: DashboardCalendarDateRange
+) {
+  const start = toCalendarDate(startValue);
+
+  if (!start || !isValid(start)) {
+    return false;
+  }
+
+  const end = toCalendarDate(endValue) || start;
+
+  if (!isValid(end)) {
+    return false;
+  }
+
+  return start <= range.end && end >= range.start;
 }
 
 function familyPerson(
@@ -190,7 +233,8 @@ function toSchedulerEvents(
 
 export function buildDashboardCalendarEventGroups(
   partneringFamilies: CombinedFamilyInfo[] | undefined,
-  familyLookup: (familyId: string | undefined) => CombinedFamilyInfo | undefined
+  familyLookup: (familyId: string | undefined) => CombinedFamilyInfo | undefined,
+  visibleDateRange: DashboardCalendarDateRange
 ): CalendarEventGroups {
   const allArrangements = (partneringFamilies || []).flatMap((family) =>
     (family.partneringFamilyInfo?.closedV1Cases || [])
@@ -198,27 +242,41 @@ export function buildDashboardCalendarEventGroups(
       .flatMap((v1Case) => getDashboardCalendarArrangements(family, v1Case))
   );
 
-  const arrangementPlannedDurations = allArrangements.map(
-    ({
-      arrangement,
-      person,
-      familyId,
-      v1CaseId,
-    }): LegacyDashboardCalendarEvent => ({
-      title: `${personNameString(person)} - ${arrangement.arrangementType}`,
-      start:
-        arrangement.plannedStartUtc &&
-        format(arrangement.plannedStartUtc, 'yyyy-MM-dd'),
-      end:
-        arrangement.plannedEndUtc &&
-        format(arrangement.plannedEndUtc, 'yyyy-MM-dd'),
-      backgroundColor: DASHBOARD_CALENDAR_LEGACY_EVENT_COLORS.lightBlue,
-      extendedProps: { familyId, v1CaseId, arrangementId: arrangement.id },
-    })
-  );
+  const arrangementPlannedDurations = allArrangements
+    .filter(({ arrangement }) =>
+      dateRangeOverlaps(
+        arrangement.plannedStartUtc,
+        arrangement.plannedEndUtc,
+        visibleDateRange
+      )
+    )
+    .map(
+      ({
+        arrangement,
+        person,
+        familyId,
+        v1CaseId,
+      }): LegacyDashboardCalendarEvent => ({
+        title: `${personNameString(person)} - ${arrangement.arrangementType}`,
+        start:
+          arrangement.plannedStartUtc &&
+          format(arrangement.plannedStartUtc, 'yyyy-MM-dd'),
+        end:
+          arrangement.plannedEndUtc &&
+          format(arrangement.plannedEndUtc, 'yyyy-MM-dd'),
+        backgroundColor: DASHBOARD_CALENDAR_LEGACY_EVENT_COLORS.lightBlue,
+        extendedProps: { familyId, v1CaseId, arrangementId: arrangement.id },
+      })
+    );
 
   const arrangementActualStarts = allArrangements
-    .filter(({ arrangement }) => arrangement.startedAtUtc)
+    .filter(({ arrangement }) =>
+      dateRangeOverlaps(
+        arrangement.startedAtUtc,
+        undefined,
+        visibleDateRange
+      )
+    )
     .map(
       ({
         arrangement,
@@ -238,7 +296,9 @@ export function buildDashboardCalendarEventGroups(
     );
 
   const arrangementActualEnds = allArrangements
-    .filter(({ arrangement }) => arrangement.endedAtUtc)
+    .filter(({ arrangement }) =>
+      dateRangeOverlaps(arrangement.endedAtUtc, undefined, visibleDateRange)
+    )
     .map(
       ({
         arrangement,
@@ -259,18 +319,26 @@ export function buildDashboardCalendarEventGroups(
 
   const arrangementCompletedRequirements = allArrangements.flatMap(
     ({ arrangement, person, familyId, v1CaseId }) =>
-      arrangement.completedRequirements?.map(
-        (completed): LegacyDashboardCalendarEvent => ({
-          title: `✅ ${personNameString(person)} - ${completed.requirementName}`,
-          date: completed.completedAtUtc,
-          backgroundColor: DASHBOARD_CALENDAR_LEGACY_EVENT_COLORS.teal,
-          extendedProps: {
-            familyId,
-            v1CaseId,
-            arrangementId: arrangement.id,
-          },
-        })
-      ) || []
+      arrangement.completedRequirements
+        ?.filter((completed) =>
+          dateRangeOverlaps(
+            completed.completedAtUtc,
+            undefined,
+            visibleDateRange
+          )
+        )
+        .map(
+          (completed): LegacyDashboardCalendarEvent => ({
+            title: `✅ ${personNameString(person)} - ${completed.requirementName}`,
+            date: completed.completedAtUtc,
+            backgroundColor: DASHBOARD_CALENDAR_LEGACY_EVENT_COLORS.teal,
+            extendedProps: {
+              familyId,
+              v1CaseId,
+              arrangementId: arrangement.id,
+            },
+          })
+        ) || []
   );
 
   const allArrangementMissingRequirements = allArrangements.flatMap(
@@ -285,7 +353,9 @@ export function buildDashboardCalendarEventGroups(
   );
 
   const arrangementPastDueRequirements = allArrangementMissingRequirements
-    .filter(({ missing }) => missing.pastDueSince)
+    .filter(({ missing }) =>
+      dateRangeOverlaps(missing.pastDueSince, undefined, visibleDateRange)
+    )
     .map(
       ({
         person,
@@ -307,7 +377,9 @@ export function buildDashboardCalendarEventGroups(
     );
 
   const arrangementUpcomingRequirements = allArrangementMissingRequirements
-    .filter(({ missing }) => missing.dueBy)
+    .filter(({ missing }) =>
+      dateRangeOverlaps(missing.dueBy, undefined, visibleDateRange)
+    )
     .map(
       ({
         person,
@@ -329,25 +401,39 @@ export function buildDashboardCalendarEventGroups(
 
   const arrangementActualChildcare = allArrangements.flatMap(
     ({ arrangement, person, familyId, v1CaseId }) => {
-      const durationEntries = (arrangement.childLocationHistory || []).map(
+      const durationEntries = (arrangement.childLocationHistory || []).flatMap(
         (entry, index, history) => {
           const nextEntry =
             index < history.length - 1 ? history[index + 1] : null;
+
+          if (
+            !dateRangeOverlaps(
+              entry.timestampUtc,
+              nextEntry?.timestampUtc,
+              visibleDateRange
+            )
+          ) {
+            return [];
+          }
+
           const locationFamily = familyLookup(entry.childLocationFamilyId);
-          return {
-            title: `🤝🏻 ${personNameString(person)} - ${familyNameString(locationFamily)}`,
-            start: entry.timestampUtc,
-            backgroundColor:
-              entry.plan === ChildLocationPlan.WithParent
-                ? undefined
-                : DASHBOARD_CALENDAR_LEGACY_EVENT_COLORS.teal,
-            end: nextEntry?.timestampUtc,
-            extendedProps: {
-              familyId,
-              v1CaseId,
-              arrangementId: arrangement.id,
+
+          return [
+            {
+              title: `🤝🏻 ${personNameString(person)} - ${familyNameString(locationFamily)}`,
+              start: entry.timestampUtc,
+              backgroundColor:
+                entry.plan === ChildLocationPlan.WithParent
+                  ? undefined
+                  : DASHBOARD_CALENDAR_LEGACY_EVENT_COLORS.teal,
+              end: nextEntry?.timestampUtc,
+              extendedProps: {
+                familyId,
+                v1CaseId,
+                arrangementId: arrangement.id,
+              },
             },
-          };
+          ];
         }
       );
       return durationEntries.filter(
@@ -359,24 +445,38 @@ export function buildDashboardCalendarEventGroups(
 
   const arrangementPlannedChildcare = allArrangements.flatMap(
     ({ arrangement, person, familyId, v1CaseId }) => {
-      const durationEntries = (arrangement.childLocationPlan || []).map(
+      const durationEntries = (arrangement.childLocationPlan || []).flatMap(
         (entry, index, plan) => {
           const nextEntry = index < plan.length - 1 ? plan[index + 1] : null;
+
+          if (
+            !dateRangeOverlaps(
+              entry.timestampUtc,
+              nextEntry?.timestampUtc,
+              visibleDateRange
+            )
+          ) {
+            return [];
+          }
+
           const locationFamily = familyLookup(entry.childLocationFamilyId);
-          return {
-            title: `✋🏻 ${personNameString(person)} - ${familyNameString(locationFamily)}`,
-            start: entry.timestampUtc,
-            backgroundColor:
-              entry.plan === ChildLocationPlan.WithParent
-                ? undefined
-                : DASHBOARD_CALENDAR_LEGACY_EVENT_COLORS.lightBlue,
-            end: nextEntry?.timestampUtc,
-            extendedProps: {
-              familyId,
-              v1CaseId,
-              arrangementId: arrangement.id,
+
+          return [
+            {
+              title: `✋🏻 ${personNameString(person)} - ${familyNameString(locationFamily)}`,
+              start: entry.timestampUtc,
+              backgroundColor:
+                entry.plan === ChildLocationPlan.WithParent
+                  ? undefined
+                  : DASHBOARD_CALENDAR_LEGACY_EVENT_COLORS.lightBlue,
+              end: nextEntry?.timestampUtc,
+              extendedProps: {
+                familyId,
+                v1CaseId,
+                arrangementId: arrangement.id,
+              },
             },
-          };
+          ];
         }
       );
       return durationEntries.filter(


### PR DESCRIPTION
## Summary
- Limit dashboard calendar event group construction to the currently visible month/agenda window
- Move date-overlap filtering into the event builder before scheduler events are materialized (call `familyLookup` on the filtered list of events, that reduces from 20k+ calls to a few hundreds with our biggest org/location)
- Keep event-type toggles as the final filter and avoid rebuilding the event lookup with object spreads

## Verification
- npm run type-check
- npx eslint src/Dashboard/DashboardCalendar.tsx src/Dashboard/dashboardCalendarEvents.ts --report-unused-disable-directives --max-warnings 0
- npm run build

Note: build still reports existing Application Insights/Rolldown annotation warnings and chunk-size warnings.