### PR TITLE
Fix responsive Featurebase launcher padding

### DIFF
--- a/src/caretogether-pwa/src/Hooks/useFeaturebase.tsx
+++ b/src/caretogether-pwa/src/Hooks/useFeaturebase.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useMediaQuery, useTheme } from '@mui/material';
 import { atom, useSetRecoilState } from 'recoil';
 import { useLoadable } from './useLoadable';
@@ -11,6 +11,14 @@ import {
 import { api } from '../Api/Api';
 import { useGlobalPermissions } from '../Model/SessionModel';
 import { Permission } from '../GeneratedClient';
+
+const FEATUREBASE_DESKTOP_VERTICAL_PADDING = 20;
+const FEATUREBASE_MOBILE_VERTICAL_PADDING = 70;
+
+type FeaturebaseIdentity = {
+  userHash: string;
+  userId: string;
+};
 
 // Recoil atom for changelog unread count
 export const changelogUnreadCountState = atom<number>({
@@ -38,14 +46,39 @@ export const useFeaturebase = () => {
   const locationConfiguration = useLoadable(locationConfigurationQuery);
   const locationContext = useLoadable(selectedLocationContextState);
   const setChangelogUnreadCount = useSetRecoilState(changelogUnreadCountState);
+  const [featurebaseIdentity, setFeaturebaseIdentity] =
+    useState<FeaturebaseIdentity>();
 
   // Check if user has permission to access support screen
   const permissions = useGlobalPermissions();
   const hasAccessToSupport = permissions(Permission.AccessSupportScreen);
 
   useEffect(() => {
-    // Only initialize Featurebase if user has access to support screen
-    if (!hasAccessToSupport) {
+    if (!hasAccessToSupport || !accountInfo?.userId) {
+      setFeaturebaseIdentity(undefined);
+      return;
+    }
+
+    let cancelled = false;
+    const userId = accountInfo.userId;
+
+    void api.users.getFeaturebaseIdentityHash().then((userHash) => {
+      if (cancelled) return;
+
+      setFeaturebaseIdentity({ userHash, userId });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accountInfo?.userId, hasAccessToSupport]);
+
+  useEffect(() => {
+    if (
+      !hasAccessToSupport ||
+      !accountInfo?.userId ||
+      featurebaseIdentity?.userId !== accountInfo.userId
+    ) {
       return;
     }
 
@@ -58,64 +91,61 @@ export const useFeaturebase = () => {
       };
     }
 
-    // Only boot Featurebase if we have user data
-    if (accountInfo?.userId) {
-      // Fetch the userHash from the backend for identity verification
-      api.users.getFeaturebaseIdentityHash().then((userHash) => {
-        // Boot Featurebase messenger with configuration including user attributes
-        win.Featurebase('boot', {
-          appId: '6890e41acb9e844a4374a7a8', // required
-          email: accountInfo.email,
-          userId: accountInfo.userId,
-          name: accountInfo.name,
-          userHash: userHash, // Add the generated userHash for identity verification
-          theme: 'light',
-          language: 'en',
-          ...(isMobile ? { verticalPadding: 70 } : {}),
-          companies: [
-            {
-              id: locationContext?.organizationId,
-              name: organizationConfiguration?.organizationName,
-              customFields: {
-                locationId: locationContext?.locationId,
-                locationName: locationConfiguration?.name,
-              },
-            },
-          ],
-        });
-
-        // Initialize changelog widget after Featurebase is booted
-        win.Featurebase(
-          'init_changelog_widget',
-          {
-            organization: 'caretogether',
-            theme: 'light',
-            locale: 'en',
-            dropdown: {
-              enabled: true,
-              placement: 'left',
-            },
-            popup: {
-              enabled: false,
-              autoOpenForNewUpdates: false,
-            },
+    // Boot Featurebase messenger with configuration including user attributes
+    win.Featurebase('boot', {
+      appId: '6890e41acb9e844a4374a7a8', // required
+      email: accountInfo.email,
+      userId: accountInfo.userId,
+      name: accountInfo.name,
+      userHash: featurebaseIdentity.userHash,
+      theme: 'light',
+      language: 'en',
+      verticalPadding: isMobile
+        ? FEATUREBASE_MOBILE_VERTICAL_PADDING
+        : FEATUREBASE_DESKTOP_VERTICAL_PADDING,
+      companies: [
+        {
+          id: locationContext?.organizationId,
+          name: organizationConfiguration?.organizationName,
+          customFields: {
+            locationId: locationContext?.locationId,
+            locationName: locationConfiguration?.name,
           },
-          (
-            error: unknown,
-            data: { action?: string; unreadCount?: number } | null
-          ) => {
-            if (error) return;
+        },
+      ],
+    });
 
-            if (data?.action === 'unreadChangelogsCountChanged') {
-              setChangelogUnreadCount(data.unreadCount ?? 0);
-            }
-          }
-        );
-      });
-    }
+    // Initialize changelog widget after Featurebase is booted
+    win.Featurebase(
+      'init_changelog_widget',
+      {
+        organization: 'caretogether',
+        theme: 'light',
+        locale: 'en',
+        dropdown: {
+          enabled: true,
+          placement: 'left',
+        },
+        popup: {
+          enabled: false,
+          autoOpenForNewUpdates: false,
+        },
+      },
+      (
+        error: unknown,
+        data: { action?: string; unreadCount?: number } | null
+      ) => {
+        if (error) return;
+
+        if (data?.action === 'unreadChangelogsCountChanged') {
+          setChangelogUnreadCount(data.unreadCount ?? 0);
+        }
+      }
+    );
   }, [
     hasAccessToSupport,
     accountInfo,
+    featurebaseIdentity,
     organizationConfiguration,
     locationConfiguration,
     locationContext,


### PR DESCRIPTION
## Summary

- fetch the Featurebase identity hash independently from responsive configuration
- ignore stale identity requests after effect cleanup
- reconfigure the existing Messenger with explicit mobile and desktop vertical padding

## Root cause

The identity request ran inside an effect that depended on the mobile breakpoint, so breakpoint changes could leave competing asynchronous boot calls. The desktop branch also omitted `verticalPadding`, which allowed Featurebase to retain an earlier mobile value.

## Impact

The chat launcher now settles at 70px on mobile layouts and 20px on desktop layouts, including devices whose viewport classification changes during initialization.

## Validation

- `npm run type-check`
- targeted ESLint on `useFeaturebase.tsx`
- targeted Prettier check on `useFeaturebase.tsx`
- targeted diff validation
