### PR TITLE
Fixed the data source for Individual Function Assignments - OData.

### DIFF
--- a/src/CareTogether.Api/OData/LiveODataModelController.cs
+++ b/src/CareTogether.Api/OData/LiveODataModelController.cs
@@ -2361,10 +2361,21 @@ namespace CareTogether.Api.OData
                     return arrangement
                         .IndividualVolunteerAssignments.Select(fva =>
                         {
+                            var volunteerFamily = TryFindFamilyInLocation(
+                                families,
+                                fva.FamilyId,
+                                organization.Id,
+                                family.Location.Id
+                            );
+                            if (volunteerFamily == null)
+                            {
+                                return null;
+                            }
+
                             var person = TryFindPersonInFamily(
                                 people,
                                 fva.PersonId,
-                                family
+                                volunteerFamily
                             );
                             if (person == null)
                             {

--- a/src/CareTogether.Api/OData/LiveODataModelController.cs
+++ b/src/CareTogether.Api/OData/LiveODataModelController.cs
@@ -2359,11 +2359,11 @@ namespace CareTogether.Api.OData
                 {
                     var arrangementRecord = arrangements.Single(arr => arr.Id == arrangement.Id);
                     return arrangement
-                        .IndividualVolunteerAssignments.Select(fva =>
+                        .IndividualVolunteerAssignments.Select(iva =>
                         {
                             var volunteerFamily = TryFindFamilyInLocation(
                                 families,
-                                fva.FamilyId,
+                                iva.FamilyId,
                                 organization.Id,
                                 family.Location.Id
                             );
@@ -2374,7 +2374,7 @@ namespace CareTogether.Api.OData
 
                             var person = TryFindPersonInFamily(
                                 people,
-                                fva.PersonId,
+                                iva.PersonId,
                                 volunteerFamily
                             );
                             if (person == null)
@@ -2389,11 +2389,11 @@ namespace CareTogether.Api.OData
                                 arrangementRecord,
                                 arrangement.Id,
                                 person,
-                                fva.PersonId,
-                                fva.ArrangementFunction
+                                iva.PersonId,
+                                iva.ArrangementFunction
                             );
                         })
-                        .Where(fva => fva != null)
+                        .Where(iva => iva != null)
                         .Cast<IndividualFunctionAssignment>();
                 });
             });

--- a/src/caretogether-pwa/package-lock.json
+++ b/src/caretogether-pwa/package-lock.json
@@ -1967,18 +1967,6 @@
         }
       }
     },
-    "node_modules/@mui/x-scheduler/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
     "node_modules/@mui/x-tree-view": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-9.4.0.tgz",

--- a/src/caretogether-pwa/package-lock.json
+++ b/src/caretogether-pwa/package-lock.json
@@ -1967,6 +1967,18 @@
         }
       }
     },
+    "node_modules/@mui/x-scheduler/node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/@mui/x-tree-view": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@mui/x-tree-view/-/x-tree-view-9.4.0.tgz",


### PR DESCRIPTION
IndividualFunctionAssignments was returning no data because individual volunteers were being resolved against the partnering family associated with the case. In most cases, the assigned volunteer belongs to a different volunteer family, so the lookup returned null and the assignment was silently filtered out.

The fix uses the assignment’s FamilyId to locate the correct volunteer family first, then resolves the assigned person within that family. This preserves location-aware lookup behavior while allowing valid individual function assignments to be included in the OData response.