### PR TITLE
Prefer active policy versions for renewal prompts

### DIFF
--- a/src/CareTogether.Core/Engines/PolicyEvaluation/FamilyApprovalCalculations.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/FamilyApprovalCalculations.cs
@@ -171,6 +171,7 @@ namespace CareTogether.Engines.PolicyEvaluation
             return new FamilyRoleVersionApprovalStatus(
                 rolePolicy.VolunteerFamilyRoleType,
                 policyVersion.Version,
+                policyVersion.SupersededAtUtc,
                 roleVersionApprovalStatus,
                 requirementCompletions
             );

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
@@ -70,14 +70,15 @@ namespace CareTogether.Engines.PolicyEvaluation
             // If there is a definitive max status, only consider missing requirements from
             // versions that have that same status; this hides missing requirements from
             // other versions of the same policy regardless of requirement stage.
-            var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
+            var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
                 familyRoleStatus.RoleVersionApprovals
             );
+            var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
+                promptableVersions
+            );
 
-            return familyRoleStatus
-                .RoleVersionApprovals.Where(r =>
-                    maxVersionStatus == null || r.CurrentStatus == maxVersionStatus
-                )
+            return promptableVersions
+                .Where(r => maxVersionStatus == null || r.CurrentStatus == maxVersionStatus)
                 .SelectMany(r =>
                     r.CurrentMissingRequirements.Where(cmr =>
                             cmr.Scope == VolunteerFamilyRequirementScope.AllAdultsInTheFamily
@@ -115,14 +116,15 @@ namespace CareTogether.Engines.PolicyEvaluation
                 // Hide missing requirements from other versions of the same role
                 // if there exists a version with a higher/equivalent max status. This
                 // is independent of requirement stage.
-                var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
+                var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
                     kv.Value.RoleVersionApprovals
                 );
+                var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
+                    promptableVersions
+                );
 
-                return kv
-                    .Value.RoleVersionApprovals.Where(r =>
-                        maxVersionStatus == null || r.CurrentStatus == maxVersionStatus
-                    )
+                return promptableVersions
+                    .Where(r => maxVersionStatus == null || r.CurrentStatus == maxVersionStatus)
                     .SelectMany(r =>
                         r.CurrentMissingRequirements.Where(cmr =>
                                 cmr.WhenMet?.Contains(DateOnly.FromDateTime(DateTime.UtcNow))
@@ -150,17 +152,18 @@ namespace CareTogether.Engines.PolicyEvaluation
                         var roleName = kv.Key;
 
                         // If role has achieved Prospective or higher status, hide applications
-                        var individualHighestStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
+                        var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
                             kv.Value.RoleVersionApprovals
+                        );
+                        var individualHighestStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
+                            promptableVersions
                         );
 
                         if (individualHighestStatus >= RoleApprovalStatus.Prospective)
                             return Enumerable.Empty<(Guid, string)>();
 
-                        return kv
-                            .Value.RoleVersionApprovals.Where(r =>
-                                r.CurrentStatus == null && kv.Value.CurrentStatus == null
-                            )
+                        return promptableVersions
+                            .Where(r => r.CurrentStatus == null)
                             .SelectMany(r => r.CurrentAvailableApplications)
                             .Select(a => (ia.Key, a.ActionName));
                     })
@@ -209,8 +212,12 @@ namespace CareTogether.Engines.PolicyEvaluation
         {
             get
             {
-                // Return raw per-version missing requirements (family-level logic will decide hiding)
-                var missingRequirements = RoleVersionApprovals
+                // Prefer active policy versions for user prompts, falling back to superseded
+                // versions only when there is no active version for the role.
+                var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
+                    RoleVersionApprovals
+                );
+                var missingRequirements = promptableVersions
                     .SelectMany(r =>
                         r.CurrentMissingRequirements.Select(cmr =>
                             (cmr.ActionName, (r.Version, r.RoleName))
@@ -226,9 +233,11 @@ namespace CareTogether.Engines.PolicyEvaluation
         }
 
         public ImmutableList<string> CurrentAvailableApplications =>
-            // Return raw per-version available applications (family-level logic will decide hiding)
-            RoleVersionApprovals
-                .Where(r => r.CurrentStatus == null && CurrentStatus == null)
+            // Prefer active policy versions for user prompts, falling back to superseded
+            // versions only when there is no active version for the role.
+            PolicyEvaluationHelpers
+                .SelectPromptableVersions(RoleVersionApprovals)
+                .Where(r => r.CurrentStatus == null)
                 .SelectMany(r => r.CurrentAvailableApplications)
                 .Select(r => r.ActionName)
                 .ToImmutableList();
@@ -237,6 +246,7 @@ namespace CareTogether.Engines.PolicyEvaluation
     public sealed record IndividualRoleVersionApprovalStatus(
         string RoleName,
         string Version,
+        DateTime? SupersededAtUtc,
         DateOnlyTimeline<RoleApprovalStatus>? Status,
         ImmutableList<IndividualRoleRequirementCompletionStatus> Requirements
     )
@@ -305,11 +315,14 @@ namespace CareTogether.Engines.PolicyEvaluation
                 // status, only consider missing requirements from versions that share
                 // that status, which hides missing requirements from other versions
                 // of the same policy (independent of requirement stage).
-                var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
+                var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
                     RoleVersionApprovals
                 );
+                var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
+                    promptableVersions
+                );
 
-                return RoleVersionApprovals
+                return promptableVersions
                     .Where(r => maxVersionStatus == null || r.CurrentStatus == maxVersionStatus)
                     .SelectMany(r =>
                         r.CurrentMissingRequirements.Select(cmr =>
@@ -330,13 +343,16 @@ namespace CareTogether.Engines.PolicyEvaluation
         {
             get
             {
+                var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
+                    RoleVersionApprovals
+                );
                 var highestStatus =
-                    PolicyEvaluationHelpers.GetMaxRoleStatus(RoleVersionApprovals) ?? default;
+                    PolicyEvaluationHelpers.GetMaxRoleStatus(promptableVersions) ?? default;
 
                 return highestStatus >= RoleApprovalStatus.Prospective
                     ? ImmutableList<string>.Empty
-                    : RoleVersionApprovals
-                        .Where(r => r.CurrentStatus == null && CurrentStatus == null)
+                    : promptableVersions
+                        .Where(r => r.CurrentStatus == null)
                         .SelectMany(r => r.CurrentAvailableApplications)
                         .Where(r => r.Scope == VolunteerFamilyRequirementScope.OncePerFamily)
                         .Select(r => r.ActionName)
@@ -353,7 +369,10 @@ namespace CareTogether.Engines.PolicyEvaluation
             get
             {
                 // Extract all missing requirements that apply to individuals, grouped by person and action
-                var missingRequirements = RoleVersionApprovals
+                var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
+                    RoleVersionApprovals
+                );
+                var missingRequirements = promptableVersions
                     .SelectMany(r =>
                         r.CurrentMissingRequirements.Where(cmr =>
                                 cmr.Scope == VolunteerFamilyRequirementScope.AllAdultsInTheFamily
@@ -400,6 +419,7 @@ namespace CareTogether.Engines.PolicyEvaluation
     public sealed record FamilyRoleVersionApprovalStatus(
         string RoleName,
         string Version,
+        DateTime? SupersededAtUtc,
         DateOnlyTimeline<RoleApprovalStatus>? Status,
         ImmutableList<FamilyRoleRequirementCompletionStatus> Requirements
     )

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/IndividualApprovalCalculations.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/IndividualApprovalCalculations.cs
@@ -98,6 +98,7 @@ namespace CareTogether.Engines.PolicyEvaluation
             return new IndividualRoleVersionApprovalStatus(
                 rolePolicy.VolunteerRoleType,
                 policyVersion.Version,
+                policyVersion.SupersededAtUtc,
                 roleVersionApprovalStatus,
                 requirementCompletionStatus
             );

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationHelpers.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using CareTogether.Resources.Policies;
@@ -25,5 +26,27 @@ namespace CareTogether.Engines.PolicyEvaluation
                 .OfType<RoleApprovalStatus>()
                 .DefaultIfEmpty()
                 .Max();
+
+        internal static ImmutableList<IndividualRoleVersionApprovalStatus> SelectPromptableVersions(
+            ImmutableList<IndividualRoleVersionApprovalStatus> versions
+        )
+        {
+            var activeVersions = versions.Where(IsActive).ToImmutableList();
+            return activeVersions.Count > 0 ? activeVersions : versions;
+        }
+
+        internal static ImmutableList<FamilyRoleVersionApprovalStatus> SelectPromptableVersions(
+            ImmutableList<FamilyRoleVersionApprovalStatus> versions
+        )
+        {
+            var activeVersions = versions.Where(IsActive).ToImmutableList();
+            return activeVersions.Count > 0 ? activeVersions : versions;
+        }
+
+        private static bool IsActive(IndividualRoleVersionApprovalStatus version) =>
+            version.SupersededAtUtc == null || version.SupersededAtUtc > DateTime.UtcNow;
+
+        private static bool IsActive(FamilyRoleVersionApprovalStatus version) =>
+            version.SupersededAtUtc == null || version.SupersededAtUtc > DateTime.UtcNow;
     }
 }

--- a/src/caretogether-pwa/src/GeneratedClient.ts
+++ b/src/caretogether-pwa/src/GeneratedClient.ts
@@ -7956,6 +7956,7 @@ export enum RoleApprovalStatus {
 export class FamilyRoleVersionApprovalStatus implements IFamilyRoleVersionApprovalStatus {
     roleName!: string;
     version!: string;
+    supersededAtUtc?: Date | undefined;
     status?: DateOnlyTimelineOfRoleApprovalStatus | undefined;
     requirements!: FamilyRoleRequirementCompletionStatus[];
 
@@ -7975,6 +7976,7 @@ export class FamilyRoleVersionApprovalStatus implements IFamilyRoleVersionApprov
         if (_data) {
             this.roleName = _data["roleName"];
             this.version = _data["version"];
+            this.supersededAtUtc = _data["supersededAtUtc"] ? new Date(_data["supersededAtUtc"].toString()) : undefined as any;
             this.status = _data["status"] ? DateOnlyTimelineOfRoleApprovalStatus.fromJS(_data["status"]) : undefined as any;
             if (Array.isArray(_data["requirements"])) {
                 this.requirements = [] as any;
@@ -7995,6 +7997,7 @@ export class FamilyRoleVersionApprovalStatus implements IFamilyRoleVersionApprov
         data = typeof data === 'object' ? data : {};
         data["roleName"] = this.roleName;
         data["version"] = this.version;
+        data["supersededAtUtc"] = this.supersededAtUtc ? this.supersededAtUtc.toISOString() : undefined as any;
         data["status"] = this.status ? this.status.toJSON() : undefined as any;
         if (Array.isArray(this.requirements)) {
             data["requirements"] = [];
@@ -8008,6 +8011,7 @@ export class FamilyRoleVersionApprovalStatus implements IFamilyRoleVersionApprov
 export interface IFamilyRoleVersionApprovalStatus {
     roleName: string;
     version: string;
+    supersededAtUtc?: Date | undefined;
     status?: DateOnlyTimelineOfRoleApprovalStatus | undefined;
     requirements: FamilyRoleRequirementCompletionStatus[];
 }
@@ -8612,6 +8616,7 @@ export interface IIndividualRoleApprovalStatus {
 export class IndividualRoleVersionApprovalStatus implements IIndividualRoleVersionApprovalStatus {
     roleName!: string;
     version!: string;
+    supersededAtUtc?: Date | undefined;
     status?: DateOnlyTimelineOfRoleApprovalStatus | undefined;
     requirements!: IndividualRoleRequirementCompletionStatus[];
 
@@ -8631,6 +8636,7 @@ export class IndividualRoleVersionApprovalStatus implements IIndividualRoleVersi
         if (_data) {
             this.roleName = _data["roleName"];
             this.version = _data["version"];
+            this.supersededAtUtc = _data["supersededAtUtc"] ? new Date(_data["supersededAtUtc"].toString()) : undefined as any;
             this.status = _data["status"] ? DateOnlyTimelineOfRoleApprovalStatus.fromJS(_data["status"]) : undefined as any;
             if (Array.isArray(_data["requirements"])) {
                 this.requirements = [] as any;
@@ -8651,6 +8657,7 @@ export class IndividualRoleVersionApprovalStatus implements IIndividualRoleVersi
         data = typeof data === 'object' ? data : {};
         data["roleName"] = this.roleName;
         data["version"] = this.version;
+        data["supersededAtUtc"] = this.supersededAtUtc ? this.supersededAtUtc.toISOString() : undefined as any;
         data["status"] = this.status ? this.status.toJSON() : undefined as any;
         if (Array.isArray(this.requirements)) {
             data["requirements"] = [];
@@ -8664,6 +8671,7 @@ export class IndividualRoleVersionApprovalStatus implements IIndividualRoleVersi
 export interface IIndividualRoleVersionApprovalStatus {
     roleName: string;
     version: string;
+    supersededAtUtc?: Date | undefined;
     status?: DateOnlyTimelineOfRoleApprovalStatus | undefined;
     requirements: IndividualRoleRequirementCompletionStatus[];
 }

--- a/swagger.json
+++ b/swagger.json
@@ -5005,6 +5005,11 @@
           "version": {
             "type": "string"
           },
+          "supersededAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
           "status": {
             "nullable": true,
             "oneOf": [
@@ -5331,6 +5336,11 @@
           },
           "version": {
             "type": "string"
+          },
+          "supersededAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           },
           "status": {
             "nullable": true,

--- a/test/CareTogether.Core.Test/ApprovalCalculationTests/CalculateCombinedFamilyApprovalsTest.cs
+++ b/test/CareTogether.Core.Test/ApprovalCalculationTests/CalculateCombinedFamilyApprovalsTest.cs
@@ -346,5 +346,126 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
                 );
             }
         }
+
+        [TestMethod]
+        public void ExpiredSupersededIndividualRoleShowsActiveVersionApplication()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateIndividualRenewalPolicy();
+            var completedIndividualRequirements = H.CompletedIndividualRequirementsWithExpiry(
+                (H.guid1, "LegacyApplication", 1, 10),
+                (H.guid1, "LegacyApproval", 1, 10)
+            );
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: ImmutableList<Resources.CompletedRequirementInfo>.Empty,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: completedIndividualRequirements,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
+            );
+
+            var availableApplications = result
+                .CurrentAvailableIndividualApplications.Where(x => x.PersonId == H.guid1)
+                .Select(x => x.ActionName)
+                .ToImmutableList();
+
+            CollectionAssert.AreEqual(
+                new[] { "CurrentApplication" },
+                availableApplications.ToArray()
+            );
+            Assert.IsFalse(
+                result.CurrentMissingIndividualRequirements.Any(x =>
+                    x.PersonId == H.guid1 && x.ActionName == "LegacyApproval"
+                )
+            );
+        }
+
+        [TestMethod]
+        public void ExpiredSupersededIndividualRoleShowsActiveVersionMissingApproval()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateIndividualRenewalPolicy();
+            var completedIndividualRequirements = H.CompletedIndividualRequirementsWithExpiry(
+                (H.guid1, "LegacyApplication", 1, 10),
+                (H.guid1, "LegacyApproval", 1, 10),
+                (H.guid1, "CurrentApplication", 11, null)
+            );
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: ImmutableList<Resources.CompletedRequirementInfo>.Empty,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: completedIndividualRequirements,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
+            );
+
+            var missingRequirements = result
+                .CurrentMissingIndividualRequirements.Where(x => x.PersonId == H.guid1)
+                .Select(x => x.ActionName)
+                .ToImmutableList();
+
+            CollectionAssert.AreEqual(new[] { "CurrentApproval" }, missingRequirements.ToArray());
+        }
+
+        private static EffectiveLocationPolicy CreateIndividualRenewalPolicy() =>
+            new(
+                ImmutableDictionary<string, ActionRequirement>.Empty,
+                ImmutableList<CustomField>.Empty,
+                new V1CasePolicy(
+                    ImmutableList<string>.Empty,
+                    ImmutableList<CustomField>.Empty,
+                    ImmutableList<ArrangementPolicy>.Empty,
+                    ImmutableList<FunctionPolicy>.Empty
+                ),
+                new VolunteerPolicy(
+                    ImmutableDictionary<string, VolunteerRolePolicy>.Empty.Add(
+                        "Role1",
+                        new VolunteerRolePolicy(
+                            "Role1",
+                            ImmutableList<VolunteerRolePolicyVersion>
+                                .Empty.Add(
+                                    new VolunteerRolePolicyVersion(
+                                        "legacy",
+                                        DateTime.UtcNow.AddDays(-1),
+                                        H.IndividualApprovalRequirements(
+                                            (
+                                                RequirementStage.Application,
+                                                "LegacyApplication"
+                                            ),
+                                            (RequirementStage.Approval, "LegacyApproval")
+                                        )
+                                    )
+                                )
+                                .Add(
+                                    new VolunteerRolePolicyVersion(
+                                        "current",
+                                        SupersededAtUtc: null,
+                                        Requirements: H.IndividualApprovalRequirements(
+                                            (
+                                                RequirementStage.Application,
+                                                "CurrentApplication"
+                                            ),
+                                            (RequirementStage.Approval, "CurrentApproval")
+                                        )
+                                    )
+                                )
+                        )
+                    ),
+                    ImmutableDictionary<string, VolunteerFamilyRolePolicy>.Empty
+                )
+            );
     }
 }

--- a/test/CareTogether.Core.Test/ApprovalCalculationTests/PolicyEvaluationHelpersTest.cs
+++ b/test/CareTogether.Core.Test/ApprovalCalculationTests/PolicyEvaluationHelpersTest.cs
@@ -27,8 +27,9 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
                 return new IndividualRoleVersionApprovalStatus(
                     "TestRole",
                     version,
-                    timeline,
-                    ImmutableList<IndividualRoleRequirementCompletionStatus>.Empty
+                    SupersededAtUtc: null,
+                    Status: timeline,
+                    Requirements: ImmutableList<IndividualRoleRequirementCompletionStatus>.Empty
                 );
             }
 
@@ -172,8 +173,9 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
                 return new FamilyRoleVersionApprovalStatus(
                     "TestRole",
                     version,
-                    timeline,
-                    ImmutableList<FamilyRoleRequirementCompletionStatus>.Empty
+                    SupersededAtUtc: null,
+                    Status: timeline,
+                    Requirements: ImmutableList<FamilyRoleRequirementCompletionStatus>.Empty
                 );
             }
 

--- a/test/CareTogether.Core.Test/ApprovalCalculationTests/RequirementRoleAttributionTests.cs
+++ b/test/CareTogether.Core.Test/ApprovalCalculationTests/RequirementRoleAttributionTests.cs
@@ -280,8 +280,9 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
                     new FamilyRoleVersionApprovalStatus(
                         roleName,
                         Version: "2024",
+                        SupersededAtUtc: null,
                         Status: null,
-                        ImmutableList.Create(
+                        Requirements: ImmutableList.Create(
                             new FamilyRoleRequirementCompletionStatus(
                                 requirementName,
                                 RequirementStage.Approval,
@@ -306,8 +307,9 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
                     new IndividualRoleVersionApprovalStatus(
                         roleName,
                         Version: "2024",
+                        SupersededAtUtc: null,
                         Status: null,
-                        ImmutableList.Create(
+                        Requirements: ImmutableList.Create(
                             new IndividualRoleRequirementCompletionStatus(
                                 requirementName,
                                 RequirementStage.Approval,


### PR DESCRIPTION
## Summary
- Prefer non-superseded volunteer policy versions when showing renewal prompts
- Include the policy version’s superseded date in the approval status output, so renewal prompts can prefer current policy versions over obsolete ones
- Add regression coverage for expired superseded individual roles renewing through active versions
- Regenerate swagger/client contract artifacts

## Example

A family is approved through a superseded policy version.

### Before

Migration HF Family is required by a superseded policy version

<img width="977" height="378" alt="image" src="https://github.com/user-attachments/assets/0f7f81f8-5ca3-488b-b8a5-e9818ce902a1" />

### After

Background Check - Minors 13+ is required by a non-superseded policy version

<img width="998" height="380" alt="image" src="https://github.com/user-attachments/assets/84ea1a5c-690b-4190-b80b-65c786647939" />
