### PR TITLE
Fix volunteer status filter selection

### DIFF
--- a/src/caretogether-pwa/src/Volunteers/VolunteersBrowserV2.tsx
+++ b/src/caretogether-pwa/src/Volunteers/VolunteersBrowserV2.tsx
@@ -31,6 +31,16 @@ function selectedFilterValues(filters: filterOption[]) {
     .map((filter) => filter.value!);
 }
 
+function hasIncompleteFilter(filterModel: GridFilterModel) {
+  return filterModel.items.some(
+    (item) =>
+      item.value === undefined ||
+      item.value === null ||
+      item.value === '' ||
+      (Array.isArray(item.value) && item.value.length === 0)
+  );
+}
+
 export function VolunteersBrowserV2() {
   const appNavigate = useAppNavigate();
   const permissions = useAllVolunteerFamiliesPermissions();
@@ -107,7 +117,7 @@ export function VolunteersBrowserV2() {
       selectedFamilyIdSet.has(family.family!.id!)
     );
   }, [selectedFamilyIds, visibleVolunteerFamilies]);
-  const filterModel = useMemo(
+  const appliedFilterModel = useMemo(
     () =>
       gridFilterModelFromVolunteerFilters({
         logicOperator: 'and',
@@ -117,6 +127,9 @@ export function VolunteersBrowserV2() {
       }),
     [requirementFilter, roleFilters, statusFilters]
   );
+  const [pendingFilterModel, setPendingFilterModel] =
+    useState<GridFilterModel | null>(null);
+  const filterModel = pendingFilterModel ?? appliedFilterModel;
 
   function selectedFamilyContactEmails() {
     return selectedVolunteerFamilies
@@ -188,6 +201,7 @@ export function VolunteersBrowserV2() {
   function handleFilterModelChange(model: GridFilterModel) {
     const filters = volunteerFiltersFromGridFilterModel(model);
 
+    setPendingFilterModel(hasIncompleteFilter(model) ? model : null);
     clearSelection();
     setRoleFilterValues(filters.roleFilters);
     setStatusFilterValues(filters.statusFilters);


### PR DESCRIPTION
## Summary

- preserve an incomplete DataGrid filter while the user selects its field and value
- return control to the existing applied volunteer filter model once the filter is complete
- keep existing role, status, and requirement filtering behavior unchanged

## Root cause

The Volunteers grid uses a controlled filter model. Selecting the Status field first emits a filter item without a value. The volunteer filter adapter intentionally omits value-less filters, so the controlled model was immediately rebuilt without that item and reset the field selection.

## Impact

Users can now select Status in the filter panel and then choose the desired status value normally.

## Validation

- `npm run build`
- ESLint on `src/Volunteers/VolunteersBrowserV2.tsx`
- Prettier check on `src/Volunteers/VolunteersBrowserV2.tsx`
- `git diff --check`
