### PR TITLE
Protect drawer content from chat launcher

### DIFF
--- a/src/caretogether-pwa/src/Families/AddAdultDrawer.tsx
+++ b/src/caretogether-pwa/src/Families/AddAdultDrawer.tsx
@@ -459,7 +459,7 @@ export function AddAdultDrawer({ onClose }: AddAdultDrawerProps) {
           gap: 1,
           justifyContent: 'flex-end',
           p: 2,
-          pb: 'calc(16px + env(safe-area-inset-bottom))',
+          pb: 'env(safe-area-inset-bottom)',
           backgroundColor: 'background.paper',
         }}
       >

--- a/src/caretogether-pwa/src/Families/AddChildDrawer.tsx
+++ b/src/caretogether-pwa/src/Families/AddChildDrawer.tsx
@@ -368,7 +368,7 @@ export function AddChildDrawer({ onClose }: AddChildDrawerProps) {
           gap: 1,
           justifyContent: 'flex-end',
           p: 2,
-          pb: 'calc(16px + env(safe-area-inset-bottom))',
+          pb: 'env(safe-area-inset-bottom)',
           backgroundColor: 'background.paper',
         }}
       >

--- a/src/caretogether-pwa/src/Families/UploadFamilyDocumentsDrawer.tsx
+++ b/src/caretogether-pwa/src/Families/UploadFamilyDocumentsDrawer.tsx
@@ -98,7 +98,7 @@ export function UploadFamilyDocumentsDrawer({
           gap: 1,
           justifyContent: 'flex-end',
           p: 2,
-          pb: 'calc(16px + env(safe-area-inset-bottom))',
+          pb: 'env(safe-area-inset-bottom)',
           backgroundColor: 'background.paper',
         }}
       >

--- a/src/caretogether-pwa/src/Notes/AddEditNoteDrawer.tsx
+++ b/src/caretogether-pwa/src/Notes/AddEditNoteDrawer.tsx
@@ -159,7 +159,7 @@ export function AddEditNoteDrawer({
           gap: 1,
           justifyContent: 'flex-end',
           p: 2,
-          pb: 'calc(16px + env(safe-area-inset-bottom))',
+          pb: 'env(safe-area-inset-bottom)',
           backgroundColor: 'background.paper',
         }}
       >

--- a/src/caretogether-pwa/src/Volunteers/CreateVolunteerFamilyDrawer.tsx
+++ b/src/caretogether-pwa/src/Volunteers/CreateVolunteerFamilyDrawer.tsx
@@ -477,7 +477,7 @@ export function CreateVolunteerFamilyDrawer({
           gap: 1,
           justifyContent: 'flex-end',
           p: 2,
-          pb: 'calc(16px + env(safe-area-inset-bottom))',
+          pb: 'env(safe-area-inset-bottom)',
           backgroundColor: 'background.paper',
         }}
       >

--- a/src/caretogether-pwa/src/theme.tsx
+++ b/src/caretogether-pwa/src/theme.tsx
@@ -1,5 +1,10 @@
 import { createTheme } from '@mui/material/styles';
 import { amber } from '@mui/material/colors';
+import { drawerClasses } from '@mui/material/Drawer';
+import {
+  DESKTOP_BOTTOM_SAFE_AREA,
+  MOBILE_BOTTOM_SAFE_AREA,
+} from './Shell/shellLayoutConstants';
 
 export const theme = createTheme({
   palette: {
@@ -20,6 +25,21 @@ export const theme = createTheme({
     h3: {
       fontSize: '1.17rem',
       fontWeight: 700,
+    },
+  },
+  components: {
+    MuiDrawer: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          [`&.${drawerClasses.anchorRight} .${drawerClasses.paper}, &.${drawerClasses.anchorBottom} .${drawerClasses.paper}`]:
+            {
+              paddingBottom: `${MOBILE_BOTTOM_SAFE_AREA}px`,
+              [theme.breakpoints.up('md')]: {
+                paddingBottom: `${DESKTOP_BOTTOM_SAFE_AREA}px`,
+              },
+            },
+        }),
+      },
     },
   },
 });


### PR DESCRIPTION
## What changed

- reserve the existing mobile and desktop bottom safe areas for every right- and bottom-anchored MUI drawer
- leave left-side navigation drawers unchanged
- remove redundant 16px additions and `calc()` wrappers from drawer footer safe-area padding

## Why

MUI drawers render through portals outside `ShellRootLayout`, so they did not inherit the shell's Featurebase-safe bottom spacing. The chat launcher could consequently overlap content and actions near the bottom of a drawer.

## Impact

Drawer content and footer actions remain reachable above the Featurebase launcher across responsive layouts. Navigation drawers retain their current spacing.

