### PR TITLE
Allow users to clear arrangement planned dates

### DIFF
--- a/src/caretogether-pwa/src/Model/V1CasesModel.ts
+++ b/src/caretogether-pwa/src/Model/V1CasesModel.ts
@@ -557,7 +557,7 @@ export function useV1CasesModel() {
         familyId: partneringFamilyId,
         referralId: v1CaseId,
         arrangementIds: [arrangementId],
-        plannedStartUtc: plannedStartLocal || undefined,
+        plannedStartUtc: plannedStartLocal ?? undefined,
       });
       return command;
     }
@@ -654,7 +654,7 @@ export function useV1CasesModel() {
         referralId: v1CaseId,
         arrangementIds: [arrangementId],
 
-        plannedEndUtc: plannedEndLocal || undefined,
+        plannedEndUtc: plannedEndLocal ?? undefined,
       });
       return command;
     }

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementPlannedDuration.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementPlannedDuration.tsx
@@ -53,14 +53,14 @@ export function ArrangementPlannedDuration({
 
   const withBackdrop = useBackdrop();
 
-  const onDateChange = async (
+  const onDateChange = async <TDate extends Date | null>(
     callback: (
       aggregateId: string,
       v1CaseId: string,
       arrangementId: string,
-      plannedStartLocal: Date
+      plannedStartLocal: TDate
     ) => Promise<void>,
-    newDate: Date
+    newDate: TDate
   ) =>
     await withBackdrop(async () => {
       await callback(partneringFamilyId, v1CaseId, arrangement.id!, newDate);
@@ -134,6 +134,7 @@ export function ArrangementPlannedDuration({
           disableFuture={false}
           canEdit={canEdit}
           availableInCurrentPhase // Available in all phases
+          allowClear
           onChange={(newDate) =>
             onDateChange(v1CasesModel.planArrangementStart, newDate)
           }
@@ -162,6 +163,7 @@ export function ArrangementPlannedDuration({
           disableFuture={false}
           canEdit={canEdit}
           availableInCurrentPhase // Available in all phases
+          allowClear
           onChange={(newDate) =>
             onDateChange(v1CasesModel.planArrangementEnd, newDate)
           }

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementTimelineSectionV2.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/ArrangementTimelineSectionV2.tsx
@@ -8,11 +8,11 @@ import { useV1CasesModel } from '../../Model/V1CasesModel';
 import { ArrangementRowV2 } from './arrangementViewModel';
 import { DateDisplayEditor } from './DateDisplayEditor';
 
-type DateCommand = (
+type DateCommand<TDate extends Date | null> = (
   aggregateId: string,
   v1CaseId: string,
   arrangementId: string,
-  date: Date
+  date: TDate
 ) => Promise<void>;
 
 function TimelineHeaderCell({ children }: { children: ReactNode }) {
@@ -88,7 +88,10 @@ export function ArrangementTimelineSectionV2({
   const withBackdrop = useBackdrop();
   const canEdit = permissions(Permission.EditArrangement);
 
-  const onDateChange = async (callback: DateCommand, newDate: Date) => {
+  const onDateChange = async <TDate extends Date | null>(
+    callback: DateCommand<TDate>,
+    newDate: TDate
+  ) => {
     await withBackdrop(async () => {
       await callback(partneringFamilyId, v1CaseId, arrangement.id!, newDate);
     });
@@ -134,6 +137,7 @@ export function ArrangementTimelineSectionV2({
           disableFuture={false}
           canEdit={canEdit}
           availableInCurrentPhase
+          allowClear
           onChange={(newDate) =>
             onDateChange(v1CasesModel.planArrangementStart, newDate)
           }
@@ -164,6 +168,7 @@ export function ArrangementTimelineSectionV2({
           disableFuture={false}
           canEdit={canEdit}
           availableInCurrentPhase
+          allowClear
           onChange={(newDate) =>
             onDateChange(v1CasesModel.planArrangementEnd, newDate)
           }

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/DateDisplayEditor.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/DateDisplayEditor.tsx
@@ -4,7 +4,7 @@ import { IconButton, Typography } from '@mui/material';
 import { useState } from 'react';
 import { EditDateDialog } from './EditDateDialog';
 
-interface DateDisplayEditorProps {
+type DateDisplayEditorCommonProps = {
   initialValue: Date | undefined;
   disablePast?: boolean;
   disableFuture?: boolean;
@@ -13,20 +13,34 @@ interface DateDisplayEditorProps {
   canEdit: boolean;
   availableInCurrentPhase: boolean;
   unavailableTooltip?: string;
-  onChange: (value: Date) => Promise<void>;
-}
+};
 
-export function DateDisplayEditor({
-  initialValue,
-  disablePast = false,
-  disableFuture = true,
-  label,
-  hideDisplayLabel = false,
-  canEdit,
-  availableInCurrentPhase,
-  unavailableTooltip,
-  onChange,
-}: DateDisplayEditorProps) {
+type RequiredDateDisplayEditorProps = DateDisplayEditorCommonProps & {
+  allowClear?: false;
+  onChange: (value: Date) => Promise<void>;
+};
+
+type ClearableDateDisplayEditorProps = DateDisplayEditorCommonProps & {
+  allowClear: true;
+  onChange: (value: Date | null) => Promise<void>;
+};
+
+type DateDisplayEditorProps =
+  | RequiredDateDisplayEditorProps
+  | ClearableDateDisplayEditorProps;
+
+export function DateDisplayEditor(props: DateDisplayEditorProps) {
+  const {
+    initialValue,
+    disablePast = false,
+    disableFuture = true,
+    label,
+    hideDisplayLabel = false,
+    canEdit,
+    availableInCurrentPhase,
+    unavailableTooltip,
+  } = props;
+  const allowClear = props.allowClear === true;
   const [editing, setEditing] = useState(false);
 
   return (
@@ -66,9 +80,17 @@ export function DateDisplayEditor({
           disablePast={disablePast}
           disableFuture={disableFuture}
           label={label}
+          allowClear={allowClear}
           onClose={() => setEditing(false)}
-          onSave={async (date) => {
-            await onChange(date);
+          onSave={async (date: Date | null) => {
+            if (props.allowClear === true) {
+              await props.onChange(date);
+              return;
+            }
+
+            if (date !== null) {
+              await props.onChange(date);
+            }
           }}
         />
       )}

--- a/src/caretogether-pwa/src/V1Cases/Arrangements/EditDateDialog.tsx
+++ b/src/caretogether-pwa/src/V1Cases/Arrangements/EditDateDialog.tsx
@@ -2,6 +2,7 @@ import Grid from '@mui/material/Grid';
 import { ValidateDatePicker } from '../../Generic/Forms/ValidateDatePicker';
 import { useState } from 'react';
 import { UpdateDialog } from '../../Generic/UpdateDialog';
+import { Box, Button } from '@mui/material';
 
 interface EditDateDialogProps {
   initialDate?: Date;
@@ -9,7 +10,8 @@ interface EditDateDialogProps {
   disableFuture?: boolean;
   label: string;
   onClose: () => void;
-  onSave: (date: Date) => Promise<void>;
+  onSave: (date: Date | null) => Promise<void>;
+  allowClear?: boolean;
 }
 
 export function EditDateDialog({
@@ -19,12 +21,21 @@ export function EditDateDialog({
   label,
   onClose,
   onSave,
+  allowClear = false,
 }: EditDateDialogProps) {
-  const [dateLocal, setDateLocal] = useState(initialDate || new Date());
+  const [dateLocal, setDateLocal] = useState<Date | null>(
+    initialDate ?? (allowClear ? null : new Date())
+  );
 
-  const [dobError, setDobError] = useState(dateLocal.getFullYear() < 1900);
+  const [dobError, setDobError] = useState(
+    dateLocal ? dateLocal.getFullYear() < 1900 : false
+  );
 
   async function save() {
+    if (!allowClear && dateLocal === null) {
+      return;
+    }
+
     await onSave(dateLocal);
   }
 
@@ -33,23 +44,45 @@ export function EditDateDialog({
       title={`Editing "${label}" date`}
       onClose={onClose}
       onSave={save}
-      enableSave={() => dateLocal != null && !dobError}
+      enableSave={() => !dobError && (allowClear || dateLocal !== null)}
     >
       <Grid container spacing={2}>
         <Grid size={12}>
           <ValidateDatePicker
             label={label}
             value={dateLocal}
-            onChange={(date) => date && setDateLocal(date)}
+            onChange={(date) => {
+              if (allowClear) {
+                setDateLocal(date);
+                return;
+              }
+
+              if (date) {
+                setDateLocal(date);
+              }
+            }}
             onErrorChange={setDobError}
             disablePast={disablePast}
             disableFuture={disableFuture}
             textFieldProps={{
               fullWidth: true,
-              required: true,
+              required: !allowClear,
               sx: { marginTop: 1 },
             }}
           />
+          {allowClear && dateLocal !== null && (
+            <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
+              <Button
+                color="secondary"
+                onClick={() => setDateLocal(null)}
+                size="small"
+                variant="text"
+                sx={{ mt: 0.5, p: 0, textTransform: 'none' }}
+              >
+                Clear date
+              </Button>
+            </Box>
+          )}
         </Grid>
       </Grid>
     </UpdateDialog>


### PR DESCRIPTION
Adds the ability to clear a planned start or planned end date from an arrangement, Users can now select Clear date from the existing date edit dialog and save the arrangement with the planned date unset, The clear option is only available for planned start and end dates, so the behavior of other required arrangement dates remains unchanged.

<img width="1249" height="829" alt="Screenshot (1357)" src="https://github.com/user-attachments/assets/3af0aa53-476b-4738-bc67-15c83897562f" />
