### PR TITLE
Fix invite redemption without org access

### DIFF
--- a/src/caretogether-pwa/src/AppRoutes.tsx
+++ b/src/caretogether-pwa/src/AppRoutes.tsx
@@ -39,6 +39,7 @@ import { Reports } from './Reports/Reports';
 import { Settings } from './Settings/SettingsRoutes';
 import { Support } from './Support';
 import { UserProfile } from './UserProfile/UserProfile';
+import { RedeemPersonInvite } from './UserProfile/RedeemPersonInvite';
 
 function RouteMigrator() {
   const trace = useScopedTrace('RouteMigrator');
@@ -267,6 +268,10 @@ export function AppRoutes() {
       <Route
         path="/org/:organizationId/:locationId/*"
         element={<LocationContextWrapper />}
+      />
+      <Route
+        path="/me/redeemPersonInvite"
+        element={<RedeemPersonInvite />}
       />
       <Route
         path="/me/*"

--- a/src/caretogether-pwa/src/Model/SessionModel.ts
+++ b/src/caretogether-pwa/src/Model/SessionModel.ts
@@ -1,4 +1,4 @@
-import { atom, selector } from 'recoil';
+import { selectorFamily } from 'recoil';
 import {
   CombinedFamilyInfo,
   CommunityInfo,
@@ -10,16 +10,9 @@ import { api } from '../Api/Api';
 import { currentLocationQuery } from './Data';
 import { ORGANIZATION_ADMINISTRATOR } from '../constants';
 
-export const redemptionSessionIdState = atom<string | null>({
-  key: 'redemptionSessionIdState',
-  default: null,
-});
-
-export const inviteReviewInfoQuery = selector({
+export const inviteReviewInfoQuery = selectorFamily({
   key: 'inviteReviewInfoQuery',
-  get: async ({ get }) => {
-    const redemptionSessionId = get(redemptionSessionIdState);
-
+  get: (redemptionSessionId: string | null) => async () => {
     if (redemptionSessionId) {
       const inviteReviewInfo =
         await api.users.examinePersonInviteRedemptionSession(

--- a/src/caretogether-pwa/src/UserProfile/RedeemPersonInvite.tsx
+++ b/src/caretogether-pwa/src/UserProfile/RedeemPersonInvite.tsx
@@ -4,33 +4,24 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   useRecoilRefresher_UNSTABLE,
   useRecoilValueLoadable,
-  useSetRecoilState,
 } from 'recoil';
 import { useBackdrop } from '../Hooks/useBackdrop';
-import {
-  inviteReviewInfoQuery,
-  redemptionSessionIdState,
-} from '../Model/SessionModel';
+import { inviteReviewInfoQuery } from '../Model/SessionModel';
 import { ProgressBackdrop } from '../Shell/ProgressBackdrop';
 import { useScreenTitle } from '../Shell/ShellScreenTitle';
 import { api } from '../Api/Api';
 import { userOrganizationAccessQuery } from '../Model/Data';
 
 function RedeemPersonInvite() {
-  // Start by configuring the current redemption session, if there is one.
   const [searchParams] = useSearchParams();
   const redemptionSessionId = searchParams.get('state');
-  const setRedemptionSessionId = useSetRecoilState(redemptionSessionIdState);
-  useEffect(() => {
-    if (redemptionSessionId) {
-      setRedemptionSessionId(redemptionSessionId);
-    }
-  }, [redemptionSessionId, setRedemptionSessionId]);
 
   // Attempt to retrieve the invite review info for the redemption session.
   // If it can be retrieved, then render the invite review to allow the user the
   // option to confirm accepting the invite.
-  const inviteReviewInfo = useRecoilValueLoadable(inviteReviewInfoQuery);
+  const inviteReviewInfo = useRecoilValueLoadable(
+    inviteReviewInfoQuery(redemptionSessionId)
+  );
 
   const withBackdrop = useBackdrop();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- Route /me/redeemPersonInvite outside the org/location shell so invited users with no tenant access can accept invites
- Load invite review data directly from the state query parameter instead of a Recoil effect-populated atom
- Keep normal /me routes inside the existing shell

## Root cause
The invite redemption route started rendering inside ShellRootLayout after the route lazy-loading cleanup. ShellRootLayout assumes organization/location context exists, but invited users legitimately have tenantAccess.organizations = [] until they accept the invite.