### PR TITLE
Improve local Playwright test setup

### DIFF
--- a/src/CareTogether.AppHost/Realms/caretogether-local-realm.json
+++ b/src/CareTogether.AppHost/Realms/caretogether-local-realm.json
@@ -100,6 +100,27 @@
           "temporary": false
         }
       ]
+    },
+    {
+      "id": "e3aaef77-0e97-47a6-b788-a67c237c781e",
+      "username": "test2@bynalogic.com",
+      "email": "test2@bynalogic.com",
+      "firstName": "Test2",
+      "lastName": "User",
+      "enabled": true,
+      "emailVerified": true,
+      "attributes": {
+        "caretogether_user_id": [
+          "e3aaef77-0e97-47a6-b788-a67c237c781e"
+        ]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "P@ssw0rd",
+          "temporary": false
+        }
+      ]
     }
   ]
 }

--- a/src/caretogether-pwa/playwright.config.ts
+++ b/src/caretogether-pwa/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 import { AUTH_FILE } from './playwright_test/support/constants';
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const BROWSER_EXECUTABLE_PATH = process.env.PLAYWRIGHT_BROWSER_EXECUTABLE_PATH;
 
 export default defineConfig({
   testDir: './playwright_test',
@@ -15,6 +16,9 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    launchOptions: BROWSER_EXECUTABLE_PATH
+      ? { executablePath: BROWSER_EXECUTABLE_PATH }
+      : undefined,
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

- add a second local Keycloak test user for multi-user Playwright scenarios
- allow Playwright to use a browser executable supplied through PLAYWRIGHT_BROWSER_EXECUTABLE_PATH
