### PR TITLE
Restrict requirement prompts to active policy versions

### DIFF
--- a/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
@@ -66,12 +66,11 @@ namespace CareTogether.Engines.PolicyEvaluation
             FamilyRoleApprovalStatus familyRoleStatus
         )
         {
-            // Determine the highest status among the versions for this family role.
-            // If there is a definitive max status, only consider missing requirements from
-            // versions that have that same status; this hides missing requirements from
-            // other versions of the same policy regardless of requirement stage.
+            // Older policy versions can prove the role is already approved/onboarded.
+            // Only active policy versions can ask for missing requirements.
             var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
-                familyRoleStatus.RoleVersionApprovals
+                familyRoleStatus.RoleVersionApprovals,
+                familyRoleStatus.CurrentStatus
             );
             var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
                 promptableVersions
@@ -113,11 +112,11 @@ namespace CareTogether.Engines.PolicyEvaluation
             return individualStatus.ApprovalStatusByRole.SelectMany(kv =>
             {
                 var roleName = kv.Key;
-                // Hide missing requirements from other versions of the same role
-                // if there exists a version with a higher/equivalent max status. This
-                // is independent of requirement stage.
+                // Older policy versions can prove the role is already approved/onboarded.
+                // Only active policy versions can ask for missing requirements.
                 var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
-                    kv.Value.RoleVersionApprovals
+                    kv.Value.RoleVersionApprovals,
+                    kv.Value.CurrentStatus
                 );
                 var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
                     promptableVersions
@@ -151,17 +150,16 @@ namespace CareTogether.Engines.PolicyEvaluation
                     {
                         var roleName = kv.Key;
 
-                        // If role has achieved Prospective or higher status, hide applications
+                        if (
+                            !PolicyEvaluationHelpers.ShouldShowApplicationPrompt(
+                                kv.Value.CurrentStatus
+                            )
+                        )
+                            return Enumerable.Empty<(Guid, string)>();
+
                         var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
                             kv.Value.RoleVersionApprovals
                         );
-                        var individualHighestStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
-                            promptableVersions
-                        );
-
-                        if (individualHighestStatus >= RoleApprovalStatus.Prospective)
-                            return Enumerable.Empty<(Guid, string)>();
-
                         return promptableVersions
                             .Where(r => r.CurrentStatus == null)
                             .SelectMany(r => r.CurrentAvailableApplications)
@@ -212,10 +210,11 @@ namespace CareTogether.Engines.PolicyEvaluation
         {
             get
             {
-                // Prefer active policy versions for user prompts, falling back to superseded
-                // versions only when there is no active version for the role.
+                // Older policy versions can prove the role is already approved/onboarded.
+                // Only active policy versions can ask for missing requirements.
                 var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
-                    RoleVersionApprovals
+                    RoleVersionApprovals,
+                    CurrentStatus
                 );
                 var missingRequirements = promptableVersions
                     .SelectMany(r =>
@@ -233,14 +232,14 @@ namespace CareTogether.Engines.PolicyEvaluation
         }
 
         public ImmutableList<string> CurrentAvailableApplications =>
-            // Prefer active policy versions for user prompts, falling back to superseded
-            // versions only when there is no active version for the role.
-            PolicyEvaluationHelpers
-                .SelectPromptableVersions(RoleVersionApprovals)
-                .Where(r => r.CurrentStatus == null)
-                .SelectMany(r => r.CurrentAvailableApplications)
-                .Select(r => r.ActionName)
-                .ToImmutableList();
+            !PolicyEvaluationHelpers.ShouldShowApplicationPrompt(CurrentStatus)
+                ? ImmutableList<string>.Empty
+                : PolicyEvaluationHelpers
+                    .SelectPromptableVersions(RoleVersionApprovals)
+                    .Where(r => r.CurrentStatus == null)
+                    .SelectMany(r => r.CurrentAvailableApplications)
+                    .Select(r => r.ActionName)
+                    .ToImmutableList();
     }
 
     public sealed record IndividualRoleVersionApprovalStatus(
@@ -311,12 +310,11 @@ namespace CareTogether.Engines.PolicyEvaluation
         {
             get
             {
-                // Determine the highest status across role versions. If there is a max
-                // status, only consider missing requirements from versions that share
-                // that status, which hides missing requirements from other versions
-                // of the same policy (independent of requirement stage).
+                // Older policy versions can prove the role is already approved/onboarded.
+                // Only active policy versions can ask for missing requirements.
                 var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
-                    RoleVersionApprovals
+                    RoleVersionApprovals,
+                    CurrentStatus
                 );
                 var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
                     promptableVersions
@@ -343,15 +341,10 @@ namespace CareTogether.Engines.PolicyEvaluation
         {
             get
             {
-                var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
-                    RoleVersionApprovals
-                );
-                var highestStatus =
-                    PolicyEvaluationHelpers.GetMaxRoleStatus(promptableVersions) ?? default;
-
-                return highestStatus >= RoleApprovalStatus.Prospective
+                return !PolicyEvaluationHelpers.ShouldShowApplicationPrompt(CurrentStatus)
                     ? ImmutableList<string>.Empty
-                    : promptableVersions
+                    : PolicyEvaluationHelpers
+                        .SelectPromptableVersions(RoleVersionApprovals)
                         .Where(r => r.CurrentStatus == null)
                         .SelectMany(r => r.CurrentAvailableApplications)
                         .Where(r => r.Scope == VolunteerFamilyRequirementScope.OncePerFamily)
@@ -370,7 +363,8 @@ namespace CareTogether.Engines.PolicyEvaluation
             {
                 // Extract all missing requirements that apply to individuals, grouped by person and action
                 var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
-                    RoleVersionApprovals
+                    RoleVersionApprovals,
+                    CurrentStatus
                 );
                 var missingRequirements = promptableVersions
                     .SelectMany(r =>

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationHelpers.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationHelpers.cs
@@ -27,20 +27,45 @@ namespace CareTogether.Engines.PolicyEvaluation
                 .DefaultIfEmpty()
                 .Max();
 
+        internal static bool ShouldShowApplicationPrompt(RoleApprovalStatus? effectiveStatus) =>
+            effectiveStatus is null or RoleApprovalStatus.Expired;
+
         internal static ImmutableList<IndividualRoleVersionApprovalStatus> SelectPromptableVersions(
             ImmutableList<IndividualRoleVersionApprovalStatus> versions
+        ) => versions.Where(IsActive).ToImmutableList();
+
+        internal static ImmutableList<IndividualRoleVersionApprovalStatus> SelectPromptableVersions(
+            ImmutableList<IndividualRoleVersionApprovalStatus> versions,
+            RoleApprovalStatus? effectiveStatus
         )
         {
-            var activeVersions = versions.Where(IsActive).ToImmutableList();
-            return activeVersions.Count > 0 ? activeVersions : versions;
+            var activeVersions = SelectPromptableVersions(versions);
+            if (effectiveStatus == RoleApprovalStatus.Expired)
+                return activeVersions;
+
+            var activeStatus = GetMaxRoleStatus(activeVersions);
+            return activeStatus == effectiveStatus
+                ? activeVersions
+                : ImmutableList<IndividualRoleVersionApprovalStatus>.Empty;
         }
 
         internal static ImmutableList<FamilyRoleVersionApprovalStatus> SelectPromptableVersions(
             ImmutableList<FamilyRoleVersionApprovalStatus> versions
+        ) => versions.Where(IsActive).ToImmutableList();
+
+        internal static ImmutableList<FamilyRoleVersionApprovalStatus> SelectPromptableVersions(
+            ImmutableList<FamilyRoleVersionApprovalStatus> versions,
+            RoleApprovalStatus? effectiveStatus
         )
         {
-            var activeVersions = versions.Where(IsActive).ToImmutableList();
-            return activeVersions.Count > 0 ? activeVersions : versions;
+            var activeVersions = SelectPromptableVersions(versions);
+            if (effectiveStatus == RoleApprovalStatus.Expired)
+                return activeVersions;
+
+            var activeStatus = GetMaxRoleStatus(activeVersions);
+            return activeStatus == effectiveStatus
+                ? activeVersions
+                : ImmutableList<FamilyRoleVersionApprovalStatus>.Empty;
         }
 
         private static bool IsActive(IndividualRoleVersionApprovalStatus version) =>

--- a/test/CareTogether.Core.Test/ApprovalCalculationTests/CalculateCombinedFamilyApprovalsTest.cs
+++ b/test/CareTogether.Core.Test/ApprovalCalculationTests/CalculateCombinedFamilyApprovalsTest.cs
@@ -420,8 +420,200 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
             CollectionAssert.AreEqual(new[] { "CurrentApproval" }, missingRequirements.ToArray());
         }
 
-        private static EffectiveLocationPolicy CreateIndividualRenewalPolicy() =>
-            new(
+        [TestMethod]
+        public void ExpiredSupersededIndividualRoleWithoutActiveVersionShowsNoPrompts()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateIndividualRenewalPolicy(includeCurrentVersion: false);
+            var completedIndividualRequirements = H.CompletedIndividualRequirementsWithExpiry(
+                (H.guid1, "LegacyApplication", 1, 10),
+                (H.guid1, "LegacyApproval", 1, 10)
+            );
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: ImmutableList<Resources.CompletedRequirementInfo>.Empty,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: completedIndividualRequirements,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
+            );
+
+            Assert.AreEqual(
+                RoleApprovalStatus.Expired,
+                result.IndividualApprovals[H.guid1].ApprovalStatusByRole["Role1"].CurrentStatus
+            );
+            Assert.IsFalse(
+                result.CurrentAvailableIndividualApplications.Any(x => x.PersonId == H.guid1)
+            );
+            Assert.IsFalse(
+                result.CurrentMissingIndividualRequirements.Any(x => x.PersonId == H.guid1)
+            );
+        }
+
+        [TestMethod]
+        public void OnboardedSupersededFamilyRoleHidesActiveVersionMissingRequirements()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateFamilyRenewalPolicy();
+            var completedFamilyRequirements = H.Completed(
+                ("LegacyApplication", 1),
+                ("LegacyApproval", 1),
+                ("CurrentApplication", 11)
+            );
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: completedFamilyRequirements,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.CompletedRequirementInfo>
+                >.Empty,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
+            );
+
+            Assert.AreEqual(
+                RoleApprovalStatus.Onboarded,
+                result.FamilyRoleApprovals["FamilyRole1"].CurrentStatus
+            );
+            Assert.IsFalse(
+                result.CurrentMissingFamilyRequirements.Any(x =>
+                    x.ActionName == "CurrentFamilyApproval"
+                )
+            );
+            Assert.IsFalse(
+                result.CurrentMissingIndividualRequirements.Any(x =>
+                    x.ActionName == "CurrentAdultApproval"
+                )
+            );
+        }
+
+        [TestMethod]
+        public void ExpiredSupersededFamilyRoleShowsActiveVersionMissingRequirements()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateFamilyRenewalPolicy();
+            var completedFamilyRequirements = H.CompletedWithExpiry(
+                ("LegacyApplication", 1, 10),
+                ("LegacyApproval", 1, 10),
+                ("CurrentApplication", 11, null)
+            );
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: completedFamilyRequirements,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.CompletedRequirementInfo>
+                >.Empty,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
+            );
+
+            Assert.AreEqual(
+                RoleApprovalStatus.Expired,
+                result.FamilyRoleApprovals["FamilyRole1"].CurrentStatus
+            );
+            CollectionAssert.AreEqual(
+                new[] { "CurrentFamilyApproval" },
+                result
+                    .CurrentMissingFamilyRequirements.Select(x => x.ActionName)
+                    .Distinct()
+                    .ToArray()
+            );
+            CollectionAssert.AreEquivalent(
+                new[] { "CurrentAdultApproval" },
+                result
+                    .CurrentMissingIndividualRequirements.Select(x => x.ActionName)
+                    .Distinct()
+                    .ToArray()
+            );
+        }
+
+        [TestMethod]
+        public void ExpiredSupersededFamilyRoleWithoutActiveVersionShowsNoPrompts()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateFamilyRenewalPolicy(includeCurrentVersion: false);
+            var completedFamilyRequirements = H.CompletedWithExpiry(
+                ("LegacyApplication", 1, 10),
+                ("LegacyApproval", 1, 10)
+            );
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: completedFamilyRequirements,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.CompletedRequirementInfo>
+                >.Empty,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
+            );
+
+            Assert.AreEqual(
+                RoleApprovalStatus.Expired,
+                result.FamilyRoleApprovals["FamilyRole1"].CurrentStatus
+            );
+            Assert.IsFalse(result.CurrentAvailableFamilyApplications.Any());
+            Assert.IsFalse(result.CurrentMissingFamilyRequirements.Any());
+            Assert.IsFalse(result.CurrentMissingIndividualRequirements.Any());
+        }
+
+        private static EffectiveLocationPolicy CreateIndividualRenewalPolicy(
+            bool includeCurrentVersion = true
+        )
+        {
+            var versions = ImmutableList<VolunteerRolePolicyVersion>.Empty.Add(
+                new VolunteerRolePolicyVersion(
+                    "legacy",
+                    DateTime.UtcNow.AddDays(-1),
+                    H.IndividualApprovalRequirements(
+                        (RequirementStage.Application, "LegacyApplication"),
+                        (RequirementStage.Approval, "LegacyApproval")
+                    )
+                )
+            );
+
+            if (includeCurrentVersion)
+            {
+                versions = versions.Add(
+                    new VolunteerRolePolicyVersion(
+                        "current",
+                        SupersededAtUtc: null,
+                        Requirements: H.IndividualApprovalRequirements(
+                            (RequirementStage.Application, "CurrentApplication"),
+                            (RequirementStage.Approval, "CurrentApproval")
+                        )
+                    )
+                );
+            }
+
+            return new(
                 ImmutableDictionary<string, ActionRequirement>.Empty,
                 ImmutableList<CustomField>.Empty,
                 new V1CasePolicy(
@@ -433,39 +625,80 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
                 new VolunteerPolicy(
                     ImmutableDictionary<string, VolunteerRolePolicy>.Empty.Add(
                         "Role1",
-                        new VolunteerRolePolicy(
-                            "Role1",
-                            ImmutableList<VolunteerRolePolicyVersion>
-                                .Empty.Add(
-                                    new VolunteerRolePolicyVersion(
-                                        "legacy",
-                                        DateTime.UtcNow.AddDays(-1),
-                                        H.IndividualApprovalRequirements(
-                                            (
-                                                RequirementStage.Application,
-                                                "LegacyApplication"
-                                            ),
-                                            (RequirementStage.Approval, "LegacyApproval")
-                                        )
-                                    )
-                                )
-                                .Add(
-                                    new VolunteerRolePolicyVersion(
-                                        "current",
-                                        SupersededAtUtc: null,
-                                        Requirements: H.IndividualApprovalRequirements(
-                                            (
-                                                RequirementStage.Application,
-                                                "CurrentApplication"
-                                            ),
-                                            (RequirementStage.Approval, "CurrentApproval")
-                                        )
-                                    )
-                                )
-                        )
+                        new VolunteerRolePolicy("Role1", versions)
                     ),
                     ImmutableDictionary<string, VolunteerFamilyRolePolicy>.Empty
                 )
             );
+        }
+
+        private static EffectiveLocationPolicy CreateFamilyRenewalPolicy(
+            bool includeCurrentVersion = true
+        )
+        {
+            var versions = ImmutableList<VolunteerFamilyRolePolicyVersion>.Empty.Add(
+                new VolunteerFamilyRolePolicyVersion(
+                    "legacy",
+                    DateTime.UtcNow.AddDays(-1),
+                    H.FamilyApprovalRequirements(
+                        (
+                            RequirementStage.Application,
+                            "LegacyApplication",
+                            VolunteerFamilyRequirementScope.OncePerFamily
+                        ),
+                        (
+                            RequirementStage.Approval,
+                            "LegacyApproval",
+                            VolunteerFamilyRequirementScope.OncePerFamily
+                        )
+                    )
+                )
+            );
+
+            if (includeCurrentVersion)
+            {
+                versions = versions.Add(
+                    new VolunteerFamilyRolePolicyVersion(
+                        "current",
+                        SupersededAtUtc: null,
+                        Requirements: H.FamilyApprovalRequirements(
+                            (
+                                RequirementStage.Application,
+                                "CurrentApplication",
+                                VolunteerFamilyRequirementScope.OncePerFamily
+                            ),
+                            (
+                                RequirementStage.Approval,
+                                "CurrentFamilyApproval",
+                                VolunteerFamilyRequirementScope.OncePerFamily
+                            ),
+                            (
+                                RequirementStage.Approval,
+                                "CurrentAdultApproval",
+                                VolunteerFamilyRequirementScope.AllAdultsInTheFamily
+                            )
+                        )
+                    )
+                );
+            }
+
+            return new(
+                ImmutableDictionary<string, ActionRequirement>.Empty,
+                ImmutableList<CustomField>.Empty,
+                new V1CasePolicy(
+                    ImmutableList<string>.Empty,
+                    ImmutableList<CustomField>.Empty,
+                    ImmutableList<ArrangementPolicy>.Empty,
+                    ImmutableList<FunctionPolicy>.Empty
+                ),
+                new VolunteerPolicy(
+                    ImmutableDictionary<string, VolunteerRolePolicy>.Empty,
+                    ImmutableDictionary<string, VolunteerFamilyRolePolicy>.Empty.Add(
+                        "FamilyRole1",
+                        new VolunteerFamilyRolePolicy("FamilyRole1", versions)
+                    )
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- source requirement/application prompts only from active policy versions
- allow older/superseded policy versions to suppress prompts through effective role status
- add regression tests for expired renewals and superseded-only policy versions
