### PR TITLE
Fix approval prompts across policy versions

### DIFF
--- a/docs/policy-version-approval-prompt-rules.md
+++ b/docs/policy-version-approval-prompt-rules.md
@@ -1,0 +1,102 @@
+# Policy Version Approval Prompt Rules
+
+Volunteer roles and volunteer family roles can have multiple policy versions. Each version has its
+own approval status timeline, while the role also exposes one effective status across all versions.
+These values serve different purposes and must not be used interchangeably.
+
+## Terminology
+
+- An **active version** has no `SupersededAtUtc` value, or its supersedence date is in the future.
+- A **superseded version** has a `SupersededAtUtc` value in the past.
+- A **version status** is the current approval status calculated from one policy version's
+  requirements.
+- The **effective status** is the current status produced by combining all version timelines,
+  including superseded versions.
+- A **prompt** is an available application or a missing approval/onboarding requirement shown to a
+  user.
+
+## Effective Status
+
+Superseded policy versions continue to contribute valid historical approvals to the effective
+status. At a given point in time, statuses use this precedence:
+
+1. Denied
+2. Inactive
+3. Onboarded
+4. Approved
+5. Expired
+6. Prospective
+
+For example, an Onboarded status from a superseded version remains the effective status while its
+requirements remain valid, even when an active version is only Prospective.
+
+## Selecting Versions That Can Prompt
+
+Prompt selection follows these rules in order:
+
+1. If the effective status is Onboarded, no version can prompt. A valid onboarding carries across
+   policy versions until it expires.
+2. Superseded versions never prompt. They can affect the effective status, but users cannot continue
+   an approval workflow under a superseded policy.
+3. Among active versions, only the version or versions with the most advanced current version
+   status can prompt.
+4. A version with no status is less advanced than any version with a status.
+5. If every active version has no status, all active versions can prompt their application
+   requirements.
+6. Active versions tied at the same most advanced status can all prompt.
+7. If there are no active versions, there are no prompts.
+
+This keeps one active approval stage visible without allowing a more advanced superseded workflow
+to hide an active workflow, except while the effective onboarding remains valid.
+
+## Requirements Shown By Version Status
+
+After promptable versions are selected, each version exposes requirements for its own current stage:
+
+| Version status | Prompts |
+| --- | --- |
+| No status | Unmet Application requirements |
+| Prospective | Unmet Approval requirements |
+| Approved | Unmet Onboarding requirements |
+| Expired | Unmet Application, Approval, and Onboarding requirements |
+| Onboarded | None |
+| Inactive | None |
+| Denied | None |
+
+Completing an active version's application moves that version from no status to Prospective, which
+replaces its application prompt with its missing approval requirements.
+
+## Examples
+
+### Prospective Superseded Version
+
+- Superseded `pre2026`: Prospective
+- Active `v1`: no status
+- Effective status: Prospective
+
+The active v1 application is shown. After it is completed, v1 becomes Prospective and its approval
+requirements are shown. Missing requirements from `pre2026` are never shown.
+
+### Onboarded Superseded Version
+
+- Superseded `pre2026`: Onboarded
+- Active `v1`: Prospective
+- Effective status: Onboarded
+
+No prompts are shown. When the inherited onboarding expires and the effective status becomes
+Expired, the active v1 workflow can prompt again.
+
+### Multiple Active Versions
+
+- Active `v1`: Prospective
+- Active `v2`: Approved
+
+Only v2 can prompt because Approved is more advanced than Prospective. If both versions are
+Approved, both can contribute missing onboarding requirements.
+
+## Implementation
+
+The shared selection logic is implemented by `PolicyEvaluationHelpers.SelectPromptableVersions` and
+is used for family applications, individual applications, family requirements, and individual
+requirements. Any new approval output must use the same helper so prompt behavior remains
+consistent.

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/IPolicyEvaluationEngine.cs
@@ -41,7 +41,7 @@ namespace CareTogether.Engines.PolicyEvaluation
             (string Version, string RoleName)[] Versions
         )> CurrentMissingIndividualRequirements =>
             FamilyRoleApprovals
-                .SelectMany(fra => GetMissingRequirementsFromFamilyRole(fra.Key, fra.Value))
+                .SelectMany(fra => GetMissingRequirementsFromFamilyRole(fra.Value))
                 .Concat(
                     IndividualApprovals.SelectMany(ia =>
                         GetMissingRequirementsFromIndividual(ia.Key, ia.Value)
@@ -62,7 +62,6 @@ namespace CareTogether.Engines.PolicyEvaluation
             string ActionName,
             (string Version, string RoleName) Version
         )> GetMissingRequirementsFromFamilyRole(
-            string roleName,
             FamilyRoleApprovalStatus familyRoleStatus
         )
         {
@@ -72,12 +71,8 @@ namespace CareTogether.Engines.PolicyEvaluation
                 familyRoleStatus.RoleVersionApprovals,
                 familyRoleStatus.CurrentStatus
             );
-            var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
-                promptableVersions
-            );
 
             return promptableVersions
-                .Where(r => maxVersionStatus == null || r.CurrentStatus == maxVersionStatus)
                 .SelectMany(r =>
                     r.CurrentMissingRequirements.Where(cmr =>
                             cmr.Scope == VolunteerFamilyRequirementScope.AllAdultsInTheFamily
@@ -111,19 +106,14 @@ namespace CareTogether.Engines.PolicyEvaluation
         {
             return individualStatus.ApprovalStatusByRole.SelectMany(kv =>
             {
-                var roleName = kv.Key;
                 // Older policy versions can prove the role is already approved/onboarded.
                 // Only active policy versions can ask for missing requirements.
                 var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
                     kv.Value.RoleVersionApprovals,
                     kv.Value.CurrentStatus
                 );
-                var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
-                    promptableVersions
-                );
 
                 return promptableVersions
-                    .Where(r => maxVersionStatus == null || r.CurrentStatus == maxVersionStatus)
                     .SelectMany(r =>
                         r.CurrentMissingRequirements.Where(cmr =>
                                 cmr.WhenMet?.Contains(DateOnly.FromDateTime(DateTime.UtcNow))
@@ -148,20 +138,11 @@ namespace CareTogether.Engines.PolicyEvaluation
                 .SelectMany(ia =>
                     ia.Value.ApprovalStatusByRole.SelectMany(kv =>
                     {
-                        var roleName = kv.Key;
-
-                        if (
-                            !PolicyEvaluationHelpers.ShouldShowApplicationPrompt(
-                                kv.Value.CurrentStatus
-                            )
-                        )
-                            return Enumerable.Empty<(Guid, string)>();
-
                         var promptableVersions = PolicyEvaluationHelpers.SelectPromptableVersions(
-                            kv.Value.RoleVersionApprovals
+                            kv.Value.RoleVersionApprovals,
+                            kv.Value.CurrentStatus
                         );
                         return promptableVersions
-                            .Where(r => r.CurrentStatus == null)
                             .SelectMany(r => r.CurrentAvailableApplications)
                             .Select(a => (ia.Key, a.ActionName));
                     })
@@ -231,15 +212,17 @@ namespace CareTogether.Engines.PolicyEvaluation
             }
         }
 
-        public ImmutableList<string> CurrentAvailableApplications =>
-            !PolicyEvaluationHelpers.ShouldShowApplicationPrompt(CurrentStatus)
-                ? ImmutableList<string>.Empty
-                : PolicyEvaluationHelpers
-                    .SelectPromptableVersions(RoleVersionApprovals)
-                    .Where(r => r.CurrentStatus == null)
+        public ImmutableList<string> CurrentAvailableApplications
+        {
+            get
+            {
+                return PolicyEvaluationHelpers
+                    .SelectPromptableVersions(RoleVersionApprovals, CurrentStatus)
                     .SelectMany(r => r.CurrentAvailableApplications)
                     .Select(r => r.ActionName)
                     .ToImmutableList();
+            }
+        }
     }
 
     public sealed record IndividualRoleVersionApprovalStatus(
@@ -316,12 +299,8 @@ namespace CareTogether.Engines.PolicyEvaluation
                     RoleVersionApprovals,
                     CurrentStatus
                 );
-                var maxVersionStatus = PolicyEvaluationHelpers.GetMaxRoleStatus(
-                    promptableVersions
-                );
 
                 return promptableVersions
-                    .Where(r => maxVersionStatus == null || r.CurrentStatus == maxVersionStatus)
                     .SelectMany(r =>
                         r.CurrentMissingRequirements.Select(cmr =>
                             (CurrentMissingRequirement: cmr, Version: (r.Version, r.RoleName))
@@ -341,15 +320,12 @@ namespace CareTogether.Engines.PolicyEvaluation
         {
             get
             {
-                return !PolicyEvaluationHelpers.ShouldShowApplicationPrompt(CurrentStatus)
-                    ? ImmutableList<string>.Empty
-                    : PolicyEvaluationHelpers
-                        .SelectPromptableVersions(RoleVersionApprovals)
-                        .Where(r => r.CurrentStatus == null)
-                        .SelectMany(r => r.CurrentAvailableApplications)
-                        .Where(r => r.Scope == VolunteerFamilyRequirementScope.OncePerFamily)
-                        .Select(r => r.ActionName)
-                        .ToImmutableList();
+                return PolicyEvaluationHelpers
+                    .SelectPromptableVersions(RoleVersionApprovals, CurrentStatus)
+                    .SelectMany(r => r.CurrentAvailableApplications)
+                    .Where(r => r.Scope == VolunteerFamilyRequirementScope.OncePerFamily)
+                    .Select(r => r.ActionName)
+                    .ToImmutableList();
             }
         }
 

--- a/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationHelpers.cs
+++ b/src/CareTogether.Core/Engines/PolicyEvaluation/PolicyEvaluationHelpers.cs
@@ -9,63 +9,67 @@ namespace CareTogether.Engines.PolicyEvaluation
     {
         internal static RoleApprovalStatus? GetMaxRoleStatus(
             ImmutableList<IndividualRoleVersionApprovalStatus> versions
-        ) =>
-            versions
+        )
+        {
+            var statuses = versions
                 .Select(r => r.CurrentStatus)
                 .Where(s => s != null)
                 .OfType<RoleApprovalStatus>()
-                .DefaultIfEmpty()
-                .Max();
+                .ToImmutableList();
+
+            return statuses.Count == 0 ? null : statuses.Max();
+        }
 
         internal static RoleApprovalStatus? GetMaxRoleStatus(
             ImmutableList<FamilyRoleVersionApprovalStatus> versions
-        ) =>
-            versions
+        )
+        {
+            var statuses = versions
                 .Select(r => r.CurrentStatus)
                 .Where(s => s != null)
                 .OfType<RoleApprovalStatus>()
-                .DefaultIfEmpty()
-                .Max();
+                .ToImmutableList();
 
-        internal static bool ShouldShowApplicationPrompt(RoleApprovalStatus? effectiveStatus) =>
-            effectiveStatus is null or RoleApprovalStatus.Expired;
-
-        internal static ImmutableList<IndividualRoleVersionApprovalStatus> SelectPromptableVersions(
-            ImmutableList<IndividualRoleVersionApprovalStatus> versions
-        ) => versions.Where(IsActive).ToImmutableList();
+            return statuses.Count == 0 ? null : statuses.Max();
+        }
 
         internal static ImmutableList<IndividualRoleVersionApprovalStatus> SelectPromptableVersions(
             ImmutableList<IndividualRoleVersionApprovalStatus> versions,
             RoleApprovalStatus? effectiveStatus
         )
         {
-            var activeVersions = SelectPromptableVersions(versions);
-            if (effectiveStatus == RoleApprovalStatus.Expired)
-                return activeVersions;
+            // A valid onboarding carries across policy versions until it expires.
+            if (effectiveStatus == RoleApprovalStatus.Onboarded)
+                return ImmutableList<IndividualRoleVersionApprovalStatus>.Empty;
 
-            var activeStatus = GetMaxRoleStatus(activeVersions);
-            return activeStatus == effectiveStatus
+            // Superseded versions contribute to effective status but never prompt. Among active
+            // versions, only workflows tied for the most advanced current status can prompt.
+            var activeVersions = versions.Where(IsActive).ToImmutableList();
+            var maxActiveStatus = GetMaxRoleStatus(activeVersions);
+            return maxActiveStatus == null
                 ? activeVersions
-                : ImmutableList<IndividualRoleVersionApprovalStatus>.Empty;
+                : activeVersions
+                    .Where(version => version.CurrentStatus == maxActiveStatus)
+                    .ToImmutableList();
         }
-
-        internal static ImmutableList<FamilyRoleVersionApprovalStatus> SelectPromptableVersions(
-            ImmutableList<FamilyRoleVersionApprovalStatus> versions
-        ) => versions.Where(IsActive).ToImmutableList();
 
         internal static ImmutableList<FamilyRoleVersionApprovalStatus> SelectPromptableVersions(
             ImmutableList<FamilyRoleVersionApprovalStatus> versions,
             RoleApprovalStatus? effectiveStatus
         )
         {
-            var activeVersions = SelectPromptableVersions(versions);
-            if (effectiveStatus == RoleApprovalStatus.Expired)
-                return activeVersions;
+            // A valid onboarding carries across policy versions until it expires.
+            if (effectiveStatus == RoleApprovalStatus.Onboarded)
+                return ImmutableList<FamilyRoleVersionApprovalStatus>.Empty;
 
-            var activeStatus = GetMaxRoleStatus(activeVersions);
-            return activeStatus == effectiveStatus
+            // Keep this overload aligned with the individual-role selection above.
+            var activeVersions = versions.Where(IsActive).ToImmutableList();
+            var maxActiveStatus = GetMaxRoleStatus(activeVersions);
+            return maxActiveStatus == null
                 ? activeVersions
-                : ImmutableList<FamilyRoleVersionApprovalStatus>.Empty;
+                : activeVersions
+                    .Where(version => version.CurrentStatus == maxActiveStatus)
+                    .ToImmutableList();
         }
 
         private static bool IsActive(IndividualRoleVersionApprovalStatus version) =>

--- a/test/CareTogether.Core.Test/ApprovalCalculationTests/CalculateCombinedFamilyApprovalsTest.cs
+++ b/test/CareTogether.Core.Test/ApprovalCalculationTests/CalculateCombinedFamilyApprovalsTest.cs
@@ -388,6 +388,45 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
         }
 
         [TestMethod]
+        public void ProspectiveSupersededIndividualRoleShowsOnlyActiveVersionApplication()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateIndividualRenewalPolicy();
+            var completedIndividualRequirements = H.CompletedIndividualRequirements(
+                (H.guid1, "LegacyApplication", 1)
+            );
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: ImmutableList<Resources.CompletedRequirementInfo>.Empty,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: completedIndividualRequirements,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
+            );
+
+            Assert.AreEqual(
+                RoleApprovalStatus.Prospective,
+                result.IndividualApprovals[H.guid1].ApprovalStatusByRole["Role1"].CurrentStatus
+            );
+            CollectionAssert.AreEqual(
+                new[] { "CurrentApplication" },
+                result
+                    .CurrentAvailableIndividualApplications.Where(x => x.PersonId == H.guid1)
+                    .Select(x => x.ActionName)
+                    .ToArray()
+            );
+            Assert.IsFalse(
+                result.CurrentMissingIndividualRequirements.Any(x => x.PersonId == H.guid1)
+            );
+        }
+
+        [TestMethod]
         public void ExpiredSupersededIndividualRoleShowsActiveVersionMissingApproval()
         {
             var family = CreateTestFamily();
@@ -457,6 +496,40 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
         }
 
         [TestMethod]
+        public void OnboardedSupersededIndividualRoleHidesActiveVersionMissingRequirements()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateIndividualRenewalPolicy();
+            var completedIndividualRequirements = H.CompletedIndividualRequirements(
+                (H.guid1, "LegacyApplication", 1),
+                (H.guid1, "LegacyApproval", 1),
+                (H.guid1, "CurrentApplication", 11)
+            );
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: ImmutableList<Resources.CompletedRequirementInfo>.Empty,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: completedIndividualRequirements,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
+            );
+
+            Assert.AreEqual(
+                RoleApprovalStatus.Onboarded,
+                result.IndividualApprovals[H.guid1].ApprovalStatusByRole["Role1"].CurrentStatus
+            );
+            Assert.IsFalse(
+                result.CurrentMissingIndividualRequirements.Any(x => x.PersonId == H.guid1)
+            );
+        }
+
+        [TestMethod]
         public void OnboardedSupersededFamilyRoleHidesActiveVersionMissingRequirements()
         {
             var family = CreateTestFamily();
@@ -488,16 +561,44 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
                 RoleApprovalStatus.Onboarded,
                 result.FamilyRoleApprovals["FamilyRole1"].CurrentStatus
             );
-            Assert.IsFalse(
-                result.CurrentMissingFamilyRequirements.Any(x =>
-                    x.ActionName == "CurrentFamilyApproval"
-                )
+            Assert.IsFalse(result.CurrentMissingFamilyRequirements.Any());
+            Assert.IsFalse(result.CurrentMissingIndividualRequirements.Any());
+        }
+
+        [TestMethod]
+        public void ProspectiveSupersededFamilyRoleShowsOnlyActiveVersionApplication()
+        {
+            var family = CreateTestFamily();
+            var locationPolicy = CreateFamilyRenewalPolicy();
+            var completedFamilyRequirements = H.Completed(("LegacyApplication", 1));
+
+            var result = ApprovalCalculations.CalculateCombinedFamilyApprovals(
+                locationPolicy: locationPolicy,
+                family: family,
+                completedFamilyRequirements: completedFamilyRequirements,
+                exemptedFamilyRequirements: ImmutableList<Resources.ExemptedRequirementInfo>.Empty,
+                familyRoleRemovals: ImmutableList<RoleRemoval>.Empty,
+                completedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.CompletedRequirementInfo>
+                >.Empty,
+                exemptedIndividualRequirements: ImmutableDictionary<
+                    Guid,
+                    ImmutableList<Resources.ExemptedRequirementInfo>
+                >.Empty,
+                individualRoleRemovals: ImmutableDictionary<Guid, ImmutableList<RoleRemoval>>.Empty
             );
-            Assert.IsFalse(
-                result.CurrentMissingIndividualRequirements.Any(x =>
-                    x.ActionName == "CurrentAdultApproval"
-                )
+
+            Assert.AreEqual(
+                RoleApprovalStatus.Prospective,
+                result.FamilyRoleApprovals["FamilyRole1"].CurrentStatus
             );
+            CollectionAssert.AreEqual(
+                new[] { "CurrentApplication" },
+                result.CurrentAvailableFamilyApplications.ToArray()
+            );
+            Assert.IsFalse(result.CurrentMissingFamilyRequirements.Any());
+            Assert.IsFalse(result.CurrentMissingIndividualRequirements.Any());
         }
 
         [TestMethod]

--- a/test/CareTogether.Core.Test/ApprovalCalculationTests/PolicyEvaluationHelpersTest.cs
+++ b/test/CareTogether.Core.Test/ApprovalCalculationTests/PolicyEvaluationHelpersTest.cs
@@ -34,17 +34,17 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
             }
 
             [TestMethod]
-            public void EmptyList_ReturnsDefault()
+            public void EmptyList_ReturnsNull()
             {
                 var result = PolicyEvaluationHelpers.GetMaxRoleStatus(
                     ImmutableList<IndividualRoleVersionApprovalStatus>.Empty
                 );
 
-                Assert.AreEqual((RoleApprovalStatus)0, result);
+                Assert.IsNull(result);
             }
 
             [TestMethod]
-            public void AllNullStatuses_ReturnsDefault()
+            public void AllNullStatuses_ReturnsNull()
             {
                 var versions = ImmutableList.Create(
                     CreateIndividualVersion("v1", null),
@@ -53,7 +53,7 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
 
                 var result = PolicyEvaluationHelpers.GetMaxRoleStatus(versions);
 
-                Assert.AreEqual((RoleApprovalStatus)0, result);
+                Assert.IsNull(result);
             }
 
             [DataTestMethod]
@@ -180,17 +180,17 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
             }
 
             [TestMethod]
-            public void EmptyList_ReturnsDefault()
+            public void EmptyList_ReturnsNull()
             {
                 var result = PolicyEvaluationHelpers.GetMaxRoleStatus(
                     ImmutableList<FamilyRoleVersionApprovalStatus>.Empty
                 );
 
-                Assert.AreEqual((RoleApprovalStatus)0, result);
+                Assert.IsNull(result);
             }
 
             [TestMethod]
-            public void AllNullStatuses_ReturnsDefault()
+            public void AllNullStatuses_ReturnsNull()
             {
                 var versions = ImmutableList.Create(
                     CreateFamilyVersion("v1", null),
@@ -199,7 +199,7 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
 
                 var result = PolicyEvaluationHelpers.GetMaxRoleStatus(versions);
 
-                Assert.AreEqual((RoleApprovalStatus)0, result);
+                Assert.IsNull(result);
             }
 
             [DataTestMethod]
@@ -302,6 +302,107 @@ namespace CareTogether.Core.Test.ApprovalCalculationTests
 
                 Assert.AreEqual(RoleApprovalStatus.Approved, result);
             }
+        }
+
+        [TestClass]
+        public class SelectPromptableVersionsTests
+        {
+            [TestMethod]
+            public void IndividualVersions_ReturnsOnlyMostAdvancedActiveVersions()
+            {
+                var versions = ImmutableList.Create(
+                    CreateIndividualVersion("unstarted", null),
+                    CreateIndividualVersion("prospective", RoleApprovalStatus.Prospective),
+                    CreateIndividualVersion("approved", RoleApprovalStatus.Approved),
+                    CreateIndividualVersion(
+                        "superseded-onboarded",
+                        RoleApprovalStatus.Onboarded,
+                        DateTime.UtcNow.AddDays(-1)
+                    )
+                );
+
+                var result = PolicyEvaluationHelpers.SelectPromptableVersions(
+                    versions,
+                    RoleApprovalStatus.Approved
+                );
+
+                CollectionAssert.AreEqual(
+                    new[] { "approved" },
+                    result.Select(version => version.Version).ToArray()
+                );
+            }
+
+            [TestMethod]
+            public void OnboardedEffectiveStatus_ReturnsNoFamilyVersions()
+            {
+                var versions = ImmutableList.Create(
+                    CreateFamilyVersion("active", RoleApprovalStatus.Prospective),
+                    CreateFamilyVersion(
+                        "superseded",
+                        RoleApprovalStatus.Onboarded,
+                        DateTime.UtcNow.AddDays(-1)
+                    )
+                );
+
+                var result = PolicyEvaluationHelpers.SelectPromptableVersions(
+                    versions,
+                    RoleApprovalStatus.Onboarded
+                );
+
+                Assert.IsFalse(result.Any());
+            }
+
+            [TestMethod]
+            public void UnstartedActiveVersions_AreAllPromptable()
+            {
+                var versions = ImmutableList.Create(
+                    CreateFamilyVersion("v1", null),
+                    CreateFamilyVersion("v2", null)
+                );
+
+                var result = PolicyEvaluationHelpers.SelectPromptableVersions(
+                    versions,
+                    effectiveStatus: null
+                );
+
+                CollectionAssert.AreEqual(
+                    new[] { "v1", "v2" },
+                    result.Select(version => version.Version).ToArray()
+                );
+            }
+
+            private static IndividualRoleVersionApprovalStatus CreateIndividualVersion(
+                string version,
+                RoleApprovalStatus? status,
+                DateTime? supersededAtUtc = null
+            ) =>
+                new(
+                    "TestRole",
+                    version,
+                    supersededAtUtc,
+                    CreateStatusTimeline(status),
+                    ImmutableList<IndividualRoleRequirementCompletionStatus>.Empty
+                );
+
+            private static FamilyRoleVersionApprovalStatus CreateFamilyVersion(
+                string version,
+                RoleApprovalStatus? status,
+                DateTime? supersededAtUtc = null
+            ) =>
+                new(
+                    "TestRole",
+                    version,
+                    supersededAtUtc,
+                    CreateStatusTimeline(status),
+                    ImmutableList<FamilyRoleRequirementCompletionStatus>.Empty
+                );
+
+            private static DateOnlyTimeline<RoleApprovalStatus>? CreateStatusTimeline(
+                RoleApprovalStatus? status
+            ) =>
+                status.HasValue
+                    ? new DateOnlyTimeline<RoleApprovalStatus>([H.DR(1, null, status.Value)])
+                    : null;
         }
     }
 }


### PR DESCRIPTION
## Summary

- separate the effective role status from active policy-version prompt selection
- allow only the most advanced active workflow or workflows to contribute prompts
- suppress all prompts while an effective Onboarded status remains valid, and resume active renewal prompts once it becomes Expired
- return null when no policy version has a status instead of producing the undefined enum value 0
- document the policy-version approval and prompt rules

## Root cause

Prompt selection compared the highest active-version status with the effective status across all versions. A status inherited from a superseded version could therefore hide every active workflow. The empty-status calculation also returned an undefined enum value instead of null, causing unstarted active versions to be filtered out.

## User impact

Prospective families inherited from a superseded policy can start the active policy application and then advance through its requirements. Families that remain Onboarded under a superseded policy, are not prompted for active-version renewal requirements until their effective status becomes Expired.
