### PR TITLE
Add arrangement policy versions

### DIFF
--- a/src/CareTogether.Api/OData/LiveODataModelController.cs
+++ b/src/CareTogether.Api/OData/LiveODataModelController.cs
@@ -199,7 +199,8 @@ namespace CareTogether.Api.OData
         DateTime? StartedUtc,
         DateTime? EndedUtc,
         ArrangementPhase Phase,
-        string? Reason
+        string? Reason,
+        string? PolicyVersion
     );
 
     public sealed record ArrangementType(
@@ -2167,7 +2168,8 @@ namespace CareTogether.Api.OData
                         arrangement.StartedAtUtc,
                         arrangement.EndedAtUtc,
                         arrangement.Phase,
-                        arrangement.Reason
+                        arrangement.Reason,
+                        arrangement.ArrangementPolicyVersion
                     );
                 });
             });

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationEngine.cs
@@ -337,7 +337,8 @@ namespace CareTogether.Engines.PolicyEvaluation
                 exemptedRequirements,
                 individualVolunteerAssignments,
                 familyVolunteerAssignments,
-                ChildLocationHistory
+                ChildLocationHistory,
+                entry.ArrangementPolicyVersion
             );
         }
 

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralCalculations.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralCalculations.cs
@@ -46,8 +46,9 @@ namespace CareTogether.Engines.PolicyEvaluation
                 arrangement => arrangement.Key,
                 arrangement =>
                 {
-                    ArrangementPolicy arrangementPolicy = v1CasePolicy.ArrangementPolicies.Single(
-                        p => p.ArrangementType == arrangement.Value.ArrangementType
+                    var arrangementPolicy = GetArrangementPolicyForEvaluation(
+                        v1CasePolicy,
+                        arrangement.Value
                     );
 
                     return CalculateArrangementStatus(
@@ -63,6 +64,40 @@ namespace CareTogether.Engines.PolicyEvaluation
                 missingIntakeRequirements,
                 missingCustomFields,
                 individualArrangements
+            );
+        }
+
+        internal static ArrangementPolicy GetArrangementPolicyForEvaluation(
+            V1CasePolicy v1CasePolicy,
+            ArrangementEntry arrangement
+        )
+        {
+            var arrangementPolicy = v1CasePolicy.ArrangementPolicies.Single(p =>
+                p.ArrangementType == arrangement.ArrangementType
+            );
+
+            if (arrangement.ArrangementPolicyVersion == null)
+                return arrangementPolicy;
+
+            var policyVersion =
+                arrangementPolicy.PolicyVersions?.SingleOrDefault(version =>
+                    version.Version == arrangement.ArrangementPolicyVersion
+                )
+                ?? throw new InvalidOperationException(
+                    $"The arrangement policy version '{arrangement.ArrangementPolicyVersion}' does not exist for arrangement type '{arrangement.ArrangementType}'."
+                );
+
+            return new ArrangementPolicy(
+                arrangementPolicy.ArrangementType,
+                policyVersion.ChildInvolvement,
+                policyVersion.ArrangementFunctions,
+                policyVersion.RequiredSetupActionNames,
+                policyVersion.RequiredMonitoringActions,
+                policyVersion.RequiredCloseoutActionNames,
+                policyVersion.RequiredSetupActions,
+                policyVersion.RequiredMonitoringActionsNew,
+                policyVersion.RequiredCloseoutActions,
+                policyVersion.SupersededAtUtc
             );
         }
 

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralEntryForCalculation.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/ReferralEntryForCalculation.cs
@@ -33,7 +33,8 @@ namespace CareTogether.Engines.PolicyEvaluation
         ImmutableList<ExemptedRequirementInfo> ExemptedRequirements,
         ImmutableList<IndividualVolunteerAssignment> IndividualVolunteerAssignments,
         ImmutableList<FamilyVolunteerAssignment> FamilyVolunteerAssignments,
-        ImmutableList<ChildLocation> ChildLocationHistory
+        ImmutableList<ChildLocation> ChildLocationHistory,
+        string? ArrangementPolicyVersion = null
     );
 
     public sealed record IndividualVolunteerAssignment(

--- a/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
+++ b/src/CareTogether.Core/Managers/CombinedFamilyInfoFormatter.cs
@@ -367,7 +367,8 @@ namespace CareTogether.Managers
                     entry.ChildLocationHistory,
                     entry.ChildLocationPlan,
                     entry.Comments,
-                    entry.Reason
+                    entry.Reason,
+                    entry.ArrangementPolicyVersion
                 );
         }
 

--- a/src/CareTogether.Core/Managers/SharedContracts.cs
+++ b/src/CareTogether.Core/Managers/SharedContracts.cs
@@ -73,7 +73,8 @@ namespace CareTogether.Managers
         ImmutableSortedSet<ChildLocationHistoryEntry> ChildLocationHistory,
         ImmutableSortedSet<ChildLocationHistoryEntry> ChildLocationPlan,
         string? Comments,
-        string? Reason
+        string? Reason,
+        string? ArrangementPolicyVersion = null
     );
 
     public sealed record Note(

--- a/src/CareTogether.Core/Resources/Policies/IPoliciesResource.cs
+++ b/src/CareTogether.Core/Resources/Policies/IPoliciesResource.cs
@@ -238,7 +238,44 @@ namespace CareTogether.Resources.Policies
         ImmutableList<RequirementDefinition>? RequiredSetupActions = null,
         ImmutableList<MonitoringRequirement>? RequiredMonitoringActionsNew = null, // TODO: Rename to RequiredMonitoringActions after migration (see TODO in ReferralPolicy)
         ImmutableList<RequirementDefinition>? RequiredCloseoutActions = null,
-        DateTime? SupersededAtUtc = null
+        DateTime? SupersededAtUtc = null,
+        ImmutableList<ArrangementPolicyVersion>? PolicyVersions = null
+    )
+    {
+        public ImmutableList<RequirementDefinition> RequiredSetupActions_PRE_MIGRATION =
+            RequiredSetupActionNames
+                .Select(requirementName => new RequirementDefinition(requirementName, true))
+                .Concat(RequiredSetupActions ?? ImmutableList<RequirementDefinition>.Empty)
+                .ToImmutableList();
+
+        public ImmutableList<MonitoringRequirement> RequiredMonitoringActions_PRE_MIGRATION =
+            RequiredMonitoringActions
+                .Select(requirement => new MonitoringRequirement(
+                    new RequirementDefinition(requirement.ActionName, true),
+                    requirement.Recurrence
+                ))
+                .Concat(RequiredMonitoringActionsNew ?? ImmutableList<MonitoringRequirement>.Empty)
+                .ToImmutableList();
+
+        public ImmutableList<RequirementDefinition> RequiredCloseoutActionNames_PRE_MIGRATION =
+            RequiredCloseoutActionNames
+                .Select(requirementName => new RequirementDefinition(requirementName, true))
+                .Concat(RequiredCloseoutActions ?? ImmutableList<RequirementDefinition>.Empty)
+                .ToImmutableList();
+    };
+
+    public sealed record ArrangementPolicyVersion(
+        string Version,
+        DateTime? SupersededAtUtc,
+        ChildInvolvement ChildInvolvement,
+        ImmutableList<ArrangementFunction> ArrangementFunctions,
+        ImmutableList<string> RequiredSetupActionNames,
+        ImmutableList<MonitoringRequirementOld> RequiredMonitoringActions,
+        ImmutableList<string> RequiredCloseoutActionNames,
+        // TODO: See TODO in ReferralPolicy
+        ImmutableList<RequirementDefinition>? RequiredSetupActions = null,
+        ImmutableList<MonitoringRequirement>? RequiredMonitoringActionsNew = null, // TODO: Rename to RequiredMonitoringActions after migration (see TODO in ReferralPolicy)
+        ImmutableList<RequirementDefinition>? RequiredCloseoutActions = null
     )
     {
         public ImmutableList<RequirementDefinition> RequiredSetupActions_PRE_MIGRATION =

--- a/src/CareTogether.Core/Resources/Referrals/IReferralsResource.cs
+++ b/src/CareTogether.Core/Resources/Referrals/IReferralsResource.cs
@@ -41,7 +41,8 @@ namespace CareTogether.Resources.V1Cases
         ImmutableSortedSet<ChildLocationHistoryEntry> ChildLocationHistory,
         ImmutableSortedSet<ChildLocationHistoryEntry> ChildLocationPlan,
         string? Comments,
-        string? Reason
+        string? Reason,
+        string? ArrangementPolicyVersion = null
     );
 
     public enum V1CaseCloseReason
@@ -195,7 +196,8 @@ namespace CareTogether.Resources.V1Cases
         string ArrangementType,
         DateTime RequestedAtUtc,
         Guid PartneringFamilyPersonId,
-        string? Reason
+        string? Reason,
+        string? ArrangementPolicyVersion = null
     ) : ArrangementsCommand(FamilyId, ReferralId, ArrangementIds);
 
     public sealed record AssignIndividualVolunteer(

--- a/src/CareTogether.Core/Resources/Referrals/ReferralModel.cs
+++ b/src/CareTogether.Core/Resources/Referrals/ReferralModel.cs
@@ -330,7 +330,8 @@ namespace CareTogether.Resources.V1Cases
                                 ImmutableSortedSet<ChildLocationHistoryEntry>.Empty,
                                 ImmutableSortedSet<ChildLocationHistoryEntry>.Empty,
                                 Comments: null,
-                                Reason: c.Reason
+                                Reason: c.Reason,
+                                ArrangementPolicyVersion: c.ArrangementPolicyVersion
                             ),
                             null
                         ),

--- a/src/caretogether-pwa/src/GeneratedClient.ts
+++ b/src/caretogether-pwa/src/GeneratedClient.ts
@@ -3044,6 +3044,7 @@ export class ArrangementPolicy implements IArrangementPolicy {
     requiredMonitoringActionsNew?: MonitoringRequirement[] | undefined;
     requiredCloseoutActions?: RequirementDefinition[] | undefined;
     supersededAtUtc?: Date | undefined;
+    policyVersions?: ArrangementPolicyVersion[] | undefined;
 
     constructor(data?: IArrangementPolicy) {
         if (data) {
@@ -3118,6 +3119,11 @@ export class ArrangementPolicy implements IArrangementPolicy {
                     this.requiredCloseoutActions!.push(RequirementDefinition.fromJS(item));
             }
             this.supersededAtUtc = _data["supersededAtUtc"] ? new Date(_data["supersededAtUtc"].toString()) : undefined as any;
+            if (Array.isArray(_data["policyVersions"])) {
+                this.policyVersions = [] as any;
+                for (let item of _data["policyVersions"])
+                    this.policyVersions!.push(ArrangementPolicyVersion.fromJS(item));
+            }
         }
     }
 
@@ -3183,6 +3189,11 @@ export class ArrangementPolicy implements IArrangementPolicy {
                 data["requiredCloseoutActions"].push(item ? item.toJSON() : undefined as any);
         }
         data["supersededAtUtc"] = this.supersededAtUtc ? this.supersededAtUtc.toISOString() : undefined as any;
+        if (Array.isArray(this.policyVersions)) {
+            data["policyVersions"] = [];
+            for (let item of this.policyVersions)
+                data["policyVersions"].push(item ? item.toJSON() : undefined as any);
+        }
         return data;
     }
 }
@@ -3201,6 +3212,7 @@ export interface IArrangementPolicy {
     requiredMonitoringActionsNew?: MonitoringRequirement[] | undefined;
     requiredCloseoutActions?: RequirementDefinition[] | undefined;
     supersededAtUtc?: Date | undefined;
+    policyVersions?: ArrangementPolicyVersion[] | undefined;
 }
 
 export class MonitoringRequirement implements IMonitoringRequirement {
@@ -3802,6 +3814,179 @@ export class MonitoringRequirementOld implements IMonitoringRequirementOld {
 export interface IMonitoringRequirementOld {
     actionName: string;
     recurrence: RecurrencePolicy;
+}
+
+export class ArrangementPolicyVersion implements IArrangementPolicyVersion {
+    requiredSetupActions_PRE_MIGRATION!: RequirementDefinition[];
+    requiredMonitoringActions_PRE_MIGRATION!: MonitoringRequirement[];
+    requiredCloseoutActionNames_PRE_MIGRATION!: RequirementDefinition[];
+    version!: string;
+    supersededAtUtc?: Date | undefined;
+    childInvolvement!: ChildInvolvement;
+    arrangementFunctions!: ArrangementFunction[];
+    requiredSetupActionNames!: string[];
+    requiredMonitoringActions!: MonitoringRequirementOld[];
+    requiredCloseoutActionNames!: string[];
+    requiredSetupActions?: RequirementDefinition[] | undefined;
+    requiredMonitoringActionsNew?: MonitoringRequirement[] | undefined;
+    requiredCloseoutActions?: RequirementDefinition[] | undefined;
+
+    constructor(data?: IArrangementPolicyVersion) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (this as any)[property] = (data as any)[property];
+            }
+        }
+        if (!data) {
+            this.requiredSetupActions_PRE_MIGRATION = [];
+            this.requiredMonitoringActions_PRE_MIGRATION = [];
+            this.requiredCloseoutActionNames_PRE_MIGRATION = [];
+            this.arrangementFunctions = [];
+            this.requiredSetupActionNames = [];
+            this.requiredMonitoringActions = [];
+            this.requiredCloseoutActionNames = [];
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["requiredSetupActions_PRE_MIGRATION"])) {
+                this.requiredSetupActions_PRE_MIGRATION = [] as any;
+                for (let item of _data["requiredSetupActions_PRE_MIGRATION"])
+                    this.requiredSetupActions_PRE_MIGRATION!.push(RequirementDefinition.fromJS(item));
+            }
+            if (Array.isArray(_data["requiredMonitoringActions_PRE_MIGRATION"])) {
+                this.requiredMonitoringActions_PRE_MIGRATION = [] as any;
+                for (let item of _data["requiredMonitoringActions_PRE_MIGRATION"])
+                    this.requiredMonitoringActions_PRE_MIGRATION!.push(MonitoringRequirement.fromJS(item));
+            }
+            if (Array.isArray(_data["requiredCloseoutActionNames_PRE_MIGRATION"])) {
+                this.requiredCloseoutActionNames_PRE_MIGRATION = [] as any;
+                for (let item of _data["requiredCloseoutActionNames_PRE_MIGRATION"])
+                    this.requiredCloseoutActionNames_PRE_MIGRATION!.push(RequirementDefinition.fromJS(item));
+            }
+            this.version = _data["version"];
+            this.supersededAtUtc = _data["supersededAtUtc"] ? new Date(_data["supersededAtUtc"].toString()) : undefined as any;
+            this.childInvolvement = _data["childInvolvement"];
+            if (Array.isArray(_data["arrangementFunctions"])) {
+                this.arrangementFunctions = [] as any;
+                for (let item of _data["arrangementFunctions"])
+                    this.arrangementFunctions!.push(ArrangementFunction.fromJS(item));
+            }
+            if (Array.isArray(_data["requiredSetupActionNames"])) {
+                this.requiredSetupActionNames = [] as any;
+                for (let item of _data["requiredSetupActionNames"])
+                    this.requiredSetupActionNames!.push(item);
+            }
+            if (Array.isArray(_data["requiredMonitoringActions"])) {
+                this.requiredMonitoringActions = [] as any;
+                for (let item of _data["requiredMonitoringActions"])
+                    this.requiredMonitoringActions!.push(MonitoringRequirementOld.fromJS(item));
+            }
+            if (Array.isArray(_data["requiredCloseoutActionNames"])) {
+                this.requiredCloseoutActionNames = [] as any;
+                for (let item of _data["requiredCloseoutActionNames"])
+                    this.requiredCloseoutActionNames!.push(item);
+            }
+            if (Array.isArray(_data["requiredSetupActions"])) {
+                this.requiredSetupActions = [] as any;
+                for (let item of _data["requiredSetupActions"])
+                    this.requiredSetupActions!.push(RequirementDefinition.fromJS(item));
+            }
+            if (Array.isArray(_data["requiredMonitoringActionsNew"])) {
+                this.requiredMonitoringActionsNew = [] as any;
+                for (let item of _data["requiredMonitoringActionsNew"])
+                    this.requiredMonitoringActionsNew!.push(MonitoringRequirement.fromJS(item));
+            }
+            if (Array.isArray(_data["requiredCloseoutActions"])) {
+                this.requiredCloseoutActions = [] as any;
+                for (let item of _data["requiredCloseoutActions"])
+                    this.requiredCloseoutActions!.push(RequirementDefinition.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): ArrangementPolicyVersion {
+        data = typeof data === 'object' ? data : {};
+        let result = new ArrangementPolicyVersion();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.requiredSetupActions_PRE_MIGRATION)) {
+            data["requiredSetupActions_PRE_MIGRATION"] = [];
+            for (let item of this.requiredSetupActions_PRE_MIGRATION)
+                data["requiredSetupActions_PRE_MIGRATION"].push(item ? item.toJSON() : undefined as any);
+        }
+        if (Array.isArray(this.requiredMonitoringActions_PRE_MIGRATION)) {
+            data["requiredMonitoringActions_PRE_MIGRATION"] = [];
+            for (let item of this.requiredMonitoringActions_PRE_MIGRATION)
+                data["requiredMonitoringActions_PRE_MIGRATION"].push(item ? item.toJSON() : undefined as any);
+        }
+        if (Array.isArray(this.requiredCloseoutActionNames_PRE_MIGRATION)) {
+            data["requiredCloseoutActionNames_PRE_MIGRATION"] = [];
+            for (let item of this.requiredCloseoutActionNames_PRE_MIGRATION)
+                data["requiredCloseoutActionNames_PRE_MIGRATION"].push(item ? item.toJSON() : undefined as any);
+        }
+        data["version"] = this.version;
+        data["supersededAtUtc"] = this.supersededAtUtc ? this.supersededAtUtc.toISOString() : undefined as any;
+        data["childInvolvement"] = this.childInvolvement;
+        if (Array.isArray(this.arrangementFunctions)) {
+            data["arrangementFunctions"] = [];
+            for (let item of this.arrangementFunctions)
+                data["arrangementFunctions"].push(item ? item.toJSON() : undefined as any);
+        }
+        if (Array.isArray(this.requiredSetupActionNames)) {
+            data["requiredSetupActionNames"] = [];
+            for (let item of this.requiredSetupActionNames)
+                data["requiredSetupActionNames"].push(item);
+        }
+        if (Array.isArray(this.requiredMonitoringActions)) {
+            data["requiredMonitoringActions"] = [];
+            for (let item of this.requiredMonitoringActions)
+                data["requiredMonitoringActions"].push(item ? item.toJSON() : undefined as any);
+        }
+        if (Array.isArray(this.requiredCloseoutActionNames)) {
+            data["requiredCloseoutActionNames"] = [];
+            for (let item of this.requiredCloseoutActionNames)
+                data["requiredCloseoutActionNames"].push(item);
+        }
+        if (Array.isArray(this.requiredSetupActions)) {
+            data["requiredSetupActions"] = [];
+            for (let item of this.requiredSetupActions)
+                data["requiredSetupActions"].push(item ? item.toJSON() : undefined as any);
+        }
+        if (Array.isArray(this.requiredMonitoringActionsNew)) {
+            data["requiredMonitoringActionsNew"] = [];
+            for (let item of this.requiredMonitoringActionsNew)
+                data["requiredMonitoringActionsNew"].push(item ? item.toJSON() : undefined as any);
+        }
+        if (Array.isArray(this.requiredCloseoutActions)) {
+            data["requiredCloseoutActions"] = [];
+            for (let item of this.requiredCloseoutActions)
+                data["requiredCloseoutActions"].push(item ? item.toJSON() : undefined as any);
+        }
+        return data;
+    }
+}
+
+export interface IArrangementPolicyVersion {
+    requiredSetupActions_PRE_MIGRATION: RequirementDefinition[];
+    requiredMonitoringActions_PRE_MIGRATION: MonitoringRequirement[];
+    requiredCloseoutActionNames_PRE_MIGRATION: RequirementDefinition[];
+    version: string;
+    supersededAtUtc?: Date | undefined;
+    childInvolvement: ChildInvolvement;
+    arrangementFunctions: ArrangementFunction[];
+    requiredSetupActionNames: string[];
+    requiredMonitoringActions: MonitoringRequirementOld[];
+    requiredCloseoutActionNames: string[];
+    requiredSetupActions?: RequirementDefinition[] | undefined;
+    requiredMonitoringActionsNew?: MonitoringRequirement[] | undefined;
+    requiredCloseoutActions?: RequirementDefinition[] | undefined;
 }
 
 export class FunctionPolicy implements IFunctionPolicy {
@@ -6899,6 +7084,7 @@ export class Arrangement implements IArrangement {
     childLocationPlan!: ChildLocationHistoryEntry[];
     comments?: string | undefined;
     reason?: string | undefined;
+    arrangementPolicyVersion?: string | undefined;
 
     constructor(data?: IArrangement) {
         if (data) {
@@ -6973,6 +7159,7 @@ export class Arrangement implements IArrangement {
             }
             this.comments = _data["comments"];
             this.reason = _data["reason"];
+            this.arrangementPolicyVersion = _data["arrangementPolicyVersion"];
         }
     }
 
@@ -7037,6 +7224,7 @@ export class Arrangement implements IArrangement {
         }
         data["comments"] = this.comments;
         data["reason"] = this.reason;
+        data["arrangementPolicyVersion"] = this.arrangementPolicyVersion;
         return data;
     }
 }
@@ -7062,6 +7250,7 @@ export interface IArrangement {
     childLocationPlan: ChildLocationHistoryEntry[];
     comments?: string | undefined;
     reason?: string | undefined;
+    arrangementPolicyVersion?: string | undefined;
 }
 
 export enum ArrangementPhase {
@@ -8542,6 +8731,7 @@ export class ArrangementEntry implements IArrangementEntry {
     childLocationPlan!: ChildLocationHistoryEntry[];
     comments?: string | undefined;
     reason?: string | undefined;
+    arrangementPolicyVersion?: string | undefined;
 
     constructor(data?: IArrangementEntry) {
         if (data) {
@@ -8604,6 +8794,7 @@ export class ArrangementEntry implements IArrangementEntry {
             }
             this.comments = _data["comments"];
             this.reason = _data["reason"];
+            this.arrangementPolicyVersion = _data["arrangementPolicyVersion"];
         }
     }
 
@@ -8658,6 +8849,7 @@ export class ArrangementEntry implements IArrangementEntry {
         }
         data["comments"] = this.comments;
         data["reason"] = this.reason;
+        data["arrangementPolicyVersion"] = this.arrangementPolicyVersion;
         return data;
     }
 }
@@ -8681,6 +8873,7 @@ export interface IArrangementEntry {
     childLocationPlan: ChildLocationHistoryEntry[];
     comments?: string | undefined;
     reason?: string | undefined;
+    arrangementPolicyVersion?: string | undefined;
 }
 
 export class Note implements INote {
@@ -9791,6 +9984,7 @@ export class CreateArrangement extends ArrangementsCommand implements ICreateArr
     requestedAtUtc!: Date;
     partneringFamilyPersonId!: string;
     reason?: string | undefined;
+    arrangementPolicyVersion?: string | undefined;
 
     constructor(data?: ICreateArrangement) {
         super(data);
@@ -9804,6 +9998,7 @@ export class CreateArrangement extends ArrangementsCommand implements ICreateArr
             this.requestedAtUtc = _data["requestedAtUtc"] ? new Date(_data["requestedAtUtc"].toString()) : undefined as any;
             this.partneringFamilyPersonId = _data["partneringFamilyPersonId"];
             this.reason = _data["reason"];
+            this.arrangementPolicyVersion = _data["arrangementPolicyVersion"];
         }
     }
 
@@ -9820,6 +10015,7 @@ export class CreateArrangement extends ArrangementsCommand implements ICreateArr
         data["requestedAtUtc"] = this.requestedAtUtc ? this.requestedAtUtc.toISOString() : undefined as any;
         data["partneringFamilyPersonId"] = this.partneringFamilyPersonId;
         data["reason"] = this.reason;
+        data["arrangementPolicyVersion"] = this.arrangementPolicyVersion;
         super.toJSON(data);
         return data;
     }
@@ -9830,6 +10026,7 @@ export interface ICreateArrangement extends IArrangementsCommand {
     requestedAtUtc: Date;
     partneringFamilyPersonId: string;
     reason?: string | undefined;
+    arrangementPolicyVersion?: string | undefined;
 }
 
 export class DeleteArrangements extends ArrangementsCommand implements IDeleteArrangements {

--- a/src/caretogether-pwa/src/Model/V1CasesModel.ts
+++ b/src/caretogether-pwa/src/Model/V1CasesModel.ts
@@ -526,7 +526,8 @@ export function useV1CasesModel() {
       arrangementType: string,
       requestedAtLocal: Date,
       partneringFamilyPersonId: string,
-      reason: string | null
+      reason: string | null,
+      arrangementPolicyVersion?: string | null
     ) => {
       const command = commandFactory(CreateArrangement, {
         familyId: partneringFamilyId,
@@ -536,6 +537,7 @@ export function useV1CasesModel() {
         requestedAtUtc: requestedAtLocal,
         partneringFamilyPersonId: partneringFamilyPersonId,
         reason: reason || undefined,
+        arrangementPolicyVersion: arrangementPolicyVersion || undefined,
       });
       return command;
     }

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementCard.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementCard.tsx
@@ -7,6 +7,7 @@ import { ArrangementCardTitle } from './ArrangementCardTitle';
 import { ArrangementCardHeaderSection } from './ArrangementCardHeaderSection';
 import { ArrangementCardDetailsSection } from './ArrangementCardDetailsSection';
 import { useRequirementContextData } from './useRequirementContextData';
+import { resolveArrangementPolicy } from './arrangementPolicyVersions';
 
 export type ArrangementCardProps = {
   partneringFamily: CombinedFamilyInfo;
@@ -23,8 +24,9 @@ export function ArrangementCard({
 }: ArrangementCardProps) {
   const policy = useRecoilValue(policyData);
 
-  const arrangementPolicy = policy.referralPolicy?.arrangementPolicies?.find(
-    (a) => a.arrangementType === arrangement.arrangementType
+  const arrangementPolicy = resolveArrangementPolicy(
+    policy.referralPolicy?.arrangementPolicies,
+    arrangement
   );
 
   const requirementsData = useRequirementContextData(

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementCardTitle.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementCardTitle.tsx
@@ -43,6 +43,11 @@ export function ArrangementCardTitle({
   return (
     <div className="ph-unmask">
       <span>{arrangement.arrangementType}</span>
+      {arrangement.arrangementPolicyVersion && (
+        <span style={{ marginLeft: 8, color: '#666', fontSize: 12 }}>
+          {arrangement.arrangementPolicyVersion}
+        </span>
+      )}
       {summaryOnly && (
         <span style={{ marginLeft: 40, float: 'right' }}>
           {arrangement.phase === ArrangementPhase.Cancelled

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementsSection/ArrangementsSection.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementsSection/ArrangementsSection.tsx
@@ -17,6 +17,7 @@ import { useRecoilValue } from 'recoil';
 import { policyData } from '../../../Model/ConfigurationModel';
 import { getFilteredArrangements } from './getFilteredArrangements';
 import { useScrollToArrangement } from './useScrollToArrangement';
+import { isArrangementPolicyAvailable } from '../arrangementPolicyVersions';
 
 type ArrangementSectionProps = {
   v1Case: V1Case;
@@ -119,10 +120,8 @@ export function ArrangementsSection({
           >
             {v1Case &&
               policy.referralPolicy?.arrangementPolicies
-                ?.filter(
-                  (arrangementPolicy) =>
-                    !arrangementPolicy.supersededAtUtc ||
-                    new Date(arrangementPolicy.supersededAtUtc) > new Date()
+                ?.filter((arrangementPolicy) =>
+                  isArrangementPolicyAvailable(arrangementPolicy)
                 )
                 .map(
                 (arrangementPolicy) => (

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementsSection/ArrangementsSectionV2.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementsSection/ArrangementsSectionV2.tsx
@@ -52,6 +52,10 @@ import { CancelArrangementDialog } from '../CancelArrangementDialog';
 import { ReopenArrangementDialog } from '../ReopenArrangementDialog';
 import { DeleteArrangementDialog } from '../DeleteArrangementDialog';
 import { format } from 'date-fns';
+import {
+  isArrangementPolicyAvailable,
+  resolveArrangementPolicy,
+} from '../arrangementPolicyVersions';
 
 type ArrangementSectionProps = {
   v1Case: V1Case;
@@ -367,7 +371,16 @@ function ArrangementTableRow({
           </IconButton>
         </TableCell>
         <TableCell className="ph-unmask">
-          {arrangement.arrangementType || '-'}
+          <Stack spacing={0.25}>
+            <Typography variant="body2">
+              {arrangement.arrangementType || '-'}
+            </Typography>
+            {arrangement.arrangementPolicyVersion && (
+              <Typography variant="caption" color="text.secondary">
+                {arrangement.arrangementPolicyVersion}
+              </Typography>
+            )}
+          </Stack>
         </TableCell>
         <TableCell>
           <Stack spacing={0.75}>
@@ -525,10 +538,8 @@ export function ArrangementsSection({
           >
             {v1Case &&
               policy.referralPolicy?.arrangementPolicies
-                ?.filter(
-                  (arrangementPolicy) =>
-                    !arrangementPolicy.supersededAtUtc ||
-                    new Date(arrangementPolicy.supersededAtUtc) > new Date()
+                ?.filter((arrangementPolicy) =>
+                  isArrangementPolicyAvailable(arrangementPolicy)
                 )
                 .map((arrangementPolicy) => (
                   <Box key={arrangementPolicy.arrangementType}>
@@ -569,10 +580,10 @@ export function ArrangementsSection({
             </TableHead>
             <TableBody>
               {filteredArrangements.map((arrangement) => {
-                const arrangementPolicy =
-                  policy.referralPolicy?.arrangementPolicies?.find(
-                    (a) => a.arrangementType === arrangement.arrangementType
-                  );
+                const arrangementPolicy = resolveArrangementPolicy(
+                  policy.referralPolicy?.arrangementPolicies,
+                  arrangement
+                );
 
                 return (
                   <ArrangementTableRow

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/CreateArrangementDialog.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/CreateArrangementDialog.tsx
@@ -1,6 +1,5 @@
 import Grid from '../../Generic/GridLegacyCompat';
-import {
-  useState } from 'react';
+import { useState } from 'react';
 import {
   Button,
   Dialog,
@@ -29,6 +28,12 @@ import { useV1CasesModel } from '../../Model/V1CasesModel';
 import { visibleFamiliesQuery } from '../../Model/Data';
 import { locationConfigurationQuery } from '../../Model/ConfigurationModel';
 import { isBackdropClick } from '../../Utilities/handleBackdropClick';
+import {
+  getAutomaticPolicyVersion,
+  getAvailablePolicyVersions,
+  hasPolicyVersions,
+  withPolicyVersion,
+} from './arrangementPolicyVersions';
 
 interface CreateArrangementDialogProps {
   v1CaseId: string;
@@ -51,6 +56,28 @@ export function CreateArrangementDialog({
     locationConfigurationQuery
   )?.arrangementReasons;
   const isReasonRequired = arrangementReasons && arrangementReasons.length > 0;
+  const availablePolicyVersions = getAvailablePolicyVersions(arrangementPolicy);
+  const policyHasVersions = hasPolicyVersions(arrangementPolicy);
+
+  const [fields, setFields] = useState({
+    requestedAtLocal: null as Date | null,
+    partneringFamilyPersonId: null as string | null,
+    reason: null as string | null,
+    arrangementPolicyVersion: getAutomaticPolicyVersion(arrangementPolicy),
+  });
+  const {
+    requestedAtLocal,
+    partneringFamilyPersonId,
+    reason,
+    arrangementPolicyVersion,
+  } = fields;
+
+  const selectedPolicyVersion = availablePolicyVersions.find(
+    (policyVersion) => policyVersion.version === arrangementPolicyVersion
+  );
+  const effectiveArrangementPolicy = selectedPolicyVersion
+    ? withPolicyVersion(arrangementPolicy, selectedPolicyVersion)
+    : arrangementPolicy;
 
   const activeAdults = family
     .family!.adults!.filter((adult) => adult.item1!.active)
@@ -58,19 +85,13 @@ export function CreateArrangementDialog({
   const children = family.family!.children!;
 
   const applicableFamilyMembers =
-    arrangementPolicy.childInvolvement === ChildInvolvement.NoChildInvolvement
+    effectiveArrangementPolicy.childInvolvement ===
+    ChildInvolvement.NoChildInvolvement
       ? activeAdults
-      : arrangementPolicy.childInvolvement ===
+      : effectiveArrangementPolicy.childInvolvement ===
           ChildInvolvement.ChildOrAdultInvolvement
         ? activeAdults.concat(children)
         : children;
-
-  const [fields, setFields] = useState({
-    requestedAtLocal: null as Date | null,
-    partneringFamilyPersonId: null as string | null,
-    reason: null as string | null,
-  });
-  const { requestedAtLocal, partneringFamilyPersonId, reason } = fields;
 
   const [dobError, setDobError] = useState(false);
 
@@ -86,6 +107,8 @@ export function CreateArrangementDialog({
         alert('A date is required.');
       } else if (isReasonRequired && (reason == null || reason.length == 0)) {
         alert('A reason for the request is required.');
+      } else if (policyHasVersions && !arrangementPolicyVersion) {
+        alert('A policy version is required.');
       } else {
         await v1CasesModel.createArrangement(
           family.family?.id as string,
@@ -93,7 +116,8 @@ export function CreateArrangementDialog({
           arrangementPolicy.arrangementType!,
           requestedAtLocal,
           partneringFamilyPersonId,
-          reason && reason.length > 0 ? reason : null
+          reason && reason.length > 0 ? reason : null,
+          arrangementPolicyVersion
         );
         //TODO: Error handling (start with a basic error dialog w/ request to share a screenshot, and App Insights logging)
         onClose();
@@ -185,6 +209,40 @@ export function CreateArrangementDialog({
                 </FormControl>
               </Grid>
             )}
+            {policyHasVersions && availablePolicyVersions.length > 1 && (
+              <Grid item xs={12} sm={6}>
+                <FormControl required fullWidth size="small">
+                  <InputLabel id="arrangement-policy-version-label">
+                    Policy Version
+                  </InputLabel>
+                  <Select
+                    labelId="arrangement-policy-version-label"
+                    label="Policy Version"
+                    id="arrangement-policy-version"
+                    value={arrangementPolicyVersion || ''}
+                    onChange={(e) =>
+                      setFields({
+                        ...fields,
+                        arrangementPolicyVersion: e.target.value as string,
+                        partneringFamilyPersonId: null,
+                      })
+                    }
+                  >
+                    <MenuItem key="placeholder" value="" disabled>
+                      Select a version
+                    </MenuItem>
+                    {availablePolicyVersions.map((policyVersion) => (
+                      <MenuItem
+                        key={policyVersion.version}
+                        value={policyVersion.version}
+                      >
+                        {policyVersion.version}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+            )}
           </Grid>
         </form>
       </DialogContent>
@@ -199,6 +257,7 @@ export function CreateArrangementDialog({
           disabled={
             !partneringFamilyPersonId ||
             (isReasonRequired && (!reason || reason.length === 0)) ||
+            (policyHasVersions && !arrangementPolicyVersion) ||
             dobError
           }
         >

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/arrangementPolicyVersions.ts
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/arrangementPolicyVersions.ts
@@ -1,0 +1,84 @@
+import {
+  Arrangement,
+  ArrangementPolicy,
+  ArrangementPolicyVersion,
+} from '../../GeneratedClient';
+
+export function hasPolicyVersions(arrangementPolicy: ArrangementPolicy) {
+  return (arrangementPolicy.policyVersions?.length ?? 0) > 0;
+}
+
+export function getAvailablePolicyVersions(
+  arrangementPolicy: ArrangementPolicy,
+  now = new Date()
+) {
+  return (
+    arrangementPolicy.policyVersions?.filter(
+      (policyVersion) =>
+        !policyVersion.supersededAtUtc ||
+        new Date(policyVersion.supersededAtUtc) > now
+    ) ?? []
+  );
+}
+
+export function isArrangementPolicyAvailable(
+  arrangementPolicy: ArrangementPolicy,
+  now = new Date()
+) {
+  if (hasPolicyVersions(arrangementPolicy)) {
+    return getAvailablePolicyVersions(arrangementPolicy, now).length > 0;
+  }
+
+  return (
+    !arrangementPolicy.supersededAtUtc ||
+    new Date(arrangementPolicy.supersededAtUtc) > now
+  );
+}
+
+export function getAutomaticPolicyVersion(
+  arrangementPolicy: ArrangementPolicy
+) {
+  if (!hasPolicyVersions(arrangementPolicy)) return null;
+
+  const availableVersions = getAvailablePolicyVersions(arrangementPolicy);
+  return availableVersions.length === 1 ? availableVersions[0].version : null;
+}
+
+export function withPolicyVersion(
+  arrangementPolicy: ArrangementPolicy,
+  policyVersion: ArrangementPolicyVersion
+): ArrangementPolicy {
+  return new ArrangementPolicy({
+    ...arrangementPolicy,
+    childInvolvement: policyVersion.childInvolvement,
+    arrangementFunctions: policyVersion.arrangementFunctions,
+    requiredSetupActionNames: policyVersion.requiredSetupActionNames,
+    requiredMonitoringActions: policyVersion.requiredMonitoringActions,
+    requiredCloseoutActionNames: policyVersion.requiredCloseoutActionNames,
+    requiredSetupActions: policyVersion.requiredSetupActions,
+    requiredMonitoringActionsNew: policyVersion.requiredMonitoringActionsNew,
+    requiredCloseoutActions: policyVersion.requiredCloseoutActions,
+    supersededAtUtc: policyVersion.supersededAtUtc,
+  });
+}
+
+export function resolveArrangementPolicy(
+  arrangementPolicies: ArrangementPolicy[] | undefined,
+  arrangement: Arrangement
+) {
+  const arrangementPolicy = arrangementPolicies?.find(
+    (policy) => policy.arrangementType === arrangement.arrangementType
+  );
+
+  if (!arrangementPolicy || !arrangement.arrangementPolicyVersion) {
+    return arrangementPolicy;
+  }
+
+  const policyVersion = arrangementPolicy.policyVersions?.find(
+    (version) => version.version === arrangement.arrangementPolicyVersion
+  );
+
+  return policyVersion
+    ? withPolicyVersion(arrangementPolicy, policyVersion)
+    : arrangementPolicy;
+}

--- a/swagger.json
+++ b/swagger.json
@@ -2383,6 +2383,13 @@
             "type": "string",
             "format": "date-time",
             "nullable": true
+          },
+          "policyVersions": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ArrangementPolicyVersion"
+            }
           }
         }
       },
@@ -2701,6 +2708,97 @@
           },
           "recurrence": {
             "$ref": "#/components/schemas/RecurrencePolicy"
+          }
+        }
+      },
+      "ArrangementPolicyVersion": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "requiredSetupActions_PRE_MIGRATION",
+          "requiredMonitoringActions_PRE_MIGRATION",
+          "requiredCloseoutActionNames_PRE_MIGRATION",
+          "version",
+          "childInvolvement",
+          "arrangementFunctions",
+          "requiredSetupActionNames",
+          "requiredMonitoringActions",
+          "requiredCloseoutActionNames"
+        ],
+        "properties": {
+          "requiredSetupActions_PRE_MIGRATION": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RequirementDefinition"
+            }
+          },
+          "requiredMonitoringActions_PRE_MIGRATION": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MonitoringRequirement"
+            }
+          },
+          "requiredCloseoutActionNames_PRE_MIGRATION": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RequirementDefinition"
+            }
+          },
+          "version": {
+            "type": "string"
+          },
+          "supersededAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "childInvolvement": {
+            "$ref": "#/components/schemas/ChildInvolvement"
+          },
+          "arrangementFunctions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArrangementFunction"
+            }
+          },
+          "requiredSetupActionNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "requiredMonitoringActions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MonitoringRequirementOld"
+            }
+          },
+          "requiredCloseoutActionNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "requiredSetupActions": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/RequirementDefinition"
+            }
+          },
+          "requiredMonitoringActionsNew": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/MonitoringRequirement"
+            }
+          },
+          "requiredCloseoutActions": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/RequirementDefinition"
+            }
           }
         }
       },
@@ -4494,6 +4592,10 @@
           "reason": {
             "type": "string",
             "nullable": true
+          },
+          "arrangementPolicyVersion": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -5373,6 +5475,10 @@
           "reason": {
             "type": "string",
             "nullable": true
+          },
+          "arrangementPolicyVersion": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -6071,6 +6177,10 @@
                 "format": "guid"
               },
               "reason": {
+                "type": "string",
+                "nullable": true
+              },
+              "arrangementPolicyVersion": {
                 "type": "string",
                 "nullable": true
               }

--- a/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateReferralStatus.cs
+++ b/test/CareTogether.Core.Test/ReferralCalculationTests/CalculateReferralStatus.cs
@@ -281,6 +281,116 @@ namespace CareTogether.Core.Test.V1CaseCalculationTests
         );
 
         [TestMethod]
+        public void ArrangementWithPolicyVersionUsesThatVersionForEvaluation()
+        {
+            var locationPolicy = new EffectiveLocationPolicy(
+                ImmutableDictionary<string, ActionRequirement>.Empty,
+                ImmutableList<CustomField>.Empty,
+                new V1CasePolicy(
+                    RequiredIntakeActionNames: [],
+                    CustomFields: ImmutableList<CustomField>.Empty,
+                    ArrangementPolicies:
+                    [
+                        new ArrangementPolicy(
+                            ArrangementType: "Hosting",
+                            ChildInvolvement: ChildInvolvement.ChildHousing,
+                            ArrangementFunctions: [],
+                            RequiredSetupActionNames: [],
+                            RequiredMonitoringActions: [],
+                            RequiredCloseoutActionNames: [],
+                            PolicyVersions:
+                            [
+                                new ArrangementPolicyVersion(
+                                    Version: "v1",
+                                    SupersededAtUtc: null,
+                                    ChildInvolvement: ChildInvolvement.ChildHousing,
+                                    ArrangementFunctions: [],
+                                    RequiredSetupActionNames: [],
+                                    RequiredMonitoringActions: [],
+                                    RequiredCloseoutActionNames: [],
+                                    RequiredSetupActions:
+                                    [
+                                        new RequirementDefinition("Version 1 Setup", true),
+                                    ],
+                                    RequiredMonitoringActionsNew: [],
+                                    RequiredCloseoutActions: []
+                                ),
+                                new ArrangementPolicyVersion(
+                                    Version: "v2",
+                                    SupersededAtUtc: null,
+                                    ChildInvolvement: ChildInvolvement.ChildHousing,
+                                    ArrangementFunctions: [],
+                                    RequiredSetupActionNames: [],
+                                    RequiredMonitoringActions: [],
+                                    RequiredCloseoutActionNames: [],
+                                    RequiredSetupActions:
+                                    [
+                                        new RequirementDefinition("Version 2 Setup", true),
+                                    ],
+                                    RequiredMonitoringActionsNew: [],
+                                    RequiredCloseoutActions: []
+                                ),
+                            ]
+                        ),
+                    ],
+                    FunctionPolicies: []
+                ),
+                new VolunteerPolicy(
+                    ImmutableDictionary<string, VolunteerRolePolicy>.Empty,
+                    ImmutableDictionary<string, VolunteerFamilyRolePolicy>.Empty
+                )
+            );
+
+            var arrangementId = Guid.NewGuid();
+            var result = CareTogether.Engines.PolicyEvaluation.V1CaseCalculations.CalculateV1CaseStatus(
+                locationPolicy,
+                locationPolicy.ReferralPolicy,
+                new CareTogether.Engines.PolicyEvaluation.V1CaseEntry(
+                    CompletedRequirements: [],
+                    ExemptedRequirements: [],
+                    CompletedCustomFields: ImmutableDictionary<
+                        string,
+                        CompletedCustomFieldInfo
+                    >.Empty,
+                    Arrangements: ImmutableDictionary<
+                        Guid,
+                        CareTogether.Engines.PolicyEvaluation.ArrangementEntry
+                    >
+                        .Empty.Add(
+                            arrangementId,
+                            new CareTogether.Engines.PolicyEvaluation.ArrangementEntry(
+                                ArrangementType: "Hosting",
+                                StartedAt: null,
+                                EndedAt: null,
+                                CancelledAt: null,
+                                PartneringFamilyPersonId: Guid.NewGuid(),
+                                CompletedRequirements: [],
+                                ExemptedRequirements: [],
+                                IndividualVolunteerAssignments: [],
+                                FamilyVolunteerAssignments: [],
+                                ChildLocationHistory: [],
+                                ArrangementPolicyVersion: "v1"
+                            )
+                        )
+                ),
+                today: new DateOnly(2024, 1, 1)
+            );
+
+            AssertEx.SequenceIs(
+                result.IndividualArrangements[arrangementId].MissingRequirements,
+                new CareTogether.Engines.PolicyEvaluation.MissingArrangementRequirement(
+                    null,
+                    null,
+                    null,
+                    null,
+                    new RequirementDefinition("Version 1 Setup", true),
+                    null,
+                    null
+                )
+            );
+        }
+
+        [TestMethod]
         public void Test()
         {
             Assert.Inconclusive("Not implemented");


### PR DESCRIPTION
## Summary
- add optional arrangement policy versions and selected arrangement policy version storage
- evaluate arrangements against their pinned policy version when present
- update arrangement creation/listing UI to use active policy versions and show version labels
- regenerate swagger.json and GeneratedClient.ts

## Verification
- dotnet build CareTogetherCMS.sln --no-restore -nologo
- dotnet test test/CareTogether.Core.Test/CareTogether.Core.Test.csproj --no-restore -nologo --filter FullyQualifiedName~ArrangementWithPolicyVersionUsesThatVersionForEvaluation
- npm run build (from src/caretogether-pwa)