### PR TITLE
Fix referral saves using local aggregate updates

### DIFF
--- a/src/CareTogether.Core/Managers/Records/RecordsManager.cs
+++ b/src/CareTogether.Core/Managers/Records/RecordsManager.cs
@@ -293,13 +293,22 @@ namespace CareTogether.Managers.Records
             try
             {
                 await ValidateCommandAsync(organizationId, locationId, command);
+
+                var commandResultRenderingContext =
+                    await CreateCommandResultRenderingContextAsync(
+                        organizationId,
+                        locationId,
+                        command
+                    );
+
                 await ExecuteCommandAsync(organizationId, locationId, user, command);
 
                 return await RenderCommandResultAsync(
                     organizationId,
                     locationId,
                     userContext,
-                    command
+                    command,
+                    commandResultRenderingContext
                 );
             }
             catch
@@ -1129,11 +1138,69 @@ namespace CareTogether.Managers.Records
         private static bool IsApprovedOrOnboarded(RoleApprovalStatus? status) =>
             status is RoleApprovalStatus.Approved or RoleApprovalStatus.Onboarded;
 
+        private sealed record CommandResultRenderingContext(
+            ImmutableDictionary<
+                Guid,
+                ImmutableHashSet<Guid>
+            > PreviouslyLinkedReferralFamilyIdsByReferralId
+        )
+        {
+            public static CommandResultRenderingContext Empty { get; } =
+                new(ImmutableDictionary<Guid, ImmutableHashSet<Guid>>.Empty);
+        }
+
+        private async Task<CommandResultRenderingContext> CreateCommandResultRenderingContextAsync(
+            Guid organizationId,
+            Guid locationId,
+            AtomicRecordsCommand command
+        )
+        {
+            if (command is not V1ReferralRecordsCommand { Command: UpdateV1ReferralFamily update })
+                return CommandResultRenderingContext.Empty;
+
+            var referral = await v1ReferralsResource.GetReferralAsync(
+                organizationId,
+                locationId,
+                update.ReferralId
+            );
+
+            if (referral?.FamilyId is not Guid familyId)
+                return CommandResultRenderingContext.Empty;
+
+            return new CommandResultRenderingContext(
+                ImmutableDictionary<Guid, ImmutableHashSet<Guid>>.Empty.SetItem(
+                    update.ReferralId,
+                    ImmutableHashSet.Create(familyId)
+                )
+            );
+        }
+
+        private async Task<RecordsAggregate?> RenderFamilyRecordsAggregateAsync(
+            Guid organizationId,
+            EffectiveLocationPolicy locationPolicy,
+            Guid locationId,
+            Guid familyId,
+            SessionUserContext userContext
+        )
+        {
+            var familyResult = await combinedFamilyInfoFormatter.RenderCombinedFamilyInfoAsync(
+                organizationId,
+                locationPolicy,
+                locationId,
+                familyId,
+                null,
+                userContext
+            );
+
+            return familyResult == null ? null : new FamilyRecordsAggregate(familyResult);
+        }
+
         private async Task<ImmutableList<RecordsAggregate>> RenderCommandResultAsync(
             Guid organizationId,
             Guid locationId,
             SessionUserContext userContext,
-            AtomicRecordsCommand command
+            AtomicRecordsCommand command,
+            CommandResultRenderingContext? commandResultRenderingContext = null
         )
         {
             var locationPolicy = await policiesResource.GetCurrentPolicy(
@@ -1164,21 +1231,31 @@ namespace CareTogether.Managers.Records
                 var results = ImmutableList.CreateBuilder<RecordsAggregate>();
                 results.Add(new ReferralRecordsAggregate(renderedReferral));
 
+                var linkedFamilyIds = commandResultRenderingContext != null
+                    && commandResultRenderingContext
+                        .PreviouslyLinkedReferralFamilyIdsByReferralId.TryGetValue(
+                        referralId,
+                        out var previousFamilyIds
+                    )
+                    ? previousFamilyIds
+                    : ImmutableHashSet<Guid>.Empty;
+
                 if (renderedReferral.Referral.FamilyId.HasValue)
-                {
-                    var familyResult =
-                        await combinedFamilyInfoFormatter.RenderCombinedFamilyInfoAsync(
+                    linkedFamilyIds = linkedFamilyIds.Add(renderedReferral.Referral.FamilyId.Value);
+
+                var linkedFamilyResults = await Task.WhenAll(
+                    linkedFamilyIds.Select(familyId =>
+                        RenderFamilyRecordsAggregateAsync(
                             organizationId,
                             locationPolicy,
                             locationId,
-                            renderedReferral.Referral.FamilyId.Value,
-                            null,
+                            familyId,
                             userContext
-                        );
+                        )
+                    )
+                );
 
-                    if (familyResult != null)
-                        results.Add(new FamilyRecordsAggregate(familyResult));
-                }
+                results.AddRange(linkedFamilyResults.WhereNotNull());
 
                 return results.ToImmutable();
             }
@@ -1234,21 +1311,17 @@ namespace CareTogether.Managers.Records
 
                 var familyResults = await Task.WhenAll(
                     familyIds.Select(familyId =>
-                        combinedFamilyInfoFormatter.RenderCombinedFamilyInfoAsync(
+                        RenderFamilyRecordsAggregateAsync(
                             organizationId,
                             locationPolicy,
                             locationId,
                             familyId,
-                            null,
                             userContext
                         )
                     )
                 );
 
-                return familyResults
-                    .OfType<CombinedFamilyInfo>() // Filters out null values
-                    .Select(result => new FamilyRecordsAggregate(result))
-                    .ToImmutableList<RecordsAggregate>();
+                return familyResults.WhereNotNull().ToImmutableList();
             }
         }
 
@@ -1273,7 +1346,7 @@ namespace CareTogether.Managers.Records
             ).SelectMany(results => results);
 
             return renderedAggregates
-                .GroupBy(aggregate => (aggregate.Id, AggregateType: aggregate.GetType()))
+                .GroupBy(aggregate => aggregate.Id)
                 .Select(group => group.Last())
                 .ToImmutableList();
         }

--- a/src/caretogether-pwa/src/Model/V1ReferralsModel.ts
+++ b/src/caretogether-pwa/src/Model/V1ReferralsModel.ts
@@ -23,14 +23,10 @@ import {
   UnassignIndividualVolunteer3 as UnassignIndividualVolunteer,
 } from '../GeneratedClient';
 import { commandFactory } from './CommandFactory';
-import { api } from '../Api/Api';
 import {
-  selectedLocationContextState,
   useAtomicRecordsCommandCallback,
   useCompositeRecordsCommandCallback,
-  visibleAggregatesState,
 } from '../Model/Data';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 interface CreateReferralPayload {
   familyId: string | null;
@@ -40,7 +36,6 @@ interface CreateReferralPayload {
 }
 
 interface UpdateReferralDetailsPayload {
-  familyId?: string | null;
   title: string;
   comment?: string;
   openedAtUtc: Date;
@@ -59,21 +54,7 @@ function useV1ReferralCommandCallback<T extends unknown[]>(
 }
 
 export function useV1ReferralsModel() {
-  const setVisibleAggregates = useSetRecoilState(visibleAggregatesState);
-  const { organizationId, locationId } = useRecoilValue(
-    selectedLocationContextState
-  );
-
-  async function refreshVisibleAggregates() {
-    const updatedAggregates = await api.records.listVisibleAggregates(
-      organizationId,
-      locationId
-    );
-
-    setVisibleAggregates(updatedAggregates);
-  }
-
-  const createReferralCommand = useAtomicRecordsCommandCallback(
+  const createReferral = useAtomicRecordsCommandCallback(
     async (referralId: string, payload: CreateReferralPayload) => {
       const command = new V1ReferralRecordsCommand();
 
@@ -89,19 +70,11 @@ export function useV1ReferralsModel() {
     }
   );
 
-  const createReferral = async (
-    referralId: string,
-    payload: CreateReferralPayload
-  ) => {
-    await createReferralCommand(referralId, payload);
-    await refreshVisibleAggregates();
-  };
-
-  const updateCustomReferralFieldCommand = useAtomicRecordsCommandCallback(
+  const updateCustomReferralField = useAtomicRecordsCommandCallback(
     async (
       referralId: string,
       customField: CustomField,
-      value: boolean | string | null
+      value: boolean | string | string[] | null
     ) => {
       const command = new V1ReferralRecordsCommand();
 
@@ -117,16 +90,7 @@ export function useV1ReferralsModel() {
     }
   );
 
-  const updateCustomReferralField = async (
-    referralId: string,
-    customField: CustomField,
-    value: boolean | string | null
-  ) => {
-    await updateCustomReferralFieldCommand(referralId, customField, value);
-    await refreshVisibleAggregates();
-  };
-
-  const updateReferralFamilyCommand = useAtomicRecordsCommandCallback(
+  const updateReferralFamily = useAtomicRecordsCommandCallback(
     async (referralId: string, familyId: string) => {
       const command = new V1ReferralRecordsCommand();
 
@@ -139,18 +103,12 @@ export function useV1ReferralsModel() {
     }
   );
 
-  const updateReferralFamily = async (referralId: string, familyId: string) => {
-    await updateReferralFamilyCommand(referralId, familyId);
-    await refreshVisibleAggregates();
-  };
-
-  const updateReferralDetailsCommand = useAtomicRecordsCommandCallback(
+  const updateReferralDetails = useAtomicRecordsCommandCallback(
     async (referralId: string, payload: UpdateReferralDetailsPayload) => {
       const command = new V1ReferralRecordsCommand();
 
       command.command = commandFactory(UpdateV1ReferralDetails, {
         referralId,
-        familyId: payload.familyId ?? undefined,
         title: payload.title,
         comment: payload.comment,
         createdAtUtc: payload.openedAtUtc,
@@ -160,15 +118,7 @@ export function useV1ReferralsModel() {
     }
   );
 
-  const updateReferralDetails = async (
-    referralId: string,
-    payload: UpdateReferralDetailsPayload
-  ) => {
-    await updateReferralDetailsCommand(referralId, payload);
-    await refreshVisibleAggregates();
-  };
-
-  const closeReferralCommand = useV1ReferralCommandCallback(
+  const closeReferral = useV1ReferralCommandCallback(
     async (referralId: string, reason: string, closedAtLocal: Date) =>
       commandFactory(CloseV1Referral, {
         referralId,
@@ -177,16 +127,7 @@ export function useV1ReferralsModel() {
       })
   );
 
-  const closeReferral = async (
-    referralId: string,
-    reason: string,
-    closedAtLocal: Date
-  ) => {
-    await closeReferralCommand(referralId, reason, closedAtLocal);
-    await refreshVisibleAggregates();
-  };
-
-  const reopenReferralCommand = useV1ReferralCommandCallback(
+  const reopenReferral = useV1ReferralCommandCallback(
     async (referralId: string) =>
       commandFactory(ReopenV1Referral, {
         referralId,
@@ -194,23 +135,13 @@ export function useV1ReferralsModel() {
       })
   );
 
-  const reopenReferral = async (referralId: string) => {
-    await reopenReferralCommand(referralId);
-    await refreshVisibleAggregates();
-  };
-
-  const acceptReferralCommand = useV1ReferralCommandCallback(
+  const acceptReferral = useV1ReferralCommandCallback(
     async (referralId: string, acceptedAtLocal?: Date) =>
       commandFactory(AcceptV1Referral, {
         referralId,
         acceptedAtUtc: acceptedAtLocal ?? new Date(),
       })
   );
-
-  const acceptReferral = async (referralId: string, acceptedAtLocal?: Date) => {
-    await acceptReferralCommand(referralId, acceptedAtLocal);
-    await refreshVisibleAggregates();
-  };
 
   const linkReferralToCaseAndAcceptCommand = useCompositeRecordsCommandCallback(
     async (
@@ -264,7 +195,7 @@ export function useV1ReferralsModel() {
     );
   };
 
-  const completeReferralRequirementCommand = useV1ReferralCommandCallback(
+  const completeReferralRequirement = useV1ReferralCommandCallback(
     async (
       referralId: string,
       requirementName: string,
@@ -283,26 +214,7 @@ export function useV1ReferralsModel() {
       })
   );
 
-  const completeReferralRequirement = async (
-    referralId: string,
-    requirementName: string,
-    requirement: ActionRequirement,
-    completedAtLocal: Date,
-    documentId: string | null,
-    noteId: string | null
-  ) => {
-    await completeReferralRequirementCommand(
-      referralId,
-      requirementName,
-      requirement,
-      completedAtLocal,
-      documentId,
-      noteId
-    );
-    await refreshVisibleAggregates();
-  };
-
-  const markReferralRequirementIncompleteCommand = useV1ReferralCommandCallback(
+  const markReferralRequirementIncomplete = useV1ReferralCommandCallback(
     async (
       referralId: string,
       completedRequirement: CompletedRequirementInfo
@@ -314,18 +226,7 @@ export function useV1ReferralsModel() {
       })
   );
 
-  const markReferralRequirementIncomplete = async (
-    referralId: string,
-    completedRequirement: CompletedRequirementInfo
-  ) => {
-    await markReferralRequirementIncompleteCommand(
-      referralId,
-      completedRequirement
-    );
-    await refreshVisibleAggregates();
-  };
-
-  const exemptReferralRequirementCommand = useV1ReferralCommandCallback(
+  const exemptReferralRequirement = useV1ReferralCommandCallback(
     async (
       referralId: string,
       requirementName: string,
@@ -340,22 +241,7 @@ export function useV1ReferralsModel() {
       })
   );
 
-  const exemptReferralRequirement = async (
-    referralId: string,
-    requirementName: string,
-    additionalComments: string,
-    exemptionExpiresAtLocal: Date | null
-  ) => {
-    await exemptReferralRequirementCommand(
-      referralId,
-      requirementName,
-      additionalComments,
-      exemptionExpiresAtLocal
-    );
-    await refreshVisibleAggregates();
-  };
-
-  const unexemptReferralRequirementCommand = useV1ReferralCommandCallback(
+  const unexemptReferralRequirement = useV1ReferralCommandCallback(
     async (referralId: string, exemptedRequirement: ExemptedRequirementInfo) =>
       commandFactory(UnexemptReferralRequirement2, {
         referralId,
@@ -363,15 +249,7 @@ export function useV1ReferralsModel() {
       })
   );
 
-  const unexemptReferralRequirement = async (
-    referralId: string,
-    exemptedRequirement: ExemptedRequirementInfo
-  ) => {
-    await unexemptReferralRequirementCommand(referralId, exemptedRequirement);
-    await refreshVisibleAggregates();
-  };
-
-  const uploadReferralDocumentMetadataCommand = useAtomicRecordsCommandCallback(
+  const uploadReferralDocumentMetadata = useAtomicRecordsCommandCallback(
     async (
       referralId: string,
       documentId: string,
@@ -388,19 +266,6 @@ export function useV1ReferralsModel() {
       return command;
     }
   );
-
-  const uploadReferralDocumentMetadata = async (
-    referralId: string,
-    documentId: string,
-    uploadedFileName: string
-  ) => {
-    await uploadReferralDocumentMetadataCommand(
-      referralId,
-      documentId,
-      uploadedFileName
-    );
-    await refreshVisibleAggregates();
-  };
 
   const assignIndividualVolunteerToReferral = useV1ReferralCommandCallback(
     async (referralId: string, personId: string, assignmentRole: string) =>

--- a/src/caretogether-pwa/src/V1Referrals/EditReferralDrawer.tsx
+++ b/src/caretogether-pwa/src/V1Referrals/EditReferralDrawer.tsx
@@ -54,7 +54,6 @@ export function EditReferralDrawer({
 
   const onSubmit = async (data: AddReferralFormValues) => {
     await updateReferralDetails(referral.referralId, {
-      familyId: data.familyId,
       openedAtUtc: data.openedAtLocal,
       title: data.title,
       comment: data.comment || undefined,


### PR DESCRIPTION
## Summary
- remove redundant full Records refreshes from V1 referral model commands so add/edit save handlers can close after the actual command succeeds
- return refreshed previous/current linked family aggregates when a referral family link changes
- stop edit referral details from sending a family id through the details command

## Verification
- dotnet build CareTogetherCMS.sln -nologo
- npm run type-check
- npm run build